### PR TITLE
test(models): add VCR cassette replay and cargo CI

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,0 +1,24 @@
+name: Cargo Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test
+        run: cargo test --all-targets

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,12 @@ Equivalent `Task` shortcuts are available in [`Taskfile.yml`](Taskfile.yml):
 - `task build`
 - `task check`
 - `task test`
+- `task release -- patch`
 - `task fmt`
 - `task doctor`
 - `task stat`
+
+Releases are managed with `cargo-release` via the `[package.metadata.release]` config in [`Cargo.toml`](Cargo.toml). Use dry runs by default and only release from `main`.
 
 ## Coding Style & Naming Conventions
 Follow idiomatic Rust and let `rustfmt` own formatting. Use 4-space indentation, `snake_case` for functions, variables, and modules, and `CamelCase` for structs and enums. Keep modules focused on one responsibility and prefer small helpers over deeply nested logic. This project already uses `anyhow::Result` for fallible flows and `clap` derives for CLI arguments; stay consistent with those patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`ragcli` is a small Rust CLI with all application code under `src/`. [`src/main.rs`](/Users/mfm/Projects/ragcli/src/main.rs) wires the CLI commands together, [`src/cli.rs`](/Users/mfm/Projects/ragcli/src/cli.rs) defines the Clap interface, [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs) handles file discovery and chunking, [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs) manages LanceDB persistence, [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs) wraps Ollama calls, and [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs) owns store configuration. GitHub Actions workflows live under [`.github/workflows/`](/Users/mfm/Projects/ragcli/.github/workflows/). Sample assets such as `example.png` and `My_Neighbor_Totoro.pdf` are local fixtures, not library code. Recorded HTTP fixtures for replay tests live under [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/).
+
+## Build, Test, and Development Commands
+Use standard Cargo commands from the repo root:
+
+- `cargo build` builds the CLI.
+- `cargo run -- doctor` checks local store layout and Ollama availability.
+- `cargo run -- index ./docs` indexes a file or directory into the default store.
+- `cargo run -- query "What is this project about?"` runs retrieval and generation.
+- `cargo check` validates the code quickly without producing a release binary.
+- `cargo test` runs the unit tests.
+- `cargo fmt -- --check` verifies formatting before review.
+
+## Coding Style & Naming Conventions
+Follow idiomatic Rust and let `rustfmt` own formatting. Use 4-space indentation, `snake_case` for functions, variables, and modules, and `CamelCase` for structs and enums. Keep modules focused on one responsibility and prefer small helpers over deeply nested logic. This project already uses `anyhow::Result` for fallible flows and `clap` derives for CLI arguments; stay consistent with those patterns.
+
+## Testing Guidelines
+Tests are primarily inline `#[cfg(test)]` unit tests inside the module they cover; see [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs), [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs), [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs), and [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs). Name tests after the behavior they verify, for example `test_replace_source_rows_removes_duplicates`. For HTTP integrations, prefer replayable cassette tests over live network dependencies when practical, and keep cassette fixtures in [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/). Add tests for new chunking, storage, config, or model-client behavior, and run `cargo test` before opening a PR.
+
+## Commit & Pull Request Guidelines
+Recent history follows concise Conventional Commit-style subjects such as `feat(cli): add hybrid lancedb retrieval` and `fix(store): rebuild fts index after delete-only updates`. Prefer `feat`, `fix`, `test`, and `ci` prefixes with a narrow scope. PRs should describe the behavior change, mention any Ollama or store-layout impact, link the relevant issue when applicable, and include CLI output snippets when user-visible behavior changes. Changes that affect CI should mention the relevant workflow, currently [`.github/workflows/cargo-test.yml`](/Users/mfm/Projects/ragcli/.github/workflows/cargo-test.yml).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-`ragcli` is a small Rust CLI with all application code under `src/`. [`src/main.rs`](/Users/mfm/Projects/ragcli/src/main.rs) wires the CLI commands together, [`src/cli.rs`](/Users/mfm/Projects/ragcli/src/cli.rs) defines the Clap interface, [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs) handles file discovery and chunking, [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs) manages LanceDB persistence, [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs) wraps Ollama calls, and [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs) owns store configuration. GitHub Actions workflows live under [`.github/workflows/`](/Users/mfm/Projects/ragcli/.github/workflows/). Sample assets such as `example.png` and `My_Neighbor_Totoro.pdf` are local fixtures, not library code. Recorded HTTP fixtures for replay tests live under [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/).
+`ragcli` is a small Rust CLI with all application code under `src/`. [`src/main.rs`](/Users/mfm/Projects/ragcli/src/main.rs) wires the CLI commands together, [`src/cli.rs`](/Users/mfm/Projects/ragcli/src/cli.rs) defines the Clap interface, [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs) handles file discovery and chunking, [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs) manages LanceDB persistence, [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs) wraps Ollama calls, and [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs) owns store configuration. GitHub Actions workflows live under [`.github/workflows/`](/Users/mfm/Projects/ragcli/.github/workflows/). Local Task automation lives in [`Taskfile.yml`](/Users/mfm/Projects/ragcli/Taskfile.yml). Sample assets such as `example.png` and `My_Neighbor_Totoro.pdf` are local fixtures, not library code. Recorded HTTP fixtures for replay tests live under [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/).
 
 ## Build, Test, and Development Commands
 Use standard Cargo commands from the repo root:
@@ -13,6 +13,15 @@ Use standard Cargo commands from the repo root:
 - `cargo check` validates the code quickly without producing a release binary.
 - `cargo test` runs the unit tests.
 - `cargo fmt -- --check` verifies formatting before review.
+
+Equivalent `Task` shortcuts are available in [`Taskfile.yml`](/Users/mfm/Projects/ragcli/Taskfile.yml):
+
+- `task build`
+- `task check`
+- `task test`
+- `task fmt`
+- `task doctor`
+- `task stat`
 
 ## Coding Style & Naming Conventions
 Follow idiomatic Rust and let `rustfmt` own formatting. Use 4-space indentation, `snake_case` for functions, variables, and modules, and `CamelCase` for structs and enums. Keep modules focused on one responsibility and prefer small helpers over deeply nested logic. This project already uses `anyhow::Result` for fallible flows and `clap` derives for CLI arguments; stay consistent with those patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-`ragcli` is a small Rust CLI with all application code under `src/`. [`src/main.rs`](/Users/mfm/Projects/ragcli/src/main.rs) wires the CLI commands together, [`src/cli.rs`](/Users/mfm/Projects/ragcli/src/cli.rs) defines the Clap interface, [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs) handles file discovery and chunking, [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs) manages LanceDB persistence, [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs) wraps Ollama calls, and [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs) owns store configuration. GitHub Actions workflows live under [`.github/workflows/`](/Users/mfm/Projects/ragcli/.github/workflows/). Local Task automation lives in [`Taskfile.yml`](/Users/mfm/Projects/ragcli/Taskfile.yml). Sample assets such as `example.png` and `My_Neighbor_Totoro.pdf` are local fixtures, not library code. Recorded HTTP fixtures for replay tests live under [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/).
+`ragcli` is a small Rust CLI with all application code under `src/`. [`src/main.rs`](src/main.rs) wires the CLI commands together, [`src/cli.rs`](src/cli.rs) defines the Clap interface, [`src/ingest.rs`](src/ingest.rs) handles file discovery and chunking, [`src/store.rs`](src/store.rs) manages LanceDB persistence, [`src/models.rs`](src/models.rs) wraps Ollama calls, and [`src/config.rs`](src/config.rs) owns store configuration. GitHub Actions workflows live under [`.github/workflows/`](.github/workflows/). Local Task automation lives in [`Taskfile.yml`](Taskfile.yml). Sample assets such as `example.png` and `My_Neighbor_Totoro.pdf` are local fixtures, not library code. Recorded HTTP fixtures for replay tests live under [`tests/cassettes/`](tests/cassettes/).
 
 ## Build, Test, and Development Commands
 Use standard Cargo commands from the repo root:
@@ -14,7 +14,7 @@ Use standard Cargo commands from the repo root:
 - `cargo test` runs the unit tests.
 - `cargo fmt -- --check` verifies formatting before review.
 
-Equivalent `Task` shortcuts are available in [`Taskfile.yml`](/Users/mfm/Projects/ragcli/Taskfile.yml):
+Equivalent `Task` shortcuts are available in [`Taskfile.yml`](Taskfile.yml):
 
 - `task build`
 - `task check`
@@ -27,7 +27,7 @@ Equivalent `Task` shortcuts are available in [`Taskfile.yml`](/Users/mfm/Project
 Follow idiomatic Rust and let `rustfmt` own formatting. Use 4-space indentation, `snake_case` for functions, variables, and modules, and `CamelCase` for structs and enums. Keep modules focused on one responsibility and prefer small helpers over deeply nested logic. This project already uses `anyhow::Result` for fallible flows and `clap` derives for CLI arguments; stay consistent with those patterns.
 
 ## Testing Guidelines
-Tests are primarily inline `#[cfg(test)]` unit tests inside the module they cover; see [`src/config.rs`](/Users/mfm/Projects/ragcli/src/config.rs), [`src/ingest.rs`](/Users/mfm/Projects/ragcli/src/ingest.rs), [`src/store.rs`](/Users/mfm/Projects/ragcli/src/store.rs), and [`src/models.rs`](/Users/mfm/Projects/ragcli/src/models.rs). Name tests after the behavior they verify, for example `test_replace_source_rows_removes_duplicates`. For HTTP integrations, prefer replayable cassette tests over live network dependencies when practical, and keep cassette fixtures in [`tests/cassettes/`](/Users/mfm/Projects/ragcli/tests/cassettes/). Add tests for new chunking, storage, config, or model-client behavior, and run `cargo test` before opening a PR.
+Tests are primarily inline `#[cfg(test)]` unit tests inside the module they cover; see [`src/config.rs`](src/config.rs), [`src/ingest.rs`](src/ingest.rs), [`src/store.rs`](src/store.rs), and [`src/models.rs`](src/models.rs). Name tests after the behavior they verify, for example `test_replace_source_rows_removes_duplicates`. For HTTP integrations, prefer replayable cassette tests over live network dependencies when practical, and keep cassette fixtures in [`tests/cassettes/`](tests/cassettes/). Add tests for new chunking, storage, config, or model-client behavior, and run `cargo test` before opening a PR.
 
 ## Commit & Pull Request Guidelines
-Recent history follows concise Conventional Commit-style subjects such as `feat(cli): add hybrid lancedb retrieval` and `fix(store): rebuild fts index after delete-only updates`. Prefer `feat`, `fix`, `test`, and `ci` prefixes with a narrow scope. PRs should describe the behavior change, mention any Ollama or store-layout impact, link the relevant issue when applicable, and include CLI output snippets when user-visible behavior changes. Changes that affect CI should mention the relevant workflow, currently [`.github/workflows/cargo-test.yml`](/Users/mfm/Projects/ragcli/.github/workflows/cargo-test.yml).
+Recent history follows concise Conventional Commit-style subjects such as `feat(cli): add hybrid lancedb retrieval` and `fix(store): rebuild fts index after delete-only updates`. Prefer `feat`, `fix`, `test`, and `ci` prefixes with a narrow scope. PRs should describe the behavior change, mention any Ollama or store-layout impact, link the relevant issue when applicable, and include CLI output snippets when user-visible behavior changes. Changes that affect CI should mention the relevant workflow, currently [`.github/workflows/cargo-test.yml`](.github/workflows/cargo-test.yml).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -477,6 +477,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1347,7 +1353,7 @@ checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -2453,7 +2459,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -4394,13 +4400,15 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-schema",
- "base64",
+ "base64 0.22.1",
  "clap",
  "futures",
  "indicatif",
  "lancedb",
  "pdf-extract",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-vcr",
  "serde",
  "serde_json",
  "sha2",
@@ -4625,7 +4633,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4666,6 +4674,42 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-vcr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3f38500f9651d4c52f17164064592326a9097ef70adbac29de1b6ef28d42bc"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "bytes",
+ "chrono",
+ "http",
+ "lazy_static",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "tracing",
+ "vcr-cassette",
 ]
 
 [[package]]
@@ -5018,7 +5062,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5331,7 +5375,7 @@ checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -5810,6 +5854,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5968,6 +6013,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6013,10 +6059,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vcr-cassette"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364f53759622897886653050d8836272da6ba50f3a4f6ad7065a78ef7141554d"
+dependencies = [
+ "chrono",
+ "serde",
+ "url",
+ "void",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,6 @@ arrow-array = "57"
 arrow-schema = "57"
 
 [dev-dependencies]
+reqwest-middleware = "0.4"
+reqwest-vcr = { version = "0.4", default-features = false, features = ["reqwest-0_12"] }
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,16 @@ edition = "2021"
 
 description = "CLI for local RAG (storage layout + plumbing)"
 
+[package.metadata.release]
+allow-branch = ["main"]
+sign-commit = false
+sign-tag = false
+push = true
+publish = false
+tag-name = "v{{version}}"
+tag-message = "Release {{version}}"
+pre-release-commit-message = "release: {{version}}"
+
 [dependencies]
 anyhow = "1"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cargo check
 cargo test
 ```
 
-If you use [Task](https://taskfile.dev/), the repo also includes [Taskfile.yml](/Users/mfm/Projects/ragcli/Taskfile.yml) with shortcuts for the common workflows:
+If you use [Task](https://taskfile.dev/), the repo also includes [Taskfile.yml](Taskfile.yml) with shortcuts for the common workflows:
 
 ```bash
 task build

--- a/README.md
+++ b/README.md
@@ -147,3 +147,21 @@ Verify:
 cargo check
 cargo test
 ```
+
+If you use [Task](https://taskfile.dev/), the repo also includes [Taskfile.yml](/Users/mfm/Projects/ragcli/Taskfile.yml) with shortcuts for the common workflows:
+
+```bash
+task build
+task check
+task test
+task fmt
+task doctor
+task stat
+```
+
+Task arguments can be forwarded to CLI tasks with `--`, for example:
+
+```bash
+task index -- ./docs
+task query -- "What is this project about?"
+```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you use [Task](https://taskfile.dev/), the repo also includes [Taskfile.yml](
 task build
 task check
 task test
+task release -- patch
 task fmt
 task doctor
 task stat
@@ -164,4 +165,19 @@ Task arguments can be forwarded to CLI tasks with `--`, for example:
 ```bash
 task index -- ./docs
 task query -- "What is this project about?"
+```
+
+Releases are configured with `cargo-release` through [`Cargo.toml`](Cargo.toml). The repository is set up to:
+
+- only release from `main`
+- create tags as `v<version>`
+- default to `cargo release` dry runs unless you pass `--execute`
+- skip crates.io publishing for now
+
+Typical usage:
+
+```bash
+cargo install cargo-release
+cargo release patch
+cargo release patch --execute
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,57 @@
+version: "3"
+
+tasks:
+  default:
+    desc: Show available tasks
+    cmds:
+      - task --list
+
+  build:
+    desc: Build the CLI
+    cmds:
+      - cargo build
+
+  check:
+    desc: Run cargo check
+    cmds:
+      - cargo check
+
+  test:
+    desc: Run cargo test
+    cmds:
+      - cargo test
+
+  fmt:
+    desc: Verify formatting with rustfmt
+    cmds:
+      - cargo fmt -- --check
+
+  doctor:
+    desc: Run the local environment and store health checks
+    cmds:
+      - cargo run -- doctor {{.CLI_ARGS}}
+
+  stat:
+    desc: Show local store statistics
+    cmds:
+      - cargo run -- stat {{.CLI_ARGS}}
+
+  index:
+    desc: Index a file or directory
+    cmds:
+      - cargo run -- index {{.CLI_ARGS}}
+
+  query:
+    desc: Query the indexed store
+    cmds:
+      - cargo run -- query {{.CLI_ARGS}}
+
+  config-show:
+    desc: Show effective config
+    cmds:
+      - cargo run -- config show {{.CLI_ARGS}}
+
+  config-set:
+    desc: Set a config key and value
+    cmds:
+      - cargo run -- config set {{.CLI_ARGS}}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,16 @@ tasks:
     cmds:
       - cargo test
 
+  release:
+    desc: Run cargo-release in dry-run mode
+    cmds:
+      - cargo release {{.CLI_ARGS}}
+
+  release-execute:
+    desc: Run cargo-release and execute the release
+    cmds:
+      - cargo release {{.CLI_ARGS}} --execute
+
   fmt:
     desc: Verify formatting with rustfmt
     cmds:

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,36 +2,47 @@
 
 use anyhow::{Context, Result};
 use base64::Engine;
+use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use serde::Deserialize;
 use std::path::Path;
 use std::time::Duration;
+#[cfg(test)]
+use std::path::PathBuf;
+#[cfg(test)]
+use reqwest_middleware::ClientWithMiddleware;
 
 /// Embedding client backed by Ollama's `/api/embed` endpoint.
 pub struct Embedder {
-    client: Client,
+    client: HttpClient,
     base_url: String,
     model: String,
 }
 
 /// Text generation client backed by Ollama's `/api/chat` endpoint.
 pub struct Generator {
-    client: Client,
+    client: HttpClient,
     base_url: String,
     model: String,
 }
 
 /// Vision captioning client that turns images into retrieval text.
 pub struct VisionCaptioner {
-    client: Client,
+    client: HttpClient,
     base_url: String,
     model: String,
 }
 
 /// Minimal Ollama API client used for health checks and model discovery.
 pub struct OllamaClient {
-    client: Client,
+    client: HttpClient,
     base_url: String,
+}
+
+enum HttpClient {
+    Reqwest(Client),
+    #[cfg(test)]
+    Middleware(ClientWithMiddleware),
 }
 
 #[derive(Debug, Deserialize)]
@@ -63,10 +74,7 @@ impl OllamaClient {
     /// Creates a new Ollama client for the given base URL.
     pub fn new(base_url: String) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .expect("build reqwest client"),
+            client: HttpClient::with_timeout(Duration::from_secs(10)),
             base_url,
         }
     }
@@ -74,15 +82,7 @@ impl OllamaClient {
     /// Returns the installed model names reported by Ollama.
     pub async fn list_models(&self) -> Result<Vec<String>> {
         let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
-        let response = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .context("call Ollama tags API")?;
-
-        let status = response.status();
-        let body = response.text().await.context("read Ollama tags response")?;
+        let (status, body) = self.client.get_text(url).await.context("call Ollama tags API")?;
         if !status.is_success() {
             anyhow::bail!("Ollama tags API error: {} - {}", status, body);
         }
@@ -97,10 +97,7 @@ impl Embedder {
     /// Creates a new embedding client.
     pub fn new(base_url: String, model: String) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(60))
-                .build()
-                .expect("build reqwest client"),
+            client: HttpClient::with_timeout(Duration::from_secs(60)),
             base_url,
             model,
         }
@@ -109,22 +106,15 @@ impl Embedder {
     /// Embeds a single text input and returns its vector.
     pub async fn embed(&self, text: &str) -> Result<Vec<f32>> {
         let url = format!("{}/api/embed", self.base_url.trim_end_matches('/'));
-        let response = self
+        let request_body = serde_json::json!({
+            "model": self.model,
+            "input": text,
+        });
+        let (status, body) = self
             .client
-            .post(url)
-            .json(&serde_json::json!({
-                "model": self.model,
-                "input": text,
-            }))
-            .send()
+            .post_json(url, request_body)
             .await
             .context("call Ollama embed API")?;
-
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .context("read Ollama embed response")?;
         if !status.is_success() {
             anyhow::bail!("Ollama embed API error: {} - {}", status, body);
         }
@@ -144,10 +134,16 @@ impl Generator {
     /// Creates a new generation client.
     pub fn new(base_url: String, model: String) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(180))
-                .build()
-                .expect("build reqwest client"),
+            client: HttpClient::with_timeout(Duration::from_secs(180)),
+            base_url,
+            model,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_client(base_url: String, model: String, client: ClientWithMiddleware) -> Self {
+        Self {
+            client: HttpClient::Middleware(client),
             base_url,
             model,
         }
@@ -164,33 +160,29 @@ impl Generator {
         let system_prompt = "You are a helpful assistant. Use the provided context to answer the question. If the answer is not in the context, say you don't know. Respond with only the final answer and no chain-of-thought.";
         let user_prompt = build_user_prompt(contexts, question);
 
-        let response = self
-            .client
-            .post(url)
-            .json(&serde_json::json!({
-                "model": self.model,
-                "stream": false,
-                "think": false,
-                "options": {
-                    "num_predict": max_tokens,
+        let request_body = serde_json::json!({
+            "model": self.model,
+            "stream": false,
+            "think": false,
+            "options": {
+                "num_predict": max_tokens,
+            },
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_prompt,
                 },
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": system_prompt,
-                    },
-                    {
-                        "role": "user",
-                        "content": user_prompt,
-                    }
-                ]
-            }))
-            .send()
+                {
+                    "role": "user",
+                    "content": user_prompt,
+                }
+            ]
+        });
+        let (status, body) = self
+            .client
+            .post_json(url, request_body)
             .await
             .context("call Ollama chat API")?;
-
-        let status = response.status();
-        let body = response.text().await.context("read Ollama chat response")?;
         if !status.is_success() {
             anyhow::bail!("Ollama chat API error: {} - {}", status, body);
         }
@@ -205,10 +197,7 @@ impl VisionCaptioner {
     /// Creates a new vision captioning client.
     pub fn new(base_url: String, model: String) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(180))
-                .build()
-                .expect("build reqwest client"),
+            client: HttpClient::with_timeout(Duration::from_secs(180)),
             base_url,
             model,
         }
@@ -221,33 +210,26 @@ impl VisionCaptioner {
         let image_b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
         let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
 
-        let response = self
+        let request_body = serde_json::json!({
+            "model": self.model,
+            "stream": false,
+            "think": false,
+            "options": {
+                "num_predict": 128,
+            },
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Describe this image for retrieval. Focus on the subjects, setting, and notable visual details.",
+                    "images": [image_b64],
+                }
+            ]
+        });
+        let (status, body) = self
             .client
-            .post(url)
-            .json(&serde_json::json!({
-                "model": self.model,
-                "stream": false,
-                "think": false,
-                "options": {
-                    "num_predict": 128,
-                },
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": "Describe this image for retrieval. Focus on the subjects, setting, and notable visual details.",
-                        "images": [image_b64],
-                    }
-                ]
-            }))
-            .send()
+            .post_json(url, request_body)
             .await
             .context("call Ollama vision chat API")?;
-
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .context("read Ollama vision response")?;
         if !status.is_success() {
             anyhow::bail!("Ollama vision API error: {} - {}", status, body);
         }
@@ -255,6 +237,66 @@ impl VisionCaptioner {
         let parsed: ChatResponse =
             serde_json::from_str(&body).context("parse Ollama vision response")?;
         Ok(parsed.message.content)
+    }
+}
+
+impl HttpClient {
+    fn with_timeout(timeout: Duration) -> Self {
+        Self::Reqwest(
+            Client::builder()
+                .timeout(timeout)
+                .build()
+                .expect("build reqwest client"),
+        )
+    }
+
+    async fn get_text(&self, url: String) -> Result<(reqwest::StatusCode, String)> {
+        let response = match self {
+            Self::Reqwest(client) => client
+                .get(url)
+                .send()
+                .await
+                .context("send HTTP GET request")?,
+            #[cfg(test)]
+            Self::Middleware(client) => client
+                .get(url)
+                .send()
+                .await
+                .context("send HTTP GET request")?,
+        };
+
+        let status = response.status();
+        let body = response.text().await.context("read HTTP response body")?;
+        Ok((status, body))
+    }
+
+    async fn post_json(
+        &self,
+        url: String,
+        body: serde_json::Value,
+    ) -> Result<(reqwest::StatusCode, String)> {
+        let body = body.to_string();
+        let response = match self {
+            Self::Reqwest(client) => client
+                .post(url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(body.clone())
+                .send()
+                .await
+                .context("send HTTP POST request")?,
+            #[cfg(test)]
+            Self::Middleware(client) => client
+                .post(url)
+                .header(CONTENT_TYPE, "application/json")
+                .body(body)
+                .send()
+                .await
+                .context("send HTTP POST request")?,
+        };
+
+        let status = response.status();
+        let body = response.text().await.context("read HTTP response body")?;
+        Ok((status, body))
     }
 }
 
@@ -266,4 +308,48 @@ fn build_user_prompt(contexts: &[String], question: &str) -> String {
     }
 
     format!("Context:\n{}\nQuestion: {}", ctx, question)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest_middleware::ClientBuilder;
+    use reqwest_vcr::{VCRMiddleware, VCRMode};
+
+    fn replay_client(cassette_name: &str) -> ClientWithMiddleware {
+        let cassette = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("cassettes")
+            .join(cassette_name);
+        let middleware = VCRMiddleware::try_from(cassette)
+            .expect("load VCR cassette")
+            .with_mode(VCRMode::Replay)
+            .with_modify_request(|request| {
+                request.headers.clear();
+            });
+
+        ClientBuilder::new(reqwest::Client::new())
+            .with(middleware)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn test_generate_answer_replays_from_cassette() {
+        let generator = Generator::new_with_client(
+            "http://ollama.test".to_string(),
+            "llama3.2".to_string(),
+            replay_client("ollama-chat-success.vcr.json"),
+        );
+
+        let answer = generator
+            .generate_answer(
+                &[String::from("A cat sits on a windowsill.")],
+                "What animal is described?",
+                64,
+            )
+            .await
+            .expect("replay Ollama chat response");
+
+        assert_eq!(answer, "A cat sits on a windowsill.");
+    }
 }

--- a/tests/cassettes/ollama-chat-success.vcr.json
+++ b/tests/cassettes/ollama-chat-success.vcr.json
@@ -1,0 +1,27 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "uri": "http://ollama.test/api/chat",
+        "body": "{\"messages\":[{\"content\":\"You are a helpful assistant. Use the provided context to answer the question. If the answer is not in the context, say you don't know. Respond with only the final answer and no chain-of-thought.\",\"role\":\"system\"},{\"content\":\"Context:\\nA cat sits on a windowsill.\\n\\n\\nQuestion: What animal is described?\",\"role\":\"user\"}],\"model\":\"llama3.2\",\"options\":{\"num_predict\":64},\"stream\":false,\"think\":false}",
+        "method": "post",
+        "headers": {}
+      },
+      "response": {
+        "body": "{\"message\":{\"content\":\"A cat sits on a windowsill.\"}}",
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Content-Type": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Wed, 02 Apr 2025 00:00:00 GMT"
+    }
+  ],
+  "recorded_with": "rVCR 0.4.0"
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `cargo test --all-targets`
- add a cassette-based replay test for the Ollama chat client using `reqwest-vcr`
- document the CI workflow and cassette fixture layout in `AGENTS.md`

## Verification
- cargo test