### PR TITLE
feat(cli): add vision indexing and progress UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 *.pdf
+*.png

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2683,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -3884,6 +3916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object_store"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,8 +4394,10 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-schema",
+ "base64",
  "clap",
  "futures",
+ "indicatif",
  "lancedb",
  "pdf-extract",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ description = "CLI for local RAG (storage layout + plumbing)"
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
+indicatif = "0.17"
 lancedb = "0.26"
 pdf-extract = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It indexes local files into a persistent LanceDB store, uses Ollama for embeddin
 
 ## Features
 
-- local text, Markdown, and PDF indexing
+- local text, Markdown, PDF, and image indexing
 - local embedding and generation through Ollama
 - persistent per-store data under `~/.config/ragcli/<name>`
 - idempotent re-indexing by `source_path`
@@ -37,6 +37,7 @@ Index a directory or file:
 ```bash
 cargo run -- index ./docs
 cargo run -- index ./My_Neighbor_Totoro.pdf
+cargo run -- index ./images
 ```
 
 Use a named store:
@@ -75,6 +76,7 @@ base_url = "http://localhost:11434"
 [models]
 embed = "nomic-embed-text-v2-moe:latest"
 chat = "qwen3.5:4b"
+vision = "qwen3.5:4b"
 
 [chunk]
 size = 1000
@@ -100,6 +102,7 @@ Each store lives under:
 
 - Re-indexing replaces existing rows for the same `source_path`.
 - Text files are decoded lossily, so non-UTF-8 files do not abort indexing.
+- Images are captioned with an Ollama vision model at index time and stored as text for retrieval.
 - Querying refuses to mix a store with a different embedding model than the one used to build it.
 - Ollama chat requests are sent with `think: false` to reduce hangs with reasoning-capable models.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,17 +16,21 @@ pub struct Config {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ModelsConfig {
     pub embed: String,
     pub chat: String,
+    pub vision: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct OllamaConfig {
     pub base_url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ChunkConfig {
     pub size: usize,
     pub overlap: usize,
@@ -37,6 +41,7 @@ impl Default for ModelsConfig {
         Self {
             embed: "nomic-embed-text-v2-moe:latest".to_string(),
             chat: "qwen3.5:4b".to_string(),
+            vision: "qwen3.5:4b".to_string(),
         }
     }
 }
@@ -140,6 +145,7 @@ mod tests {
         let cfg = load_or_create_config(&store).unwrap();
         assert_eq!(cfg.models.embed, "nomic-embed-text-v2-moe:latest");
         assert_eq!(cfg.models.chat, "qwen3.5:4b");
+        assert_eq!(cfg.models.vision, "qwen3.5:4b");
         assert!(config_path(&store).exists());
 
         let cfg2 = load_or_create_config(&store).unwrap();

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,6 +1,7 @@
-use crate::models::Embedder;
+use crate::models::{Embedder, VisionCaptioner};
 use crate::store::ChunkRow;
 use anyhow::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
 use pdf_extract::extract_text_by_pages;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
@@ -26,6 +27,7 @@ pub struct IngestResult {
 enum FileKind {
     Text,
     Pdf,
+    Image,
     Unsupported,
 }
 
@@ -34,8 +36,10 @@ pub async fn ingest_path(
     chunk_size: usize,
     overlap: usize,
     embedder: &Embedder,
+    vision: Option<&VisionCaptioner>,
 ) -> Result<IngestResult> {
     let files = collect_files(path)?;
+    let progress = build_progress_bar(files.len() as u64);
     let mut rows = Vec::new();
     let mut source_paths = BTreeSet::new();
     let mut dim = None;
@@ -47,11 +51,13 @@ pub async fn ingest_path(
     };
 
     for file in files {
+        progress.set_message(format!("Reading {}", display_name(&file)));
         match file_kind(&file) {
             FileKind::Text => {
                 source_paths.insert(file.display().to_string());
                 match load_text_file(&file) {
                     Ok(text) => {
+                        progress.set_message(format!("Embedding {}", display_name(&file)));
                         let chunks = chunk_text(&text, chunk_size, overlap);
                         match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
                             Ok(mut file_rows) => {
@@ -73,6 +79,7 @@ pub async fn ingest_path(
             }
             FileKind::Pdf => {
                 source_paths.insert(file.display().to_string());
+                progress.set_message(format!("Extracting {}", display_name(&file)));
                 match extract_text_by_pages(&file)
                     .with_context(|| format!("extract pdf text: {}", file.display()))
                 {
@@ -81,6 +88,11 @@ pub async fn ingest_path(
                         let mut file_failed = None;
                         for (page_idx, page_text) in pages.into_iter().enumerate() {
                             let page_num = (page_idx + 1) as i32;
+                            progress.set_message(format!(
+                                "Embedding {} (page {})",
+                                display_name(&file),
+                                page_num
+                            ));
                             let chunks = chunk_text(&page_text, chunk_size, overlap);
                             match embed_chunks(&file, page_num, chunks, embedder, &mut dim).await {
                                 Ok(mut page_rows) => file_rows.append(&mut page_rows),
@@ -106,9 +118,49 @@ pub async fn ingest_path(
                     }
                 }
             }
+            FileKind::Image => {
+                source_paths.insert(file.display().to_string());
+                let Some(vision) = vision else {
+                    stats.skipped_files += 1;
+                    stats.errors.push(format!(
+                        "{}: image skipped because no vision model is configured",
+                        file.display()
+                    ));
+                    continue;
+                };
+
+                progress.set_message(format!("Captioning {}", display_name(&file)));
+                match vision.caption_image(&file).await {
+                    Ok(caption) => {
+                        progress.set_message(format!("Embedding {}", display_name(&file)));
+                        let chunks = vec![build_image_retrieval_text(&file, &caption)];
+                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
+                            Ok(mut file_rows) => {
+                                stats.indexed_files += 1;
+                                stats.total_chunks += file_rows.len();
+                                rows.append(&mut file_rows);
+                            }
+                            Err(err) => {
+                                stats.skipped_files += 1;
+                                stats.errors.push(format!("{}: {}", file.display(), err));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        stats.skipped_files += 1;
+                        stats.errors.push(format!("{}: {}", file.display(), err));
+                    }
+                }
+            }
             FileKind::Unsupported => {}
         }
+        progress.inc(1);
     }
+
+    progress.finish_with_message(format!(
+        "Indexed {} file(s), wrote {} chunk(s)",
+        stats.indexed_files, stats.total_chunks
+    ));
 
     Ok(IngestResult {
         rows,
@@ -175,6 +227,7 @@ fn file_kind(path: &Path) -> FileKind {
     match ext.as_str() {
         "md" | "markdown" | "txt" | "rst" => FileKind::Text,
         "pdf" => FileKind::Pdf,
+        "png" | "jpg" | "jpeg" | "webp" => FileKind::Image,
         _ => FileKind::Unsupported,
     }
 }
@@ -182,6 +235,28 @@ fn file_kind(path: &Path) -> FileKind {
 fn load_text_file(path: &Path) -> Result<String> {
     let bytes = fs::read(path)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn build_progress_bar(total_files: u64) -> ProgressBar {
+    let bar = ProgressBar::new(total_files.max(1));
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}",
+    )
+    .expect("valid progress template")
+    .progress_chars("=>-");
+    bar.set_style(style);
+    bar
+}
+
+fn display_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}
+
+fn build_image_retrieval_text(path: &Path, caption: &str) -> String {
+    format!("File: {}\nCaption: {}", display_name(path), caption.trim())
 }
 
 pub fn chunk_text(text: &str, chunk_size: usize, overlap: usize) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use config::{
 use futures::TryStreamExt;
 use ingest::ingest_path;
 use lancedb::query::{ExecutableQuery, QueryBase};
-use models::{Embedder, Generator, OllamaClient};
+use models::{Embedder, Generator, OllamaClient, VisionCaptioner};
 use std::fs;
+use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use store::{connect_db, ensure_metadata, extract_contexts, load_metadata, replace_source_rows};
 
@@ -51,6 +52,7 @@ async fn cmd_index(
     chunk_overlap: Option<usize>,
     embed_model: Option<String>,
 ) -> Result<()> {
+    let started = Instant::now();
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let cfg = load_or_create_config(&store)?;
@@ -63,7 +65,11 @@ async fn cmd_index(
         embed_model.unwrap_or_else(|| resolve_model_name(&store, &cfg.models.embed));
 
     let embedder = Embedder::new(cfg.ollama.base_url.clone(), embed_model_name.clone());
-    let result = ingest_path(&path, size, overlap, &embedder).await?;
+    let vision = VisionCaptioner::new(
+        cfg.ollama.base_url.clone(),
+        resolve_model_name(&store, &cfg.models.vision),
+    );
+    let result = ingest_path(&path, size, overlap, &embedder, Some(&vision)).await?;
 
     if let Some(dim) = result.embedding_dim {
         ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
@@ -78,6 +84,7 @@ async fn cmd_index(
     println!("  indexed files: {}", result.stats.indexed_files);
     println!("  skipped files: {}", result.stats.skipped_files);
     println!("  chunks written: {}", result.stats.total_chunks);
+    println!("  elapsed: {:.2?}", started.elapsed());
 
     if !result.stats.errors.is_empty() {
         println!("  errors:");
@@ -173,6 +180,7 @@ async fn cmd_doctor(name: Option<&str>) -> Result<()> {
     println!("  ollama url: {}", cfg.ollama.base_url);
     println!("  embed model: {}", cfg.models.embed);
     println!("  chat model: {}", cfg.models.chat);
+    println!("  vision model: {}", cfg.models.vision);
 
     let ollama = OllamaClient::new(cfg.ollama.base_url.clone());
     match ollama.list_models().await {
@@ -185,6 +193,10 @@ async fn cmd_doctor(name: Option<&str>) -> Result<()> {
             println!(
                 "  chat model installed: {}",
                 status(models.iter().any(|model| model == &cfg.models.chat))
+            );
+            println!(
+                "  vision model installed: {}",
+                status(models.iter().any(|model| model == &cfg.models.vision))
             );
         }
         Err(err) => {

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
+use base64::Engine;
 use reqwest::Client;
 use serde::Deserialize;
+use std::path::Path;
 use std::time::Duration;
 
 pub struct Embedder {
@@ -10,6 +12,12 @@ pub struct Embedder {
 }
 
 pub struct Generator {
+    client: Client,
+    base_url: String,
+    model: String,
+}
+
+pub struct VisionCaptioner {
     client: Client,
     base_url: String,
     model: String,
@@ -177,6 +185,61 @@ impl Generator {
 
         let parsed: ChatResponse =
             serde_json::from_str(&body).context("parse Ollama chat response")?;
+        Ok(parsed.message.content)
+    }
+}
+
+impl VisionCaptioner {
+    pub fn new(base_url: String, model: String) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(180))
+                .build()
+                .expect("build reqwest client"),
+            base_url,
+            model,
+        }
+    }
+
+    pub async fn caption_image(&self, image_path: &Path) -> Result<String> {
+        let bytes = std::fs::read(image_path)
+            .with_context(|| format!("read image: {}", image_path.display()))?;
+        let image_b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
+
+        let response = self
+            .client
+            .post(url)
+            .json(&serde_json::json!({
+                "model": self.model,
+                "stream": false,
+                "think": false,
+                "options": {
+                    "num_predict": 128,
+                },
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Describe this image for retrieval. Focus on the subjects, setting, and notable visual details.",
+                        "images": [image_b64],
+                    }
+                ]
+            }))
+            .send()
+            .await
+            .context("call Ollama vision chat API")?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .context("read Ollama vision response")?;
+        if !status.is_success() {
+            anyhow::bail!("Ollama vision API error: {} - {}", status, body);
+        }
+
+        let parsed: ChatResponse =
+            serde_json::from_str(&body).context("parse Ollama vision response")?;
         Ok(parsed.message.content)
     }
 }


### PR DESCRIPTION
## Summary
- add image indexing through Ollama vision captioning and store filename + caption text for retrieval
- add a styled indexing progress bar with per-file status updates and elapsed time
- update doctor/config/docs for the new vision model flow

## Verification
- cargo check
- cargo test