### PR TITLE
feat(ingest): add liteparse pdf parser option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,14 @@
 //! Command-line interface definitions for `ragcli`.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+/// PDF extraction backend used during indexing.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum PdfParserArg {
+    Native,
+    Liteparse,
+}
 
 /// Top-level CLI arguments.
 #[derive(Parser, Debug)]
@@ -32,6 +39,9 @@ pub enum Command {
         /// Overrides the embedding model name.
         #[arg(long)]
         embed_model: Option<String>,
+        /// Selects the PDF parser used for `.pdf` inputs.
+        #[arg(long, value_enum)]
+        pdf_parser: Option<PdfParserArg>,
     },
     /// Queries the local store and generates an answer.
     Query {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use walkdir::WalkDir;
 
 /// Aggregated indexing counters for a single ingest run.
@@ -51,6 +52,12 @@ struct ChunkContent {
     metadata: Value,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfParser {
+    Native,
+    Liteparse,
+}
+
 /// Walks a file or directory, extracts supported content, and returns chunk rows.
 pub async fn ingest_path(
     path: &Path,
@@ -58,6 +65,7 @@ pub async fn ingest_path(
     overlap: usize,
     embedder: &Embedder,
     vision: Option<&VisionCaptioner>,
+    pdf_parser: PdfParser,
 ) -> Result<IngestResult> {
     let files = collect_files(path)?;
     let progress = build_progress_bar(files.len() as u64);
@@ -125,9 +133,7 @@ pub async fn ingest_path(
             FileKind::Pdf => {
                 source_paths.insert(file.display().to_string());
                 progress.set_message(format!("Extracting {}", display_name(&file)));
-                match extract_text_by_pages(&file)
-                    .with_context(|| format!("extract pdf text: {}", file.display()))
-                {
+                match extract_pdf_pages(&file, pdf_parser) {
                     Ok(pages) => {
                         let mut file_rows = Vec::new();
                         let mut file_failed = None;
@@ -287,6 +293,75 @@ fn file_kind(path: &Path) -> FileKind {
 fn load_text_file(path: &Path) -> Result<String> {
     let bytes = fs::read(path)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn extract_pdf_pages(path: &Path, parser: PdfParser) -> Result<Vec<String>> {
+    match parser {
+        PdfParser::Native => extract_text_by_pages(path)
+            .with_context(|| format!("extract pdf text: {}", path.display())),
+        PdfParser::Liteparse => extract_pdf_pages_with_liteparse(path),
+    }
+}
+
+fn extract_pdf_pages_with_liteparse(path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("lit")
+        .arg("parse")
+        .arg(path)
+        .arg("--format")
+        .arg("json")
+        .arg("--quiet")
+        .output()
+        .with_context(|| {
+            format!(
+                "run liteparse CLI (`lit parse`) for {}",
+                path.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "liteparse failed for {}: {}",
+            path.display(),
+            stderr.trim()
+        );
+    }
+
+    parse_liteparse_pages(&output.stdout)
+        .with_context(|| format!("parse liteparse output for {}", path.display()))
+}
+
+fn parse_liteparse_pages(bytes: &[u8]) -> Result<Vec<String>> {
+    let value: Value = serde_json::from_slice(bytes).context("decode liteparse JSON")?;
+    if let Some(pages) = value.get("pages").and_then(Value::as_array) {
+        let extracted = pages
+            .iter()
+            .filter_map(|page| page.get("text").and_then(Value::as_str))
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if !extracted.is_empty() {
+            return Ok(extracted);
+        }
+    }
+
+    if let Some(text) = value.get("text").and_then(Value::as_str) {
+        let pages = split_liteparse_text_pages(text);
+        if !pages.is_empty() {
+            return Ok(pages);
+        }
+    }
+
+    anyhow::bail!("liteparse output did not contain page text")
+}
+
+fn split_liteparse_text_pages(text: &str) -> Vec<String> {
+    text.split('\u{c}')
+        .map(str::trim)
+        .filter(|page| !page.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 fn build_progress_bar(total_files: u64) -> ProgressBar {
@@ -771,5 +846,28 @@ mod tests {
         let text = load_text_file(&path).unwrap();
         assert!(text.contains('f'));
         assert!(text.contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn test_parse_liteparse_pages_from_pages_array() {
+        let json = br#"{
+            "pages": [
+                {"page": 1, "text": "First page"},
+                {"page": 2, "text": "Second page"}
+            ]
+        }"#;
+
+        let pages = parse_liteparse_pages(json).unwrap();
+        assert_eq!(pages, vec!["First page", "Second page"]);
+    }
+
+    #[test]
+    fn test_parse_liteparse_pages_from_form_feed_text() {
+        let json = br#"{
+            "text": "First page\fSecond page"
+        }"#;
+
+        let pages = parse_liteparse_pages(json).unwrap();
+        assert_eq!(pages, vec!["First page", "Second page"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,14 @@ mod store;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use cli::{Cli, Command, ConfigCommand};
+use cli::{Cli, Command, ConfigCommand, PdfParserArg};
 use config::{
     ensure_store_layout, load_or_create_config, load_or_create_config_with_sources,
     load_or_create_file_config, normalize_chunk_settings, resolve_model_name, save_config, status,
     store_dir,
 };
 use futures::TryStreamExt;
-use ingest::ingest_path;
+use ingest::{ingest_path, PdfParser};
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use models::{Embedder, Generator, OllamaClient, VisionCaptioner};
@@ -37,7 +37,10 @@ async fn main() -> Result<()> {
             chunk_size,
             chunk_overlap,
             embed_model,
-        } => cmd_index(name, path, chunk_size, chunk_overlap, embed_model).await?,
+            pdf_parser,
+        } => {
+            cmd_index(name, path, chunk_size, chunk_overlap, embed_model, pdf_parser).await?
+        }
         Command::Query {
             question,
             top_k,
@@ -62,6 +65,7 @@ async fn cmd_index(
     chunk_size: Option<usize>,
     chunk_overlap: Option<usize>,
     embed_model: Option<String>,
+    pdf_parser: Option<PdfParserArg>,
 ) -> Result<()> {
     let started = Instant::now();
     let store = store_dir(name)?;
@@ -80,7 +84,18 @@ async fn cmd_index(
         cfg.ollama.base_url.clone(),
         resolve_model_name(&store, &cfg.models.vision),
     );
-    let result = ingest_path(&path, size, overlap, &embedder, Some(&vision)).await?;
+    let result = ingest_path(
+        &path,
+        size,
+        overlap,
+        &embedder,
+        Some(&vision),
+        match pdf_parser.unwrap_or(PdfParserArg::Native) {
+            PdfParserArg::Native => PdfParser::Native,
+            PdfParserArg::Liteparse => PdfParser::Liteparse,
+        },
+    )
+    .await?;
 
     if let Some(dim) = result.embedding_dim {
         ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;


### PR DESCRIPTION
## Summary
- add a  flag to 
- keep the existing native PDF extraction path as the default backend
- add a LiteParse-backed PDF path via  with page-text normalization and tests

## Verification
- cargo check
- cargo test