### PR TITLE
build(changelog): add git-cliff automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,13 @@ Equivalent `Task` shortcuts are available in [`Taskfile.yml`](Taskfile.yml):
 - `task build`
 - `task check`
 - `task test`
+- `task changelog`
 - `task release -- patch`
 - `task fmt`
 - `task doctor`
 - `task stat`
 
-Releases are managed with `cargo-release` via the `[package.metadata.release]` config in [`Cargo.toml`](Cargo.toml). Use dry runs by default and only release from `main`.
+Releases are managed with `cargo-release` via the `[package.metadata.release]` config in [`Cargo.toml`](Cargo.toml). Changelogs are generated with [`git-cliff`](https://git-cliff.org/) using [`cliff.toml`](cliff.toml) and written to [`CHANGELOG.md`](CHANGELOG.md). Use dry runs by default and only release from `main`.
 
 ## Coding Style & Naming Conventions
 Follow idiomatic Rust and let `rustfmt` own formatting. Use 4-space indentation, `snake_case` for functions, variables, and modules, and `CamelCase` for structs and enums. Keep modules focused on one responsibility and prefer small helpers over deeply nested logic. This project already uses `anyhow::Result` for fallible flows and `clap` derives for CLI arguments; stay consistent with those patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+## v0.1.0 - 2026-04-03
+
+
+### Build
+
+- **task:** add Taskfile shortcuts
+
+- **release:** add cargo-release config
+
+
+### Documentation
+
+- **rustdoc:** document public APIs
+
+
+### Features
+
+- **cli:** build local rag flow with ollama
+
+- **cli:** add vision indexing and progress UI
+
+- **cli:** add hybrid lancedb retrieval
+
+- **config:** add config show/set and env overrides
+
+- **cli:** add store stats summary
+
+- **ingest:** add format-aware chunking
+
+- **ingest:** add liteparse pdf parser option
+
+
+### Fixes
+
+- **store:** rebuild fts index after delete-only updates
+
+- **config:** address review feedback
+
+- **repo:** use relative links and install protoc
+
+
+### Refactors
+
+- **store:** simplify fts index updates
+
+
+### Testing
+
+- **models:** add VCR cassette replay and cargo CI
+
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 tag-name = "v{{version}}"
 tag-message = "Release {{version}}"
 pre-release-commit-message = "release: {{version}}"
-pre-release-hook = ["git-cliff", "-o", "CHANGELOG.md"]
+pre-release-hook = ["git-cliff", "--tag", "v{{version}}", "-o", "CHANGELOG.md"]
 
 [dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 tag-name = "v{{version}}"
 tag-message = "Release {{version}}"
 pre-release-commit-message = "release: {{version}}"
+pre-release-hook = ["git-cliff", "-o", "CHANGELOG.md"]
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you use [Task](https://taskfile.dev/), the repo also includes [Taskfile.yml](
 task build
 task check
 task test
+task changelog
 task release -- patch
 task fmt
 task doctor
@@ -171,6 +172,7 @@ Releases are configured with `cargo-release` through [`Cargo.toml`](Cargo.toml).
 
 - only release from `main`
 - create tags as `v<version>`
+- regenerate [`CHANGELOG.md`](CHANGELOG.md) with [`git-cliff`](https://git-cliff.org/) before the release commit
 - default to `cargo release` dry runs unless you pass `--execute`
 - skip crates.io publishing for now
 
@@ -178,6 +180,8 @@ Typical usage:
 
 ```bash
 cargo install cargo-release
+cargo install git-cliff
+git-cliff -o CHANGELOG.md
 cargo release patch
 cargo release patch --execute
 ```

--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Typical usage:
 ```bash
 cargo install cargo-release
 cargo install git-cliff
-git-cliff -o CHANGELOG.md
 cargo release patch
 cargo release patch --execute
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,16 @@ tasks:
     cmds:
       - cargo test
 
+  changelog:
+    desc: Generate CHANGELOG.md with git-cliff
+    cmds:
+      - git-cliff -o CHANGELOG.md
+
+  changelog-preview:
+    desc: Preview unreleased changelog output
+    cmds:
+      - git-cliff --unreleased
+
   release:
     desc: Run cargo-release in dry-run mode
     cmds:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{% if version %}## {{ version }} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}## Unreleased
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat=": ") | last | trim }}{% if commit.breaking %} [breaking]{% endif %}
+{% endfor %}
+{% endfor %}
+
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Fixes" },
+    { message = "^refactor", group = "Refactors" },
+    { message = "^perf", group = "Performance" },
+    { message = "^test", group = "Testing" },
+    { message = "^docs?", group = "Documentation" },
+    { message = "^build", group = "Build" },
+    { message = "^ci", group = "CI" },
+    { message = "^chore", group = "Chores" },
+    { message = "^release", skip = true },
+    { message = "^Merge", skip = true },
+]
+link_parsers = [
+    { pattern = "#(\\d+)", href = "https://github.com/mfmezger/ragcli/issues/$1" },
+]


### PR DESCRIPTION
## Summary
- add `git-cliff` configuration and a tracked `CHANGELOG.md`
- generate changelogs through Task shortcuts and wire changelog generation into `cargo-release`
- document the changelog and release workflow in the repo docs

## Verification
- task --list