### PR TITLE
feat(config): add config show/set and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ size = 1000
 overlap = 200
 ```
 
+Effective runtime values can be overridden with environment variables:
+
+```bash
+export RAGCLI_OLLAMA_URL=http://localhost:11434
+export RAGCLI_EMBED_MODEL=nomic-embed-text-v2-moe:latest
+export RAGCLI_CHAT_MODEL=qwen3.5:4b
+export RAGCLI_VISION_MODEL=qwen3.5:4b
+```
+
+You can inspect and update config without editing TOML by hand:
+
+```bash
+cargo run -- config show
+cargo run -- config set models.embed nomic-embed-text-v2-moe:latest
+cargo run -- config set ollama.base_url http://localhost:11434
+```
+
 ## Storage
 
 Each store lives under:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,24 @@ pub enum Command {
         #[arg(long, default_value_t = 256)]
         max_tokens: usize,
     },
+    /// Show or update config values
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
     /// Check store layout and status
     Doctor,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommand {
+    /// Print the effective config for this store
+    Show,
+    /// Set a config key in ~/.config/ragcli/<name>/config.toml
+    Set {
+        /// Config key such as models.embed or ollama.base_url
+        key: String,
+        /// New value to write
+        value: String,
+    },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,14 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_STORE_NAME: &str = "default";
+pub const ENV_OLLAMA_URL: &str = "RAGCLI_OLLAMA_URL";
+pub const ENV_EMBED_MODEL: &str = "RAGCLI_EMBED_MODEL";
+pub const ENV_CHAT_MODEL: &str = "RAGCLI_CHAT_MODEL";
+pub const ENV_VISION_MODEL: &str = "RAGCLI_VISION_MODEL";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
@@ -73,6 +78,31 @@ impl Default for Config {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigValueSource {
+    File,
+    Env(&'static str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigSources {
+    pub ollama_base_url: ConfigValueSource,
+    pub models_embed: ConfigValueSource,
+    pub models_chat: ConfigValueSource,
+    pub models_vision: ConfigValueSource,
+}
+
+impl Default for ConfigSources {
+    fn default() -> Self {
+        Self {
+            ollama_base_url: ConfigValueSource::File,
+            models_embed: ConfigValueSource::File,
+            models_chat: ConfigValueSource::File,
+            models_vision: ConfigValueSource::File,
+        }
+    }
+}
+
 pub fn base_dir() -> Result<PathBuf> {
     let xdg_dirs = xdg::BaseDirectories::with_prefix("ragcli")?;
     Ok(xdg_dirs.get_config_home())
@@ -95,7 +125,7 @@ pub fn ensure_store_layout(store: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn load_or_create_config(store: &Path) -> Result<Config> {
+pub fn load_or_create_file_config(store: &Path) -> Result<Config> {
     let path = config_path(store);
     if path.exists() {
         let raw = fs::read_to_string(&path)?;
@@ -109,8 +139,80 @@ pub fn load_or_create_config(store: &Path) -> Result<Config> {
     Ok(cfg)
 }
 
+pub fn save_config(store: &Path, cfg: &Config) -> Result<()> {
+    let raw = toml::to_string_pretty(cfg)?;
+    fs::write(config_path(store), raw)?;
+    Ok(())
+}
+
+pub fn load_or_create_config(store: &Path) -> Result<Config> {
+    Ok(load_or_create_file_config(store)?.apply_env_overrides())
+}
+
+pub fn load_or_create_config_with_sources(store: &Path) -> Result<(Config, ConfigSources)> {
+    let cfg = load_or_create_file_config(store)?;
+    Ok(cfg.apply_env_overrides_with_sources())
+}
+
 pub fn resolve_model_name(_store: &Path, model: &str) -> String {
     model.to_string()
+}
+
+impl Config {
+    pub fn apply_env_overrides(mut self) -> Self {
+        if let Ok(value) = env::var(ENV_OLLAMA_URL) {
+            self.ollama.base_url = value;
+        }
+        if let Ok(value) = env::var(ENV_EMBED_MODEL) {
+            self.models.embed = value;
+        }
+        if let Ok(value) = env::var(ENV_CHAT_MODEL) {
+            self.models.chat = value;
+        }
+        if let Ok(value) = env::var(ENV_VISION_MODEL) {
+            self.models.vision = value;
+        }
+        self
+    }
+
+    pub fn apply_env_overrides_with_sources(mut self) -> (Self, ConfigSources) {
+        let mut sources = ConfigSources::default();
+
+        if let Ok(value) = env::var(ENV_OLLAMA_URL) {
+            self.ollama.base_url = value;
+            sources.ollama_base_url = ConfigValueSource::Env(ENV_OLLAMA_URL);
+        }
+        if let Ok(value) = env::var(ENV_EMBED_MODEL) {
+            self.models.embed = value;
+            sources.models_embed = ConfigValueSource::Env(ENV_EMBED_MODEL);
+        }
+        if let Ok(value) = env::var(ENV_CHAT_MODEL) {
+            self.models.chat = value;
+            sources.models_chat = ConfigValueSource::Env(ENV_CHAT_MODEL);
+        }
+        if let Ok(value) = env::var(ENV_VISION_MODEL) {
+            self.models.vision = value;
+            sources.models_vision = ConfigValueSource::Env(ENV_VISION_MODEL);
+        }
+
+        (self, sources)
+    }
+
+    pub fn set_path(&mut self, key: &str, value: &str) -> Result<()> {
+        match key {
+            "ollama.base_url" => self.ollama.base_url = value.to_string(),
+            "models.embed" => self.models.embed = value.to_string(),
+            "models.chat" => self.models.chat = value.to_string(),
+            "models.vision" => self.models.vision = value.to_string(),
+            "chunk.size" => self.chunk.size = value.parse()?,
+            "chunk.overlap" => self.chunk.overlap = value.parse()?,
+            _ => anyhow::bail!(
+                "unknown config key: {} (expected one of ollama.base_url, models.embed, models.chat, models.vision, chunk.size, chunk.overlap)",
+                key
+            ),
+        }
+        Ok(())
+    }
 }
 
 pub fn normalize_chunk_settings(size: usize, overlap: usize) -> (usize, usize) {
@@ -142,13 +244,13 @@ mod tests {
         let store = dir.path().join("store");
         fs::create_dir_all(&store).unwrap();
 
-        let cfg = load_or_create_config(&store).unwrap();
+        let cfg = load_or_create_file_config(&store).unwrap();
         assert_eq!(cfg.models.embed, "nomic-embed-text-v2-moe:latest");
         assert_eq!(cfg.models.chat, "qwen3.5:4b");
         assert_eq!(cfg.models.vision, "qwen3.5:4b");
         assert!(config_path(&store).exists());
 
-        let cfg2 = load_or_create_config(&store).unwrap();
+        let cfg2 = load_or_create_file_config(&store).unwrap();
         assert_eq!(cfg2.models.embed, "nomic-embed-text-v2-moe:latest");
         assert_eq!(cfg2.chunk.size, 1000);
     }
@@ -172,5 +274,83 @@ mod tests {
         let (size2, overlap2) = normalize_chunk_settings(10, 50);
         assert_eq!(size2, 10);
         assert_eq!(overlap2, 9);
+    }
+
+    #[test]
+    fn test_set_path_updates_supported_keys() {
+        let mut cfg = Config::default();
+
+        cfg.set_path("ollama.base_url", "http://ollama:11434")
+            .unwrap();
+        cfg.set_path("models.embed", "embed-x").unwrap();
+        cfg.set_path("models.chat", "chat-x").unwrap();
+        cfg.set_path("models.vision", "vision-x").unwrap();
+        cfg.set_path("chunk.size", "512").unwrap();
+        cfg.set_path("chunk.overlap", "64").unwrap();
+
+        assert_eq!(cfg.ollama.base_url, "http://ollama:11434");
+        assert_eq!(cfg.models.embed, "embed-x");
+        assert_eq!(cfg.models.chat, "chat-x");
+        assert_eq!(cfg.models.vision, "vision-x");
+        assert_eq!(cfg.chunk.size, 512);
+        assert_eq!(cfg.chunk.overlap, 64);
+    }
+
+    #[test]
+    fn test_apply_env_overrides_with_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("store");
+        fs::create_dir_all(&store).unwrap();
+        let path = config_path(&store);
+        fs::write(
+            &path,
+            r#"[ollama]
+base_url = "http://localhost:11434"
+
+[models]
+embed = "embed-file"
+chat = "chat-file"
+vision = "vision-file"
+
+[chunk]
+size = 1000
+overlap = 200
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            env::set_var(ENV_OLLAMA_URL, "http://remote:11434");
+            env::set_var(ENV_EMBED_MODEL, "embed-env");
+            env::set_var(ENV_CHAT_MODEL, "chat-env");
+            env::set_var(ENV_VISION_MODEL, "vision-env");
+        }
+
+        let (cfg, sources) = load_or_create_config_with_sources(&store).unwrap();
+
+        assert_eq!(cfg.ollama.base_url, "http://remote:11434");
+        assert_eq!(cfg.models.embed, "embed-env");
+        assert_eq!(cfg.models.chat, "chat-env");
+        assert_eq!(cfg.models.vision, "vision-env");
+        assert_eq!(
+            sources.ollama_base_url,
+            ConfigValueSource::Env(ENV_OLLAMA_URL)
+        );
+        assert_eq!(
+            sources.models_embed,
+            ConfigValueSource::Env(ENV_EMBED_MODEL)
+        );
+        assert_eq!(sources.models_chat, ConfigValueSource::Env(ENV_CHAT_MODEL));
+        assert_eq!(
+            sources.models_vision,
+            ConfigValueSource::Env(ENV_VISION_MODEL)
+        );
+
+        unsafe {
+            env::remove_var(ENV_OLLAMA_URL);
+            env::remove_var(ENV_EMBED_MODEL);
+            env::remove_var(ENV_CHAT_MODEL);
+            env::remove_var(ENV_VISION_MODEL);
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,25 @@ impl Default for ConfigSources {
     }
 }
 
+impl ConfigSources {
+    pub fn overrides(&self) -> Vec<String> {
+        let mut overrides = Vec::new();
+        if let ConfigValueSource::Env(var) = self.ollama_base_url {
+            overrides.push(format!("ollama.base_url <- {}", var));
+        }
+        if let ConfigValueSource::Env(var) = self.models_embed {
+            overrides.push(format!("models.embed <- {}", var));
+        }
+        if let ConfigValueSource::Env(var) = self.models_chat {
+            overrides.push(format!("models.chat <- {}", var));
+        }
+        if let ConfigValueSource::Env(var) = self.models_vision {
+            overrides.push(format!("models.vision <- {}", var));
+        }
+        overrides
+    }
+}
+
 pub fn base_dir() -> Result<PathBuf> {
     let xdg_dirs = xdg::BaseDirectories::with_prefix("ragcli")?;
     Ok(xdg_dirs.get_config_home())
@@ -159,20 +178,8 @@ pub fn resolve_model_name(_store: &Path, model: &str) -> String {
 }
 
 impl Config {
-    pub fn apply_env_overrides(mut self) -> Self {
-        if let Ok(value) = env::var(ENV_OLLAMA_URL) {
-            self.ollama.base_url = value;
-        }
-        if let Ok(value) = env::var(ENV_EMBED_MODEL) {
-            self.models.embed = value;
-        }
-        if let Ok(value) = env::var(ENV_CHAT_MODEL) {
-            self.models.chat = value;
-        }
-        if let Ok(value) = env::var(ENV_VISION_MODEL) {
-            self.models.vision = value;
-        }
-        self
+    pub fn apply_env_overrides(self) -> Self {
+        self.apply_env_overrides_with_sources().0
     }
 
     pub fn apply_env_overrides_with_sources(mut self) -> (Self, ConfigSources) {
@@ -237,6 +244,12 @@ pub fn status(exists: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_config_create_and_reload() {
@@ -298,6 +311,7 @@ mod tests {
 
     #[test]
     fn test_apply_env_overrides_with_sources() {
+        let _guard = env_lock().lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let store = dir.path().join("store");
         fs::create_dir_all(&store).unwrap();
@@ -318,6 +332,11 @@ overlap = 200
 "#,
         )
         .unwrap();
+
+        let previous_ollama_url = env::var_os(ENV_OLLAMA_URL);
+        let previous_embed_model = env::var_os(ENV_EMBED_MODEL);
+        let previous_chat_model = env::var_os(ENV_CHAT_MODEL);
+        let previous_vision_model = env::var_os(ENV_VISION_MODEL);
 
         unsafe {
             env::set_var(ENV_OLLAMA_URL, "http://remote:11434");
@@ -347,10 +366,22 @@ overlap = 200
         );
 
         unsafe {
-            env::remove_var(ENV_OLLAMA_URL);
-            env::remove_var(ENV_EMBED_MODEL);
-            env::remove_var(ENV_CHAT_MODEL);
-            env::remove_var(ENV_VISION_MODEL);
+            match previous_ollama_url {
+                Some(value) => env::set_var(ENV_OLLAMA_URL, value),
+                None => env::remove_var(ENV_OLLAMA_URL),
+            }
+            match previous_embed_model {
+                Some(value) => env::set_var(ENV_EMBED_MODEL, value),
+                None => env::remove_var(ENV_EMBED_MODEL),
+            }
+            match previous_chat_model {
+                Some(value) => env::set_var(ENV_CHAT_MODEL, value),
+                None => env::remove_var(ENV_CHAT_MODEL),
+            }
+            match previous_vision_model {
+                Some(value) => env::set_var(ENV_VISION_MODEL, value),
+                None => env::remove_var(ENV_VISION_MODEL),
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use cli::{Cli, Command, ConfigCommand};
 use config::{
     ensure_store_layout, load_or_create_config, load_or_create_config_with_sources,
     load_or_create_file_config, normalize_chunk_settings, resolve_model_name, save_config, status,
-    store_dir, ConfigValueSource,
+    store_dir,
 };
 use futures::TryStreamExt;
 use ingest::ingest_path;
@@ -244,19 +244,7 @@ async fn cmd_config_show(name: Option<&str>) -> Result<()> {
     println!();
     println!("{}", toml::to_string_pretty(&cfg)?);
 
-    let mut overrides = Vec::new();
-    if let ConfigValueSource::Env(var) = sources.ollama_base_url {
-        overrides.push(format!("ollama.base_url <- {}", var));
-    }
-    if let ConfigValueSource::Env(var) = sources.models_embed {
-        overrides.push(format!("models.embed <- {}", var));
-    }
-    if let ConfigValueSource::Env(var) = sources.models_chat {
-        overrides.push(format!("models.chat <- {}", var));
-    }
-    if let ConfigValueSource::Env(var) = sources.models_vision {
-        overrides.push(format!("models.vision <- {}", var));
-    }
+    let overrides = sources.overrides();
 
     if !overrides.is_empty() {
         println!("Active environment overrides:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ mod store;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use cli::{Cli, Command};
+use cli::{Cli, Command, ConfigCommand};
 use config::{
-    ensure_store_layout, load_or_create_config, normalize_chunk_settings, resolve_model_name,
-    status, store_dir,
+    ensure_store_layout, load_or_create_config, load_or_create_config_with_sources,
+    load_or_create_file_config, normalize_chunk_settings, resolve_model_name, save_config, status,
+    store_dir, ConfigValueSource,
 };
 use futures::TryStreamExt;
 use ingest::ingest_path;
@@ -43,6 +44,10 @@ async fn main() -> Result<()> {
             gen_model,
             max_tokens,
         } => cmd_query(name, question, top_k, show_context, gen_model, max_tokens).await?,
+        Command::Config { command } => match command {
+            ConfigCommand::Show => cmd_config_show(name).await?,
+            ConfigCommand::Set { key, value } => cmd_config_set(name, key, value).await?,
+        },
         Command::Doctor => cmd_doctor(name).await?,
     }
 
@@ -226,5 +231,51 @@ async fn cmd_doctor(name: Option<&str>) -> Result<()> {
         println!("  {}: {} ({})", sub, path.display(), status(path.exists()));
     }
 
+    Ok(())
+}
+
+async fn cmd_config_show(name: Option<&str>) -> Result<()> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let (cfg, sources) = load_or_create_config_with_sources(&store)?;
+
+    println!("Store: {}", store.display());
+    println!("Config: {}", config::config_path(&store).display());
+    println!();
+    println!("{}", toml::to_string_pretty(&cfg)?);
+
+    let mut overrides = Vec::new();
+    if let ConfigValueSource::Env(var) = sources.ollama_base_url {
+        overrides.push(format!("ollama.base_url <- {}", var));
+    }
+    if let ConfigValueSource::Env(var) = sources.models_embed {
+        overrides.push(format!("models.embed <- {}", var));
+    }
+    if let ConfigValueSource::Env(var) = sources.models_chat {
+        overrides.push(format!("models.chat <- {}", var));
+    }
+    if let ConfigValueSource::Env(var) = sources.models_vision {
+        overrides.push(format!("models.vision <- {}", var));
+    }
+
+    if !overrides.is_empty() {
+        println!("Active environment overrides:");
+        for override_entry in overrides {
+            println!("  {}", override_entry);
+        }
+    }
+
+    Ok(())
+}
+
+async fn cmd_config_set(name: Option<&str>, key: String, value: String) -> Result<()> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let mut cfg = load_or_create_file_config(&store)?;
+    cfg.set_path(&key, &value)?;
+    save_config(&store, &cfg)?;
+
+    println!("Updated {}", config::config_path(&store).display());
+    println!("  {} = {}", key, value);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add \ and \ for store config management
- support env var overrides for Ollama URL and embed/chat/vision models
- document the new config workflow and override variables

## Verification
- cargo test
- cargo run -- --name smoke config set models.embed embed-smoke
- cargo run -- --name smoke config show