### PR TITLE
feat(cli): add store stats summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It indexes local files into a persistent LanceDB store, uses Ollama for embeddin
 - idempotent re-indexing by `source_path`
 - compatibility checks for embedding model + chunk settings
 - `doctor` checks for store state, Ollama reachability, and installed models
+- `stat` summarizes indexed content, approximate embedded token volume, and store disk usage
 - optional retrieval inspection with `query --show-context`
 
 ## Quick Start
@@ -27,6 +28,7 @@ ollama pull nomic-embed-text-v2-moe:latest
 ollama pull qwen3.5:4b
 
 cargo run -- doctor
+cargo run -- stat
 cargo run -- index ./docs
 cargo run -- query "What is this project about?"
 ```
@@ -58,6 +60,12 @@ Check local setup:
 
 ```bash
 cargo run -- doctor
+```
+
+Inspect what is already embedded:
+
+```bash
+cargo run -- stat
 ```
 
 ## Configuration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,8 @@ pub enum Command {
         #[arg(long, default_value_t = 256)]
         max_tokens: usize,
     },
+    /// Show a summary of indexed content and store usage
+    Stat,
     /// Check store layout and status
     Doctor,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,12 @@ use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use models::{Embedder, Generator, OllamaClient, VisionCaptioner};
 use std::fs;
+use std::path::Path;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use store::{
-    connect_db, ensure_fts_index, ensure_metadata, extract_contexts, load_metadata,
-    replace_source_rows,
+    collect_store_stats, connect_db, ensure_fts_index, ensure_metadata, extract_contexts,
+    load_metadata, replace_source_rows,
 };
 
 #[tokio::main]
@@ -43,6 +44,7 @@ async fn main() -> Result<()> {
             gen_model,
             max_tokens,
         } => cmd_query(name, question, top_k, show_context, gen_model, max_tokens).await?,
+        Command::Stat => cmd_stat(name).await?,
         Command::Doctor => cmd_doctor(name).await?,
     }
 
@@ -164,6 +166,100 @@ async fn cmd_query(
     Ok(())
 }
 
+async fn cmd_stat(name: Option<&str>) -> Result<()> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let cfg = load_or_create_config(&store)?;
+    let metadata = load_metadata(&store).ok();
+    let db = connect_db(&store).await?;
+
+    let table = match db.open_table(store::DEFAULT_TABLE_NAME).execute().await {
+        Ok(table) => Some(table),
+        Err(_) => None,
+    };
+
+    let mut batches = Vec::new();
+    if let Some(table) = &table {
+        batches = table
+            .query()
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+    }
+
+    let stats = collect_store_stats(&batches, 5)?;
+    let total_store_bytes = dir_size_bytes(&store)?;
+    let lancedb_bytes = dir_size_bytes(&store.join("lancedb"))?;
+    let meta_bytes = dir_size_bytes(&store.join("meta"))?;
+    let cache_bytes = dir_size_bytes(&store.join("cache"))?;
+    let models_bytes = dir_size_bytes(&store.join("models"))?;
+
+    println!("Store summary");
+    println!("  store: {}", store.display());
+    println!("  ollama url: {}", cfg.ollama.base_url);
+    println!("  rows embedded: {}", stats.total_chunks);
+    println!("  source files: {}", stats.unique_sources);
+    println!(
+        "  content mix: {} text, {} pdf, {} image, {} other",
+        stats.content_kinds.text_files,
+        stats.content_kinds.pdf_files,
+        stats.content_kinds.image_files,
+        stats.content_kinds.other_files
+    );
+    println!("  pdf pages: {}", stats.pdf_pages);
+    println!("  embedded chars: {}", fmt_count(stats.total_chars));
+    println!(
+        "  estimated embedded tokens: ~{}",
+        fmt_count(stats.estimated_tokens)
+    );
+
+    if stats.total_chunks > 0 {
+        println!(
+            "  avg chunk: {} chars, ~{} tokens",
+            stats.total_chars / stats.total_chunks,
+            stats.estimated_tokens / stats.total_chunks
+        );
+        println!(
+            "  chunk range: {}..{} chars",
+            stats.min_chunk_chars, stats.max_chunk_chars
+        );
+    }
+
+    if let Some(metadata) = metadata {
+        println!(
+            "  embedding: {} (dim {})",
+            metadata.embed_model, metadata.embedding_dim
+        );
+        println!(
+            "  chunking: size {}, overlap {}",
+            metadata.chunk_size, metadata.chunk_overlap
+        );
+    } else {
+        println!("  embedding: metadata missing");
+    }
+
+    println!("  disk usage: {}", fmt_bytes(total_store_bytes));
+    println!("    lancedb: {}", fmt_bytes(lancedb_bytes));
+    println!("    meta: {}", fmt_bytes(meta_bytes));
+    println!("    cache: {}", fmt_bytes(cache_bytes));
+    println!("    models: {}", fmt_bytes(models_bytes));
+
+    if !stats.top_sources.is_empty() {
+        println!("  top sources by chunk count:");
+        for source in &stats.top_sources {
+            println!(
+                "    - {}  [{} chunks, ~{} tokens]",
+                source.source_path,
+                source.chunks,
+                fmt_count(source.estimated_tokens)
+            );
+        }
+    }
+
+    Ok(())
+}
+
 async fn cmd_doctor(name: Option<&str>) -> Result<()> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
@@ -227,4 +323,52 @@ async fn cmd_doctor(name: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn dir_size_bytes(path: &Path) -> Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    if path.is_file() {
+        return Ok(path.metadata()?.len());
+    }
+
+    let mut total = 0_u64;
+    for entry in walkdir::WalkDir::new(path) {
+        let entry = entry?;
+        if entry.file_type().is_file() {
+            total += entry.metadata()?.len();
+        }
+    }
+    Ok(total)
+}
+
+fn fmt_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn fmt_count(value: usize) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    let len = digits.len();
+    for (idx, ch) in digits.chars().enumerate() {
+        if idx > 0 && (len - idx).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,7 +8,7 @@ use lancedb::index::Index;
 use lancedb::index::IndexType;
 use lancedb::{connect, Connection, Table};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -36,6 +36,35 @@ pub struct StoreMetadata {
     pub embedding_dim: usize,
     pub chunk_size: usize,
     pub chunk_overlap: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct ContentKindCounts {
+    pub text_files: usize,
+    pub pdf_files: usize,
+    pub image_files: usize,
+    pub other_files: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct SourceChunkStat {
+    pub source_path: String,
+    pub chunks: usize,
+    pub chars: usize,
+    pub estimated_tokens: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct StoreStats {
+    pub total_chunks: usize,
+    pub unique_sources: usize,
+    pub pdf_pages: usize,
+    pub total_chars: usize,
+    pub estimated_tokens: usize,
+    pub min_chunk_chars: usize,
+    pub max_chunk_chars: usize,
+    pub content_kinds: ContentKindCounts,
+    pub top_sources: Vec<SourceChunkStat>,
 }
 
 impl StoreMetadata {
@@ -247,6 +276,94 @@ pub fn extract_contexts(batches: &[RecordBatch]) -> Result<Vec<String>> {
     Ok(out)
 }
 
+pub fn collect_store_stats(batches: &[RecordBatch], top_n: usize) -> Result<StoreStats> {
+    let mut stats = StoreStats::default();
+    let mut source_stats: BTreeMap<String, SourceChunkStat> = BTreeMap::new();
+    let mut pdf_pages = BTreeSet::new();
+
+    for batch in batches {
+        let text_col = batch
+            .column_by_name("chunk_text")
+            .context("chunk_text column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("chunk_text column type")?;
+        let source_col = batch
+            .column_by_name("source_path")
+            .context("source_path column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("source_path column type")?;
+        let page_col = batch
+            .column_by_name("page")
+            .context("page column missing")?
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .context("page column type")?;
+
+        for i in 0..batch.num_rows() {
+            let source = source_col.value(i);
+            let text = text_col.value(i);
+            let chars = text.chars().count();
+            let estimated_tokens = estimate_token_count(text);
+
+            stats.total_chunks += 1;
+            stats.total_chars += chars;
+            stats.estimated_tokens += estimated_tokens;
+            if stats.total_chunks == 1 {
+                stats.min_chunk_chars = chars;
+                stats.max_chunk_chars = chars;
+            } else {
+                stats.min_chunk_chars = stats.min_chunk_chars.min(chars);
+                stats.max_chunk_chars = stats.max_chunk_chars.max(chars);
+            }
+
+            let entry = source_stats
+                .entry(source.to_string())
+                .or_insert_with(|| SourceChunkStat {
+                    source_path: source.to_string(),
+                    ..Default::default()
+                });
+            entry.chunks += 1;
+            entry.chars += chars;
+            entry.estimated_tokens += estimated_tokens;
+
+            match classify_source_kind(source) {
+                SourceKind::Pdf => {
+                    if page_col.value(i) > 0 {
+                        pdf_pages.insert((source.to_string(), page_col.value(i)));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    stats.unique_sources = source_stats.len();
+    stats.pdf_pages = pdf_pages.len();
+
+    for source in source_stats.keys() {
+        match classify_source_kind(source) {
+            SourceKind::Pdf => stats.content_kinds.pdf_files += 1,
+            SourceKind::Image => stats.content_kinds.image_files += 1,
+            SourceKind::Text => stats.content_kinds.text_files += 1,
+            SourceKind::Other => stats.content_kinds.other_files += 1,
+        }
+    }
+
+    let mut top_sources = source_stats.into_values().collect::<Vec<_>>();
+    top_sources.sort_by(|a, b| {
+        b.chunks
+            .cmp(&a.chunks)
+            .then_with(|| b.estimated_tokens.cmp(&a.estimated_tokens))
+            .then_with(|| a.source_path.cmp(&b.source_path))
+    });
+    top_sources.truncate(top_n);
+    stats.top_sources = top_sources;
+
+    Ok(stats)
+}
+
 pub fn strip_thinking(text: &str) -> String {
     if let Some(start) = text.find("<think>") {
         let end = text.find("</think>");
@@ -261,6 +378,42 @@ pub fn strip_thinking(text: &str) -> String {
 
 fn sql_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceKind {
+    Text,
+    Pdf,
+    Image,
+    Other,
+}
+
+fn classify_source_kind(source: &str) -> SourceKind {
+    let ext = Path::new(source)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("");
+
+    if ext.eq_ignore_ascii_case("pdf") {
+        SourceKind::Pdf
+    } else if ["png", "jpg", "jpeg", "webp"]
+        .iter()
+        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+    {
+        SourceKind::Image
+    } else if ["md", "markdown", "txt", "rst"]
+        .iter()
+        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+    {
+        SourceKind::Text
+    } else {
+        SourceKind::Other
+    }
+}
+
+fn estimate_token_count(text: &str) -> usize {
+    let chars = text.chars().count();
+    chars.div_ceil(4)
 }
 
 #[cfg(test)]
@@ -365,5 +518,37 @@ mod tests {
     fn test_strip_thinking() {
         let input = "<think>hidden</think>\nFinal answer.";
         assert_eq!(strip_thinking(input).trim(), "Final answer.");
+    }
+
+    #[test]
+    fn test_collect_store_stats_counts_content() {
+        let schema = build_schema(2);
+        let batch = build_record_batch(
+            schema,
+            &[
+                sample_row("notes.md", "hello world", 1.0),
+                ChunkRow {
+                    page: 1,
+                    ..sample_row("paper.pdf", "page one", 2.0)
+                },
+                ChunkRow {
+                    page: 2,
+                    ..sample_row("paper.pdf", "page two", 3.0)
+                },
+                sample_row("image.png", "caption text", 4.0),
+            ],
+        )
+        .unwrap();
+
+        let stats = collect_store_stats(&[batch], 5).unwrap();
+
+        assert_eq!(stats.total_chunks, 4);
+        assert_eq!(stats.unique_sources, 3);
+        assert_eq!(stats.content_kinds.text_files, 1);
+        assert_eq!(stats.content_kinds.pdf_files, 1);
+        assert_eq!(stats.content_kinds.image_files, 1);
+        assert_eq!(stats.pdf_pages, 2);
+        assert_eq!(stats.top_sources[0].source_path, "paper.pdf");
+        assert_eq!(stats.top_sources[0].chunks, 2);
     }
 }


### PR DESCRIPTION
## Summary
- add a new stat command for store-level content and usage reporting
- summarize embedded rows, file mix, estimated token volume, and chunk sizing
- show disk usage breakdown and document the new command in the README

## Verification
- cargo test
- cargo run -- stat