### PR TITLE
feat(cli): add hybrid lancedb retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It indexes local files into a persistent LanceDB store, uses Ollama for embeddin
 
 - local text, Markdown, PDF, and image indexing
 - local embedding and generation through Ollama
+- hybrid retrieval with LanceDB vector search + BM25 full-text search
 - persistent per-store data under `~/.config/ragcli/<name>`
 - idempotent re-indexing by `source_path`
 - compatibility checks for embedding model + chunk settings
@@ -103,6 +104,7 @@ Each store lives under:
 - Re-indexing replaces existing rows for the same `source_path`.
 - Text files are decoded lossily, so non-UTF-8 files do not abort indexing.
 - Images are captioned with an Ollama vision model at index time and stored as text for retrieval.
+- Queries use LanceDB hybrid search: semantic nearest-neighbor search plus BM25 full-text search on `chunk_text`.
 - Querying refuses to mix a store with a different embedding model than the one used to build it.
 - Ollama chat requests are sent with `think: false` to reduce hangs with reasoning-capable models.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,16 @@ use config::{
 };
 use futures::TryStreamExt;
 use ingest::ingest_path;
+use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use models::{Embedder, Generator, OllamaClient, VisionCaptioner};
 use std::fs;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
-use store::{connect_db, ensure_metadata, extract_contexts, load_metadata, replace_source_rows};
+use store::{
+    connect_db, ensure_fts_index, ensure_metadata, extract_contexts, load_metadata,
+    replace_source_rows,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -119,12 +123,14 @@ async fn cmd_query(
         .execute()
         .await
         .context("open table")?;
+    ensure_fts_index(&table, false).await?;
 
     let embedder = Embedder::new(cfg.ollama.base_url.clone(), embed_model_name);
     let embedding = embedder.embed(&question).await?;
 
     let batches: Vec<arrow_array::RecordBatch> = table
         .query()
+        .full_text_search(FullTextSearchQuery::new(question.clone()))
         .nearest_to(embedding.as_slice())?
         .limit(top_k)
         .execute()

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,6 +3,9 @@ use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use lancedb::database::CreateTableMode;
+use lancedb::index::scalar::FtsIndexBuilder;
+use lancedb::index::Index;
+use lancedb::index::IndexType;
 use lancedb::{connect, Connection, Table};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -11,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub const DEFAULT_TABLE_NAME: &str = "chunks";
+pub const DEFAULT_FTS_COLUMN: &str = "chunk_text";
 const STORE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
@@ -119,6 +123,7 @@ pub async fn replace_source_rows(
     }
 
     if rows.is_empty() {
+        ensure_fts_index(&table, false).await?;
         return Ok(());
     }
 
@@ -126,6 +131,29 @@ pub async fn replace_source_rows(
     let batch = build_record_batch(schema.clone(), rows)?;
     let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
     table.add(Box::new(batches)).execute().await?;
+    ensure_fts_index(&table, true).await?;
+    Ok(())
+}
+
+pub async fn ensure_fts_index(table: &Table, replace: bool) -> Result<()> {
+    let has_fts = table.list_indices().await?.into_iter().any(|index| {
+        index.index_type == IndexType::FTS
+            && index.columns.len() == 1
+            && index.columns[0] == DEFAULT_FTS_COLUMN
+    });
+
+    if has_fts && !replace {
+        return Ok(());
+    }
+
+    let mut builder = table.create_index(
+        &[DEFAULT_FTS_COLUMN],
+        Index::FTS(FtsIndexBuilder::default()),
+    );
+    if has_fts && replace {
+        builder = builder.replace(true);
+    }
+    builder.execute().await.context("create FTS index")?;
     Ok(())
 }
 
@@ -244,7 +272,9 @@ fn sql_string(value: &str) -> String {
 mod tests {
     use super::*;
     use futures::TryStreamExt;
+    use lancedb::index::scalar::FullTextSearchQuery;
     use lancedb::query::ExecutableQuery;
+    use lancedb::query::QueryBase;
 
     fn sample_row(source_path: &str, text: &str, value: f32) -> ChunkRow {
         ChunkRow {
@@ -296,6 +326,44 @@ mod tests {
         assert_eq!(contexts.len(), 2);
         assert!(contexts.iter().any(|ctx| ctx.contains("new")));
         assert!(!contexts.iter().any(|ctx| ctx.contains("old")));
+    }
+
+    #[tokio::test]
+    async fn test_hybrid_search_keeps_keyword_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = connect_db(dir.path()).await.unwrap();
+
+        replace_source_rows(
+            &db,
+            &[
+                sample_row("a.txt", "semantic neighbor", -10.0),
+                sample_row("b.txt", "rarekeyword exact match", 100.0),
+            ],
+            &["a.txt".to_string(), "b.txt".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let table = db.open_table(DEFAULT_TABLE_NAME).execute().await.unwrap();
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .full_text_search(FullTextSearchQuery::new("rarekeyword".to_string()))
+            .limit(2)
+            .nearest_to(&[-10.0, -10.0])
+            .unwrap()
+            .execute()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let contexts = extract_contexts(&batches).unwrap();
+
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.iter().any(|ctx| ctx.contains("semantic neighbor")));
+        assert!(contexts
+            .iter()
+            .any(|ctx| ctx.contains("rarekeyword exact match")));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -122,15 +122,12 @@ pub async fn replace_source_rows(
             .await?;
     }
 
-    if rows.is_empty() {
-        ensure_fts_index(&table, true).await?;
-        return Ok(());
+    if !rows.is_empty() {
+        let schema = build_schema(rows[0].embedding.len());
+        let batch = build_record_batch(schema.clone(), rows)?;
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+        table.add(Box::new(batches)).execute().await?;
     }
-
-    let schema = build_schema(rows[0].embedding.len());
-    let batch = build_record_batch(schema.clone(), rows)?;
-    let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
-    table.add(Box::new(batches)).execute().await?;
     ensure_fts_index(&table, true).await?;
     Ok(())
 }
@@ -150,9 +147,7 @@ pub async fn ensure_fts_index(table: &Table, replace: bool) -> Result<()> {
         &[DEFAULT_FTS_COLUMN],
         Index::FTS(FtsIndexBuilder::default()),
     );
-    if has_fts && replace {
-        builder = builder.replace(true);
-    }
+    builder = builder.replace(replace);
     builder.execute().await.context("create FTS index")?;
     Ok(())
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -123,7 +123,7 @@ pub async fn replace_source_rows(
     }
 
     if rows.is_empty() {
-        ensure_fts_index(&table, false).await?;
+        ensure_fts_index(&table, true).await?;
         return Ok(());
     }
 
@@ -348,9 +348,9 @@ mod tests {
         let batches: Vec<RecordBatch> = table
             .query()
             .full_text_search(FullTextSearchQuery::new("rarekeyword".to_string()))
-            .limit(2)
             .nearest_to(&[-10.0, -10.0])
             .unwrap()
+            .limit(2)
             .execute()
             .await
             .unwrap()


### PR DESCRIPTION
## Summary
- add LanceDB hybrid retrieval by combining BM25 full-text search with vector search
- build and refresh the chunk_text FTS index during indexing and lazily for older stores on query
- add a regression test and document the new retrieval behavior

## Verification
- cargo test