### PR TITLE
refactor(ingest): unify source kind handling

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,6 +1,7 @@
 //! File ingestion and chunking for the local RAG store.
 
 use crate::models::{Embedder, VisionCaptioner};
+use crate::source_kind::SourceKind;
 use crate::store::ChunkRow;
 use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -37,19 +38,16 @@ pub struct IngestResult {
     pub stats: IndexStats,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FileKind {
-    Text,
-    Markdown,
-    Pdf,
-    Image,
-    Unsupported,
-}
-
 #[derive(Debug, Clone)]
 struct ChunkContent {
     text: String,
     metadata: Value,
+}
+
+#[derive(Debug, Clone)]
+struct ExtractedUnit {
+    page_num: i32,
+    chunks: Vec<ChunkContent>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,135 +79,36 @@ pub async fn ingest_path(
 
     for file in files {
         progress.set_message(format!("Reading {}", display_name(&file)));
-        match file_kind(&file) {
-            FileKind::Text => {
-                source_paths.insert(file.display().to_string());
-                match load_text_file(&file) {
-                    Ok(text) => {
-                        progress.set_message(format!("Embedding {}", display_name(&file)));
-                        let chunks = chunk_plain_text(&text, chunk_size, overlap);
-                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
-                            Ok(mut file_rows) => {
-                                stats.indexed_files += 1;
-                                stats.total_chunks += file_rows.len();
-                                rows.append(&mut file_rows);
-                            }
-                            Err(err) => {
-                                stats.skipped_files += 1;
-                                stats.errors.push(format!("{}: {}", file.display(), err));
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        stats.skipped_files += 1;
-                        stats.errors.push(format!("{}: {}", file.display(), err));
-                    }
-                }
-            }
-            FileKind::Markdown => {
-                source_paths.insert(file.display().to_string());
-                match load_text_file(&file) {
-                    Ok(text) => {
-                        progress.set_message(format!("Embedding {}", display_name(&file)));
-                        let chunks = chunk_markdown(&text, chunk_size, overlap);
-                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
-                            Ok(mut file_rows) => {
-                                stats.indexed_files += 1;
-                                stats.total_chunks += file_rows.len();
-                                rows.append(&mut file_rows);
-                            }
-                            Err(err) => {
-                                stats.skipped_files += 1;
-                                stats.errors.push(format!("{}: {}", file.display(), err));
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        stats.skipped_files += 1;
-                        stats.errors.push(format!("{}: {}", file.display(), err));
-                    }
-                }
-            }
-            FileKind::Pdf => {
-                source_paths.insert(file.display().to_string());
-                progress.set_message(format!("Extracting {}", display_name(&file)));
-                match extract_pdf_pages(&file, pdf_parser) {
-                    Ok(pages) => {
-                        let mut file_rows = Vec::new();
-                        let mut file_failed = None;
-                        for (page_idx, page_text) in pages.into_iter().enumerate() {
-                            let page_num = (page_idx + 1) as i32;
-                            progress.set_message(format!(
-                                "Embedding {} (page {})",
-                                display_name(&file),
-                                page_num
-                            ));
-                            let chunks = chunk_pdf_page(&page_text, page_num, chunk_size, overlap);
-                            match embed_chunks(&file, page_num, chunks, embedder, &mut dim).await {
-                                Ok(mut page_rows) => file_rows.append(&mut page_rows),
-                                Err(err) => {
-                                    file_failed = Some(err);
-                                    break;
-                                }
-                            }
-                        }
-
-                        if let Some(err) = file_failed {
-                            stats.skipped_files += 1;
-                            stats.errors.push(format!("{}: {}", file.display(), err));
-                        } else {
-                            stats.indexed_files += 1;
-                            stats.total_chunks += file_rows.len();
-                            rows.append(&mut file_rows);
-                        }
-                    }
-                    Err(err) => {
-                        stats.skipped_files += 1;
-                        stats.errors.push(format!("{}: {}", file.display(), err));
-                    }
-                }
-            }
-            FileKind::Image => {
-                source_paths.insert(file.display().to_string());
-                let Some(vision) = vision else {
-                    stats.skipped_files += 1;
-                    stats.errors.push(format!(
-                        "{}: image skipped because no vision model is configured",
-                        file.display()
-                    ));
-                    continue;
-                };
-
-                progress.set_message(format!("Captioning {}", display_name(&file)));
-                match vision.caption_image(&file).await {
-                    Ok(caption) => {
-                        progress.set_message(format!("Embedding {}", display_name(&file)));
-                        let chunks = vec![ChunkContent {
-                            text: build_image_retrieval_text(&file, &caption),
-                            metadata: json!({
-                                "format": "image",
-                            }),
-                        }];
-                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
-                            Ok(mut file_rows) => {
-                                stats.indexed_files += 1;
-                                stats.total_chunks += file_rows.len();
-                                rows.append(&mut file_rows);
-                            }
-                            Err(err) => {
-                                stats.skipped_files += 1;
-                                stats.errors.push(format!("{}: {}", file.display(), err));
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        stats.skipped_files += 1;
-                        stats.errors.push(format!("{}: {}", file.display(), err));
-                    }
-                }
-            }
-            FileKind::Unsupported => {}
+        let kind = SourceKind::from_path(&file);
+        if kind == SourceKind::Unsupported {
+            progress.inc(1);
+            continue;
         }
+
+        source_paths.insert(file.display().to_string());
+
+        match extract_units(
+            &file, kind, chunk_size, overlap, vision, pdf_parser, &progress,
+        )
+        .await
+        {
+            Ok(units) => match embed_units(&file, units, embedder, &mut dim, &progress).await {
+                Ok(mut file_rows) => {
+                    stats.indexed_files += 1;
+                    stats.total_chunks += file_rows.len();
+                    rows.append(&mut file_rows);
+                }
+                Err(err) => {
+                    stats.skipped_files += 1;
+                    stats.errors.push(format!("{}: {}", file.display(), err));
+                }
+            },
+            Err(err) => {
+                stats.skipped_files += 1;
+                stats.errors.push(format!("{}: {}", file.display(), err));
+            }
+        }
+
         progress.inc(1);
     }
 
@@ -224,6 +123,87 @@ pub async fn ingest_path(
         embedding_dim: dim,
         stats,
     })
+}
+
+async fn extract_units(
+    path: &Path,
+    kind: SourceKind,
+    chunk_size: usize,
+    overlap: usize,
+    vision: Option<&VisionCaptioner>,
+    pdf_parser: PdfParser,
+    progress: &ProgressBar,
+) -> Result<Vec<ExtractedUnit>> {
+    match kind {
+        SourceKind::Text | SourceKind::Markdown => {
+            let text = load_text_file(path)?;
+            let chunks = match kind {
+                SourceKind::Text => chunk_plain_text(&text, chunk_size, overlap),
+                SourceKind::Markdown => chunk_markdown(&text, chunk_size, overlap),
+                _ => unreachable!("text-like source kind already matched"),
+            };
+            Ok(vec![ExtractedUnit {
+                page_num: 0,
+                chunks,
+            }])
+        }
+        SourceKind::Pdf => {
+            progress.set_message(format!("Extracting {}", display_name(path)));
+            let pages = extract_pdf_pages(path, pdf_parser)?;
+            Ok(pages
+                .into_iter()
+                .enumerate()
+                .map(|(page_idx, page_text)| {
+                    let page_num = (page_idx + 1) as i32;
+                    ExtractedUnit {
+                        page_num,
+                        chunks: chunk_pdf_page(&page_text, page_num, chunk_size, overlap),
+                    }
+                })
+                .collect())
+        }
+        SourceKind::Image => {
+            let vision = vision.context("image skipped because no vision model is configured")?;
+            progress.set_message(format!("Captioning {}", display_name(path)));
+            let caption = vision.caption_image(path).await?;
+            Ok(vec![ExtractedUnit {
+                page_num: 0,
+                chunks: vec![ChunkContent {
+                    text: build_image_retrieval_text(path, &caption),
+                    metadata: json!({
+                        "format": SourceKind::Image
+                            .format_label()
+                            .expect("image has format label"),
+                    }),
+                }],
+            }])
+        }
+        SourceKind::Unsupported => Ok(Vec::new()),
+    }
+}
+
+async fn embed_units(
+    path: &Path,
+    units: Vec<ExtractedUnit>,
+    embedder: &Embedder,
+    dim: &mut Option<usize>,
+    progress: &ProgressBar,
+) -> Result<Vec<ChunkRow>> {
+    let mut rows = Vec::new();
+    for unit in units {
+        if unit.page_num > 0 {
+            progress.set_message(format!(
+                "Embedding {} (page {})",
+                display_name(path),
+                unit.page_num
+            ));
+        } else {
+            progress.set_message(format!("Embedding {}", display_name(path)));
+        }
+        let mut unit_rows = embed_chunks(path, unit.page_num, unit.chunks, embedder, dim).await?;
+        rows.append(&mut unit_rows);
+    }
+    Ok(rows)
 }
 
 async fn embed_chunks(
@@ -275,21 +255,6 @@ fn collect_files(path: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-fn file_kind(path: &Path) -> FileKind {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    match ext.as_str() {
-        "md" | "markdown" => FileKind::Markdown,
-        "txt" | "rst" => FileKind::Text,
-        "pdf" => FileKind::Pdf,
-        "png" | "jpg" | "jpeg" | "webp" => FileKind::Image,
-        _ => FileKind::Unsupported,
-    }
-}
-
 fn load_text_file(path: &Path) -> Result<String> {
     let bytes = fs::read(path)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
@@ -311,20 +276,11 @@ fn extract_pdf_pages_with_liteparse(path: &Path) -> Result<Vec<String>> {
         .arg("json")
         .arg("--quiet")
         .output()
-        .with_context(|| {
-            format!(
-                "run liteparse CLI (`lit parse`) for {}",
-                path.display()
-            )
-        })?;
+        .with_context(|| format!("run liteparse CLI (`lit parse`) for {}", path.display()))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "liteparse failed for {}: {}",
-            path.display(),
-            stderr.trim()
-        );
+        anyhow::bail!("liteparse failed for {}: {}", path.display(), stderr.trim());
     }
 
     parse_liteparse_pages(&output.stdout)
@@ -392,7 +348,7 @@ fn chunk_plain_text(text: &str, chunk_size: usize, overlap: usize) -> Vec<ChunkC
         .map(|text| ChunkContent {
             text,
             metadata: json!({
-                "format": "text",
+                "format": SourceKind::Text.format_label().expect("text has format label"),
             }),
         })
         .collect()
@@ -456,7 +412,7 @@ fn chunk_pdf_page(
             chunks.push(ChunkContent {
                 text,
                 metadata: json!({
-                    "format": "pdf",
+                    "format": SourceKind::Pdf.format_label().expect("pdf has format label"),
                     "section": heading,
                 }),
             });
@@ -521,7 +477,9 @@ fn push_markdown_section(
             sections.push(ChunkContent {
                 text: prefix,
                 metadata: json!({
-                    "format": "markdown",
+                    "format": SourceKind::Markdown
+                        .format_label()
+                        .expect("markdown has format label"),
                     "headings": heading_stack,
                 }),
             });
@@ -533,7 +491,9 @@ fn push_markdown_section(
         sections.push(ChunkContent {
             text,
             metadata: json!({
-                "format": "markdown",
+                "format": SourceKind::Markdown
+                    .format_label()
+                    .expect("markdown has format label"),
                 "headings": heading_stack,
             }),
         });
@@ -799,7 +759,9 @@ mod tests {
                 body.len(),
                 body
             );
-            stream.write_all(response.as_bytes()).expect("write response");
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
         });
 
         format!("http://{}", addr)
@@ -920,15 +882,6 @@ mod tests {
     }
 
     #[test]
-    fn test_file_kind_recognizes_supported_extensions() {
-        assert_eq!(file_kind(Path::new("notes.md")), FileKind::Markdown);
-        assert_eq!(file_kind(Path::new("notes.txt")), FileKind::Text);
-        assert_eq!(file_kind(Path::new("paper.PDF")), FileKind::Pdf);
-        assert_eq!(file_kind(Path::new("image.jpeg")), FileKind::Image);
-        assert_eq!(file_kind(Path::new("archive.zip")), FileKind::Unsupported);
-    }
-
-    #[test]
     fn test_display_name_and_image_retrieval_text() {
         let path = Path::new("/tmp/example-image.png");
         assert_eq!(display_name(path), "example-image.png");
@@ -955,11 +908,7 @@ mod tests {
 
     #[test]
     fn test_chunk_blocks_with_prefix_and_overlap() {
-        let blocks = vec![
-            "Alpha".to_string(),
-            "Beta".to_string(),
-            "Gamma".to_string(),
-        ];
+        let blocks = vec!["Alpha".to_string(), "Beta".to_string(), "Gamma".to_string()];
 
         let chunks = chunk_blocks(&blocks, Some("Headings: Guide"), 28, 6);
 
@@ -984,14 +933,22 @@ mod tests {
         assert!(starts_with_section_marker("2.1 Methods"));
         assert!(!starts_with_section_marker("Methods"));
         assert!(is_title_like("Project Overview"));
-        assert!(!is_title_like("a very long phrase with too many lowercase words perhaps"));
-        assert_eq!(build_pdf_prefix(4, Some("Methods")), "Page: 4\nSection: Methods");
+        assert!(!is_title_like(
+            "a very long phrase with too many lowercase words perhaps"
+        ));
+        assert_eq!(
+            build_pdf_prefix(4, Some("Methods")),
+            "Page: 4\nSection: Methods"
+        );
         assert_eq!(build_pdf_prefix(4, None), "Page: 4");
     }
 
     #[test]
     fn test_overlap_blocks_char_len_hash_and_hex() {
-        let kept = overlap_blocks(&["one".to_string(), "two".to_string(), "three".to_string()], 6);
+        let kept = overlap_blocks(
+            &["one".to_string(), "two".to_string(), "three".to_string()],
+            6,
+        );
         assert_eq!(kept, vec!["three"]);
         assert_eq!(char_len("hé🙂"), 3);
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -161,22 +161,39 @@ async fn extract_units(
             let text = load_html_file(path)?;
             Ok(vec![ExtractedUnit {
                 page_num: 0,
-                chunks: chunk_document_text(&text, "html", None, chunk_size, overlap),
+                chunks: chunk_document_text(
+                    &text,
+                    kind.format_label().expect("html has format label"),
+                    None,
+                    chunk_size,
+                    overlap,
+                ),
             }])
         }
         SourceKind::Csv { delimiter } => {
             let text = load_delimited_file(path, delimiter)?;
-            let format = if delimiter == b'\t' { "tsv" } else { "csv" };
             Ok(vec![ExtractedUnit {
                 page_num: 0,
-                chunks: chunk_document_text(&text, format, None, chunk_size, overlap),
+                chunks: chunk_document_text(
+                    &text,
+                    kind.format_label().expect("csv has format label"),
+                    None,
+                    chunk_size,
+                    overlap,
+                ),
             }])
         }
         SourceKind::Code { language } => {
             let text = load_text_file(path)?;
             Ok(vec![ExtractedUnit {
                 page_num: 0,
-                chunks: chunk_document_text(&text, "code", Some(language), chunk_size, overlap),
+                chunks: chunk_document_text(
+                    &text,
+                    kind.format_label().expect("code has format label"),
+                    Some(language),
+                    chunk_size,
+                    overlap,
+                ),
             }])
         }
         SourceKind::Pdf => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod config;
 mod ingest;
 mod models;
+mod source_kind;
 mod store;
 
 use anyhow::{Context, Result};
@@ -39,7 +40,15 @@ async fn main() -> Result<()> {
             embed_model,
             pdf_parser,
         } => {
-            cmd_index(name, path, chunk_size, chunk_overlap, embed_model, pdf_parser).await?
+            cmd_index(
+                name,
+                path,
+                chunk_size,
+                chunk_overlap,
+                embed_model,
+                pdf_parser,
+            )
+            .await?
         }
         Command::Query {
             question,
@@ -441,7 +450,11 @@ mod tests {
         ENV_LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    async fn with_test_env<T, F>(config_home: &Path, ollama_url: Option<&str>, f: impl FnOnce() -> F) -> T
+    async fn with_test_env<T, F>(
+        config_home: &Path,
+        ollama_url: Option<&str>,
+        f: impl FnOnce() -> F,
+    ) -> T
     where
         F: std::future::Future<Output = T>,
     {
@@ -487,7 +500,9 @@ mod tests {
                     body.len(),
                     body
                 );
-                stream.write_all(response.as_bytes()).expect("write response");
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
             }
         });
 
@@ -522,9 +537,13 @@ mod tests {
     async fn test_cmd_config_set_and_show_succeed_for_named_store() {
         let dir = tempfile::tempdir().unwrap();
         with_test_env(dir.path(), None, || async {
-            cmd_config_set(Some("test-store"), "models.chat".to_string(), "chat-z".to_string())
-                .await
-                .unwrap();
+            cmd_config_set(
+                Some("test-store"),
+                "models.chat".to_string(),
+                "chat-z".to_string(),
+            )
+            .await
+            .unwrap();
             cmd_config_show(Some("test-store")).await.unwrap();
 
             let store = store_dir(Some("test-store")).unwrap();
@@ -547,7 +566,9 @@ mod tests {
     #[tokio::test]
     async fn test_cmd_doctor_succeeds_with_reachable_mock_ollama() {
         let dir = tempfile::tempdir().unwrap();
-        let server = sequential_json_server(vec![r#"{"models":[{"name":"nomic-embed-text-v2-moe:latest"},{"name":"qwen3.5:4b"}]}"#]);
+        let server = sequential_json_server(vec![
+            r#"{"models":[{"name":"nomic-embed-text-v2-moe:latest"},{"name":"qwen3.5:4b"}]}"#,
+        ]);
 
         with_test_env(dir.path(), Some(&server), || async {
             cmd_doctor(Some("reachable")).await.unwrap();
@@ -565,16 +586,9 @@ mod tests {
 
         let index_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
         with_test_env(dir.path(), Some(&index_server), || async {
-            cmd_index(
-                Some("e2e"),
-                input.clone(),
-                Some(200),
-                Some(0),
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+            cmd_index(Some("e2e"), input.clone(), Some(200), Some(0), None, None)
+                .await
+                .unwrap();
             cmd_stat(Some("e2e")).await.unwrap();
         })
         .await;

--- a/src/source_kind.rs
+++ b/src/source_kind.rs
@@ -1,0 +1,111 @@
+//! Shared source-kind classification for ingestion and store statistics.
+
+use std::path::Path;
+
+/// File kind recognized by `ragcli`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    Text,
+    Markdown,
+    Pdf,
+    Image,
+    Unsupported,
+}
+
+/// Aggregated content category used for store statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentCategory {
+    Text,
+    Pdf,
+    Image,
+    Other,
+}
+
+impl SourceKind {
+    /// Classifies a source path by file extension.
+    pub fn from_path(path: &Path) -> Self {
+        let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+
+        if ["md", "markdown"]
+            .iter()
+            .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+        {
+            Self::Markdown
+        } else if ["txt", "rst"]
+            .iter()
+            .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+        {
+            Self::Text
+        } else if ext.eq_ignore_ascii_case("pdf") {
+            Self::Pdf
+        } else if ["png", "jpg", "jpeg", "webp"]
+            .iter()
+            .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+        {
+            Self::Image
+        } else {
+            Self::Unsupported
+        }
+    }
+
+    /// Returns the metadata format label used for chunk metadata.
+    pub fn format_label(self) -> Option<&'static str> {
+        match self {
+            Self::Text => Some("text"),
+            Self::Markdown => Some("markdown"),
+            Self::Pdf => Some("pdf"),
+            Self::Image => Some("image"),
+            Self::Unsupported => None,
+        }
+    }
+
+    /// Returns the aggregate content category used in store statistics.
+    pub fn content_category(self) -> ContentCategory {
+        match self {
+            Self::Text | Self::Markdown => ContentCategory::Text,
+            Self::Pdf => ContentCategory::Pdf,
+            Self::Image => ContentCategory::Image,
+            Self::Unsupported => ContentCategory::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_source_kind_from_path_and_content_category() {
+        assert_eq!(
+            SourceKind::from_path(Path::new("notes.md")),
+            SourceKind::Markdown
+        );
+        assert_eq!(
+            SourceKind::from_path(Path::new("notes.txt")),
+            SourceKind::Text
+        );
+        assert_eq!(
+            SourceKind::from_path(Path::new("paper.PDF")),
+            SourceKind::Pdf
+        );
+        assert_eq!(
+            SourceKind::from_path(Path::new("image.jpeg")),
+            SourceKind::Image
+        );
+        assert_eq!(
+            SourceKind::from_path(Path::new("archive.zip")),
+            SourceKind::Unsupported
+        );
+
+        assert_eq!(
+            SourceKind::Markdown.content_category(),
+            ContentCategory::Text
+        );
+        assert_eq!(
+            SourceKind::Unsupported.content_category(),
+            ContentCategory::Other
+        );
+        assert_eq!(SourceKind::Pdf.format_label(), Some("pdf"));
+        assert_eq!(SourceKind::Unsupported.format_label(), None);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -349,6 +349,8 @@ pub fn collect_store_stats(batches: &[RecordBatch], top_n: usize) -> Result<Stor
             .as_any()
             .downcast_ref::<Int32Array>()
             .context("page column type")?;
+        let mut current_source = None;
+        let mut current_kind = SourceKind::Unsupported;
 
         for i in 0..batch.num_rows() {
             let source = source_col.value(i);
@@ -377,8 +379,12 @@ pub fn collect_store_stats(batches: &[RecordBatch], top_n: usize) -> Result<Stor
             entry.chars += chars;
             entry.estimated_tokens += estimated_tokens;
 
-            if SourceKind::from_path(Path::new(source)) == SourceKind::Pdf && page_col.value(i) > 0
-            {
+            if current_source != Some(source) {
+                current_source = Some(source);
+                current_kind = SourceKind::from_path(Path::new(source));
+            }
+
+            if current_kind == SourceKind::Pdf && page_col.value(i) > 0 {
                 pdf_pages.insert((source.to_string(), page_col.value(i)));
             }
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,6 @@
 //! LanceDB storage helpers and store metadata utilities.
 
+use crate::source_kind::{ContentCategory, SourceKind};
 use anyhow::{bail, Context, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -376,13 +377,9 @@ pub fn collect_store_stats(batches: &[RecordBatch], top_n: usize) -> Result<Stor
             entry.chars += chars;
             entry.estimated_tokens += estimated_tokens;
 
-            match classify_source_kind(source) {
-                SourceKind::Pdf => {
-                    if page_col.value(i) > 0 {
-                        pdf_pages.insert((source.to_string(), page_col.value(i)));
-                    }
-                }
-                _ => {}
+            if SourceKind::from_path(Path::new(source)) == SourceKind::Pdf && page_col.value(i) > 0
+            {
+                pdf_pages.insert((source.to_string(), page_col.value(i)));
             }
         }
     }
@@ -391,11 +388,11 @@ pub fn collect_store_stats(batches: &[RecordBatch], top_n: usize) -> Result<Stor
     stats.pdf_pages = pdf_pages.len();
 
     for source in source_stats.keys() {
-        match classify_source_kind(source) {
-            SourceKind::Pdf => stats.content_kinds.pdf_files += 1,
-            SourceKind::Image => stats.content_kinds.image_files += 1,
-            SourceKind::Text => stats.content_kinds.text_files += 1,
-            SourceKind::Other => stats.content_kinds.other_files += 1,
+        match SourceKind::from_path(Path::new(source)).content_category() {
+            ContentCategory::Pdf => stats.content_kinds.pdf_files += 1,
+            ContentCategory::Image => stats.content_kinds.image_files += 1,
+            ContentCategory::Text => stats.content_kinds.text_files += 1,
+            ContentCategory::Other => stats.content_kinds.other_files += 1,
         }
     }
 
@@ -427,37 +424,6 @@ pub fn strip_thinking(text: &str) -> String {
 
 fn sql_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SourceKind {
-    Text,
-    Pdf,
-    Image,
-    Other,
-}
-
-fn classify_source_kind(source: &str) -> SourceKind {
-    let ext = Path::new(source)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .unwrap_or("");
-
-    if ext.eq_ignore_ascii_case("pdf") {
-        SourceKind::Pdf
-    } else if ["png", "jpg", "jpeg", "webp"]
-        .iter()
-        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
-    {
-        SourceKind::Image
-    } else if ["md", "markdown", "txt", "rst"]
-        .iter()
-        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
-    {
-        SourceKind::Text
-    } else {
-        SourceKind::Other
-    }
 }
 
 fn estimate_token_count(text: &str) -> usize {


### PR DESCRIPTION
## Summary
- add a shared source kind classifier used by ingestion and store stats
- refactor ingestion into extraction and embedding helpers around a common unit shape
- remove duplicated file-type mapping logic from store stats

## Testing
- cargo check
- cargo test

Closes #15