### PR TITLE
feat(index): add excludes and more document formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1959,6 +1969,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,6 +2378,32 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "html2text"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf7722c2ffdd62628b6e13065b6ab6cf154a236bd476c6e89af1352d745b83e"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "nom 7.1.3",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
+]
 
 [[package]]
 name = "htmlescape"
@@ -3638,6 +3697,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +3895,12 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -4127,11 +4223,49 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4231,6 +4365,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -4402,7 +4542,10 @@ dependencies = [
  "arrow-schema",
  "base64 0.22.1",
  "clap",
+ "csv",
  "futures",
+ "globset",
+ "html2text",
  "indicatif",
  "lancedb",
  "pdf-extract",
@@ -5254,6 +5397,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5530,6 +5698,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -6015,6 +6194,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ pre-release-hook = ["git-cliff", "--tag", "v{{version}}", "-o", "CHANGELOG.md"]
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
+csv = "1"
 futures = "0.3"
+globset = "0.4"
+html2text = "0.13"
 indicatif = "0.17"
 lancedb = "0.26"
 pdf-extract = "0.10"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It indexes local files into a persistent LanceDB store, uses Ollama for embeddin
 
 ## Features
 
-- local text, Markdown, PDF, and image indexing
+- local text, Markdown, HTML, CSV/TSV, source code, PDF, and image indexing
 - local embedding and generation through Ollama
 - hybrid retrieval with LanceDB vector search + BM25 full-text search
 - persistent per-store data under `~/.config/ragcli/<name>`
@@ -41,6 +41,7 @@ Index a directory or file:
 cargo run -- index ./docs
 cargo run -- index ./My_Neighbor_Totoro.pdf
 cargo run -- index ./images
+cargo run -- index . --exclude '**/target/**' --exclude '**/.git/**'
 ```
 
 Use a named store:
@@ -109,6 +110,16 @@ cargo run -- config set models.embed nomic-embed-text-v2-moe:latest
 cargo run -- config set ollama.base_url http://localhost:11434
 ```
 
+Supported indexable formats currently include:
+
+- plain text: `.txt`, `.rst`
+- Markdown: `.md`, `.markdown`
+- HTML: `.html`, `.htm`
+- tabular text: `.csv`, `.tsv`
+- source/config text: `.rs`, `.py`, `.js`, `.ts`, `.tsx`, `.jsx`, `.go`, `.java`, `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.sh`, `.bash`, `.toml`, `.yaml`, `.yml`, `.json`
+- PDF: `.pdf`
+- images: `.png`, `.jpg`, `.jpeg`, `.webp`
+
 ## Storage
 
 Each store lives under:
@@ -127,7 +138,10 @@ Each store lives under:
 ## Behavior Notes
 
 - Re-indexing replaces existing rows for the same `source_path`.
-- Text files are decoded lossily, so non-UTF-8 files do not abort indexing.
+- Text and source files are decoded lossily, so non-UTF-8 files do not abort indexing.
+- Hidden files and directories are skipped during directory traversal unless `--include-hidden` is set.
+- `index --exclude <glob>` can be repeated to skip unwanted files or directories.
+- HTML is converted to readable text before chunking, and CSV/TSV rows are flattened into labeled text.
 - Images are captioned with an Ollama vision model at index time and stored as text for retrieval.
 - Queries use LanceDB hybrid search: semantic nearest-neighbor search plus BM25 full-text search on `chunk_text`.
 - Querying refuses to mix a store with a different embedding model than the one used to build it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,12 @@ pub enum Command {
         /// Selects the PDF parser used for `.pdf` inputs.
         #[arg(long, value_enum)]
         pdf_parser: Option<PdfParserArg>,
+        /// Excludes files or directories matching the provided glob.
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+        /// Includes hidden files and directories during traversal.
+        #[arg(long, default_value_t = false)]
+        include_hidden: bool,
     },
     /// Queries the local store and generates an answer.
     Query {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -3,6 +3,7 @@
 use crate::models::{Embedder, VisionCaptioner};
 use crate::store::ChunkRow;
 use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use indicatif::{ProgressBar, ProgressStyle};
 use pdf_extract::extract_text_by_pages;
 use serde_json::{json, Value};
@@ -11,7 +12,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 /// Aggregated indexing counters for a single ingest run.
 pub struct IndexStats {
@@ -41,6 +42,9 @@ pub struct IngestResult {
 enum FileKind {
     Text,
     Markdown,
+    Html,
+    Csv { delimiter: u8 },
+    Code { language: &'static str },
     Pdf,
     Image,
     Unsupported,
@@ -58,6 +62,12 @@ pub enum PdfParser {
     Liteparse,
 }
 
+#[derive(Debug)]
+struct IngestOptions {
+    excludes: GlobSet,
+    include_hidden: bool,
+}
+
 /// Walks a file or directory, extracts supported content, and returns chunk rows.
 pub async fn ingest_path(
     path: &Path,
@@ -66,8 +76,11 @@ pub async fn ingest_path(
     embedder: &Embedder,
     vision: Option<&VisionCaptioner>,
     pdf_parser: PdfParser,
+    exclude_patterns: &[String],
+    include_hidden: bool,
 ) -> Result<IngestResult> {
-    let files = collect_files(path)?;
+    let options = build_ingest_options(exclude_patterns, include_hidden)?;
+    let files = collect_files(path, &options)?;
     let progress = build_progress_bar(files.len() as u64);
     let mut rows = Vec::new();
     let mut source_paths = BTreeSet::new();
@@ -112,6 +125,80 @@ pub async fn ingest_path(
                     Ok(text) => {
                         progress.set_message(format!("Embedding {}", display_name(&file)));
                         let chunks = chunk_markdown(&text, chunk_size, overlap);
+                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
+                            Ok(mut file_rows) => {
+                                stats.indexed_files += 1;
+                                stats.total_chunks += file_rows.len();
+                                rows.append(&mut file_rows);
+                            }
+                            Err(err) => {
+                                stats.skipped_files += 1;
+                                stats.errors.push(format!("{}: {}", file.display(), err));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        stats.skipped_files += 1;
+                        stats.errors.push(format!("{}: {}", file.display(), err));
+                    }
+                }
+            }
+            FileKind::Html => {
+                source_paths.insert(file.display().to_string());
+                match load_html_file(&file) {
+                    Ok(text) => {
+                        progress.set_message(format!("Embedding {}", display_name(&file)));
+                        let chunks = chunk_document_text(&text, "html", None, chunk_size, overlap);
+                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
+                            Ok(mut file_rows) => {
+                                stats.indexed_files += 1;
+                                stats.total_chunks += file_rows.len();
+                                rows.append(&mut file_rows);
+                            }
+                            Err(err) => {
+                                stats.skipped_files += 1;
+                                stats.errors.push(format!("{}: {}", file.display(), err));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        stats.skipped_files += 1;
+                        stats.errors.push(format!("{}: {}", file.display(), err));
+                    }
+                }
+            }
+            FileKind::Csv { delimiter } => {
+                source_paths.insert(file.display().to_string());
+                match load_delimited_file(&file, delimiter) {
+                    Ok(text) => {
+                        progress.set_message(format!("Embedding {}", display_name(&file)));
+                        let format = if delimiter == b'\t' { "tsv" } else { "csv" };
+                        let chunks = chunk_document_text(&text, format, None, chunk_size, overlap);
+                        match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
+                            Ok(mut file_rows) => {
+                                stats.indexed_files += 1;
+                                stats.total_chunks += file_rows.len();
+                                rows.append(&mut file_rows);
+                            }
+                            Err(err) => {
+                                stats.skipped_files += 1;
+                                stats.errors.push(format!("{}: {}", file.display(), err));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        stats.skipped_files += 1;
+                        stats.errors.push(format!("{}: {}", file.display(), err));
+                    }
+                }
+            }
+            FileKind::Code { language } => {
+                source_paths.insert(file.display().to_string());
+                match load_text_file(&file) {
+                    Ok(text) => {
+                        progress.set_message(format!("Embedding {}", display_name(&file)));
+                        let chunks =
+                            chunk_document_text(&text, "code", Some(language), chunk_size, overlap);
                         match embed_chunks(&file, 0, chunks, embedder, &mut dim).await {
                             Ok(mut file_rows) => {
                                 stats.indexed_files += 1;
@@ -259,20 +346,62 @@ async fn embed_chunks(
     Ok(rows)
 }
 
-fn collect_files(path: &Path) -> Result<Vec<PathBuf>> {
+fn build_ingest_options(
+    exclude_patterns: &[String],
+    include_hidden: bool,
+) -> Result<IngestOptions> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in exclude_patterns {
+        builder
+            .add(Glob::new(pattern).with_context(|| format!("invalid exclude glob: {pattern}"))?);
+    }
+
+    Ok(IngestOptions {
+        excludes: builder.build().context("build exclude glob set")?,
+        include_hidden,
+    })
+}
+
+fn collect_files(path: &Path, options: &IngestOptions) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     if path.is_file() {
-        files.push(path.to_path_buf());
+        if should_index_path(path, options) {
+            files.push(path.to_path_buf());
+        }
         return Ok(files);
     }
 
-    for entry in WalkDir::new(path) {
+    for entry in WalkDir::new(path)
+        .into_iter()
+        .filter_entry(|entry| should_traverse_entry(entry, options))
+    {
         let entry = entry?;
-        if entry.file_type().is_file() {
+        if entry.file_type().is_file() && should_index_path(entry.path(), options) {
             files.push(entry.path().to_path_buf());
         }
     }
     Ok(files)
+}
+
+fn should_traverse_entry(entry: &DirEntry, options: &IngestOptions) -> bool {
+    if entry.depth() == 0 {
+        return true;
+    }
+    if options.excludes.is_match(entry.path()) {
+        return false;
+    }
+
+    options.include_hidden || !is_hidden_path(entry.path())
+}
+
+fn should_index_path(path: &Path, options: &IngestOptions) -> bool {
+    !options.excludes.is_match(path) && (options.include_hidden || !is_hidden_path(path))
+}
+
+fn is_hidden_path(path: &Path) -> bool {
+    path.file_name()
+        .map(|name| name.to_string_lossy().starts_with('.'))
+        .unwrap_or(false)
 }
 
 fn file_kind(path: &Path) -> FileKind {
@@ -284,6 +413,28 @@ fn file_kind(path: &Path) -> FileKind {
     match ext.as_str() {
         "md" | "markdown" => FileKind::Markdown,
         "txt" | "rst" => FileKind::Text,
+        "html" | "htm" => FileKind::Html,
+        "csv" => FileKind::Csv { delimiter: b',' },
+        "tsv" => FileKind::Csv { delimiter: b'\t' },
+        "rs" => FileKind::Code { language: "rust" },
+        "py" => FileKind::Code { language: "python" },
+        "js" => FileKind::Code {
+            language: "javascript",
+        },
+        "ts" => FileKind::Code {
+            language: "typescript",
+        },
+        "tsx" => FileKind::Code { language: "tsx" },
+        "jsx" => FileKind::Code { language: "jsx" },
+        "go" => FileKind::Code { language: "go" },
+        "java" => FileKind::Code { language: "java" },
+        "c" => FileKind::Code { language: "c" },
+        "cc" | "cpp" | "cxx" => FileKind::Code { language: "cpp" },
+        "h" | "hpp" => FileKind::Code {
+            language: "c-header",
+        },
+        "sh" | "bash" => FileKind::Code { language: "shell" },
+        "toml" | "yaml" | "yml" | "json" => FileKind::Code { language: "config" },
         "pdf" => FileKind::Pdf,
         "png" | "jpg" | "jpeg" | "webp" => FileKind::Image,
         _ => FileKind::Unsupported,
@@ -293,6 +444,54 @@ fn file_kind(path: &Path) -> FileKind {
 fn load_text_file(path: &Path) -> Result<String> {
     let bytes = fs::read(path)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn load_html_file(path: &Path) -> Result<String> {
+    let html = load_text_file(path)?;
+    let rendered =
+        html2text::from_read(html.as_bytes(), usize::MAX).context("render html as text")?;
+    Ok(rendered.trim().to_string())
+}
+
+fn load_delimited_file(path: &Path, delimiter: u8) -> Result<String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(delimiter)
+        .flexible(true)
+        .from_path(path)
+        .with_context(|| format!("open delimited file: {}", path.display()))?;
+
+    let headers = reader
+        .headers()
+        .with_context(|| format!("read headers from {}", path.display()))?
+        .iter()
+        .map(|header| header.trim().to_string())
+        .collect::<Vec<_>>();
+
+    let mut lines = Vec::new();
+    if !headers.is_empty() {
+        lines.push(format!("Columns: {}", headers.join(", ")));
+    }
+
+    for record in reader.records() {
+        let record = record.with_context(|| format!("read row from {}", path.display()))?;
+        let cells = record
+            .iter()
+            .enumerate()
+            .map(|(idx, value)| {
+                let label = headers
+                    .get(idx)
+                    .map(String::as_str)
+                    .filter(|header| !header.is_empty());
+                match label {
+                    Some(header) => format!("{}: {}", header, value.trim()),
+                    None => value.trim().to_string(),
+                }
+            })
+            .collect::<Vec<_>>();
+        lines.push(cells.join(" | "));
+    }
+
+    Ok(lines.join("\n"))
 }
 
 fn extract_pdf_pages(path: &Path, parser: PdfParser) -> Result<Vec<String>> {
@@ -311,20 +510,11 @@ fn extract_pdf_pages_with_liteparse(path: &Path) -> Result<Vec<String>> {
         .arg("json")
         .arg("--quiet")
         .output()
-        .with_context(|| {
-            format!(
-                "run liteparse CLI (`lit parse`) for {}",
-                path.display()
-            )
-        })?;
+        .with_context(|| format!("run liteparse CLI (`lit parse`) for {}", path.display()))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "liteparse failed for {}: {}",
-            path.display(),
-            stderr.trim()
-        );
+        anyhow::bail!("liteparse failed for {}: {}", path.display(), stderr.trim());
     }
 
     parse_liteparse_pages(&output.stdout)
@@ -386,16 +576,31 @@ fn build_image_retrieval_text(path: &Path, caption: &str) -> String {
     format!("File: {}\nCaption: {}", display_name(path), caption.trim())
 }
 
-fn chunk_plain_text(text: &str, chunk_size: usize, overlap: usize) -> Vec<ChunkContent> {
+fn chunk_document_text(
+    text: &str,
+    format: &str,
+    language: Option<&str>,
+    chunk_size: usize,
+    overlap: usize,
+) -> Vec<ChunkContent> {
     chunk_text(text, chunk_size, overlap)
         .into_iter()
-        .map(|text| ChunkContent {
-            text,
-            metadata: json!({
-                "format": "text",
-            }),
+        .map(|text| {
+            let mut metadata = json!({
+                "format": format,
+            });
+            if let Some(obj) = metadata.as_object_mut() {
+                if let Some(language) = language {
+                    obj.insert("language".to_string(), json!(language));
+                }
+            }
+            ChunkContent { text, metadata }
         })
         .collect()
+}
+
+fn chunk_plain_text(text: &str, chunk_size: usize, overlap: usize) -> Vec<ChunkContent> {
+    chunk_document_text(text, "text", None, chunk_size, overlap)
 }
 
 fn chunk_markdown(text: &str, chunk_size: usize, overlap: usize) -> Vec<ChunkContent> {
@@ -799,7 +1004,9 @@ mod tests {
                 body.len(),
                 body
             );
-            stream.write_all(response.as_bytes()).expect("write response");
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
         });
 
         format!("http://{}", addr)
@@ -912,17 +1119,47 @@ mod tests {
         fs::write(&file, "a").unwrap();
         fs::write(&nested, "b").unwrap();
 
-        assert_eq!(collect_files(&file).unwrap(), vec![file.clone()]);
+        let options = build_ingest_options(&[], true).unwrap();
+        assert_eq!(collect_files(&file, &options).unwrap(), vec![file.clone()]);
 
-        let mut files = collect_files(dir.path()).unwrap();
+        let mut files = collect_files(dir.path(), &options).unwrap();
         files.sort();
         assert_eq!(files, vec![file, nested]);
+    }
+
+    #[test]
+    fn test_collect_files_skips_hidden_and_excluded_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let visible = dir.path().join("visible.txt");
+        let hidden_dir = dir.path().join(".git");
+        let hidden_file = hidden_dir.join("config");
+        let excluded_dir = dir.path().join("target");
+        let excluded_file = excluded_dir.join("out.txt");
+        fs::create_dir_all(&hidden_dir).unwrap();
+        fs::create_dir_all(&excluded_dir).unwrap();
+        fs::write(&visible, "ok").unwrap();
+        fs::write(&hidden_file, "hidden").unwrap();
+        fs::write(&excluded_file, "skip").unwrap();
+
+        let options = build_ingest_options(&["**/target/**".to_string()], false).unwrap();
+        let files = collect_files(dir.path(), &options).unwrap();
+
+        assert_eq!(files, vec![visible]);
     }
 
     #[test]
     fn test_file_kind_recognizes_supported_extensions() {
         assert_eq!(file_kind(Path::new("notes.md")), FileKind::Markdown);
         assert_eq!(file_kind(Path::new("notes.txt")), FileKind::Text);
+        assert_eq!(file_kind(Path::new("page.html")), FileKind::Html);
+        assert_eq!(
+            file_kind(Path::new("table.tsv")),
+            FileKind::Csv { delimiter: b'\t' }
+        );
+        assert_eq!(
+            file_kind(Path::new("lib.rs")),
+            FileKind::Code { language: "rust" }
+        );
         assert_eq!(file_kind(Path::new("paper.PDF")), FileKind::Pdf);
         assert_eq!(file_kind(Path::new("image.jpeg")), FileKind::Image);
         assert_eq!(file_kind(Path::new("archive.zip")), FileKind::Unsupported);
@@ -955,11 +1192,7 @@ mod tests {
 
     #[test]
     fn test_chunk_blocks_with_prefix_and_overlap() {
-        let blocks = vec![
-            "Alpha".to_string(),
-            "Beta".to_string(),
-            "Gamma".to_string(),
-        ];
+        let blocks = vec!["Alpha".to_string(), "Beta".to_string(), "Gamma".to_string()];
 
         let chunks = chunk_blocks(&blocks, Some("Headings: Guide"), 28, 6);
 
@@ -977,6 +1210,35 @@ mod tests {
     }
 
     #[test]
+    fn test_chunk_document_text_adds_language_metadata() {
+        let chunks = chunk_document_text("fn main() {}", "code", Some("rust"), 100, 0);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].metadata["format"], "code");
+        assert_eq!(chunks[0].metadata["language"], "rust");
+    }
+
+    #[test]
+    fn test_load_html_and_delimited_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = dir.path().join("index.html");
+        let csv = dir.path().join("people.csv");
+        fs::write(
+            &html,
+            "<html><body><h1>Title</h1><p>Hello <b>world</b>.</p></body></html>",
+        )
+        .unwrap();
+        fs::write(&csv, "name,role\nMina,Engineer\nKai,Designer\n").unwrap();
+
+        let html_text = load_html_file(&html).unwrap();
+        assert!(html_text.contains("Title"));
+        assert!(html_text.contains("Hello world."));
+
+        let csv_text = load_delimited_file(&csv, b',').unwrap();
+        assert!(csv_text.contains("Columns: name, role"));
+        assert!(csv_text.contains("name: Mina | role: Engineer"));
+    }
+
+    #[test]
     fn test_pdf_heading_helpers_and_prefix() {
         assert!(looks_like_pdf_heading("INTRODUCTION"));
         assert!(looks_like_pdf_heading("1.2 Background"));
@@ -984,14 +1246,22 @@ mod tests {
         assert!(starts_with_section_marker("2.1 Methods"));
         assert!(!starts_with_section_marker("Methods"));
         assert!(is_title_like("Project Overview"));
-        assert!(!is_title_like("a very long phrase with too many lowercase words perhaps"));
-        assert_eq!(build_pdf_prefix(4, Some("Methods")), "Page: 4\nSection: Methods");
+        assert!(!is_title_like(
+            "a very long phrase with too many lowercase words perhaps"
+        ));
+        assert_eq!(
+            build_pdf_prefix(4, Some("Methods")),
+            "Page: 4\nSection: Methods"
+        );
         assert_eq!(build_pdf_prefix(4, None), "Page: 4");
     }
 
     #[test]
     fn test_overlap_blocks_char_len_hash_and_hex() {
-        let kept = overlap_blocks(&["one".to_string(), "two".to_string(), "three".to_string()], 6);
+        let kept = overlap_blocks(
+            &["one".to_string(), "two".to_string(), "three".to_string()],
+            6,
+        );
         assert_eq!(kept, vec!["three"]);
         assert_eq!(char_len("hé🙂"), 3);
 
@@ -1011,9 +1281,18 @@ mod tests {
         fs::write(&image, b"image-bytes").unwrap();
 
         let embedder = Embedder::new("http://unused".to_string(), "embed".to_string());
-        let result = ingest_path(dir.path(), 100, 0, &embedder, None, PdfParser::Native)
-            .await
-            .unwrap();
+        let result = ingest_path(
+            dir.path(),
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(result.rows.is_empty());
         assert_eq!(result.stats.indexed_files, 0);
@@ -1029,7 +1308,7 @@ mod tests {
         fs::write(&pdf, b"not a real pdf").unwrap();
 
         let embedder = Embedder::new("http://unused".to_string(), "embed".to_string());
-        let result = ingest_path(&pdf, 100, 0, &embedder, None, PdfParser::Native)
+        let result = ingest_path(&pdf, 100, 0, &embedder, None, PdfParser::Native, &[], false)
             .await
             .unwrap();
 
@@ -1040,6 +1319,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_ingest_path_indexes_html_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = dir.path().join("index.html");
+        fs::write(
+            &html,
+            "<html><body><h1>Guide</h1><p>Hello world.</p></body></html>",
+        )
+        .unwrap();
+
+        let base_url = one_shot_json_server("200 OK", r#"{"embeddings":[[0.1,0.2]]}"#);
+        let embedder = Embedder::new(base_url, "embed".to_string());
+        let result = ingest_path(
+            &html,
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.indexed_files, 1);
+        assert_eq!(result.stats.skipped_files, 0);
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].page, 0);
+        assert!(result.rows[0].chunk_text.contains("Guide"));
+        assert!(result.rows[0].chunk_text.contains("Hello world."));
+        assert!(result.rows[0].metadata.contains("\"format\":\"html\""));
+    }
+
+    #[tokio::test]
     async fn test_ingest_path_reports_text_embedding_error() {
         let dir = tempfile::tempdir().unwrap();
         let text = dir.path().join("note.txt");
@@ -1047,9 +1360,18 @@ mod tests {
 
         let base_url = one_shot_json_server("500 Internal Server Error", r#"{"error":"boom"}"#);
         let embedder = Embedder::new(base_url, "embed".to_string());
-        let result = ingest_path(&text, 100, 0, &embedder, None, PdfParser::Native)
-            .await
-            .unwrap();
+        let result = ingest_path(
+            &text,
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(result.rows.is_empty());
         assert_eq!(result.stats.indexed_files, 0);

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -39,7 +39,7 @@ pub struct IngestResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FileKind {
+pub(crate) enum FileKind {
     Text,
     Markdown,
     Html,
@@ -404,7 +404,7 @@ fn is_hidden_path(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn file_kind(path: &Path) -> FileKind {
+pub(crate) fn file_kind(path: &Path) -> FileKind {
     let ext = path
         .extension()
         .and_then(|e| e.to_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,20 @@ async fn main() -> Result<()> {
             chunk_overlap,
             embed_model,
             pdf_parser,
+            exclude,
+            include_hidden,
         } => {
-            cmd_index(name, path, chunk_size, chunk_overlap, embed_model, pdf_parser).await?
+            cmd_index(
+                name,
+                path,
+                chunk_size,
+                chunk_overlap,
+                embed_model,
+                pdf_parser,
+                exclude,
+                include_hidden,
+            )
+            .await?
         }
         Command::Query {
             question,
@@ -66,6 +78,8 @@ async fn cmd_index(
     chunk_overlap: Option<usize>,
     embed_model: Option<String>,
     pdf_parser: Option<PdfParserArg>,
+    exclude: Vec<String>,
+    include_hidden: bool,
 ) -> Result<()> {
     let started = Instant::now();
     let store = store_dir(name)?;
@@ -94,6 +108,8 @@ async fn cmd_index(
             PdfParserArg::Native => PdfParser::Native,
             PdfParserArg::Liteparse => PdfParser::Liteparse,
         },
+        &exclude,
+        include_hidden,
     )
     .await?;
 
@@ -441,7 +457,11 @@ mod tests {
         ENV_LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    async fn with_test_env<T, F>(config_home: &Path, ollama_url: Option<&str>, f: impl FnOnce() -> F) -> T
+    async fn with_test_env<T, F>(
+        config_home: &Path,
+        ollama_url: Option<&str>,
+        f: impl FnOnce() -> F,
+    ) -> T
     where
         F: std::future::Future<Output = T>,
     {
@@ -487,7 +507,9 @@ mod tests {
                     body.len(),
                     body
                 );
-                stream.write_all(response.as_bytes()).expect("write response");
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
             }
         });
 
@@ -522,9 +544,13 @@ mod tests {
     async fn test_cmd_config_set_and_show_succeed_for_named_store() {
         let dir = tempfile::tempdir().unwrap();
         with_test_env(dir.path(), None, || async {
-            cmd_config_set(Some("test-store"), "models.chat".to_string(), "chat-z".to_string())
-                .await
-                .unwrap();
+            cmd_config_set(
+                Some("test-store"),
+                "models.chat".to_string(),
+                "chat-z".to_string(),
+            )
+            .await
+            .unwrap();
             cmd_config_show(Some("test-store")).await.unwrap();
 
             let store = store_dir(Some("test-store")).unwrap();
@@ -547,7 +573,9 @@ mod tests {
     #[tokio::test]
     async fn test_cmd_doctor_succeeds_with_reachable_mock_ollama() {
         let dir = tempfile::tempdir().unwrap();
-        let server = sequential_json_server(vec![r#"{"models":[{"name":"nomic-embed-text-v2-moe:latest"},{"name":"qwen3.5:4b"}]}"#]);
+        let server = sequential_json_server(vec![
+            r#"{"models":[{"name":"nomic-embed-text-v2-moe:latest"},{"name":"qwen3.5:4b"}]}"#,
+        ]);
 
         with_test_env(dir.path(), Some(&server), || async {
             cmd_doctor(Some("reachable")).await.unwrap();
@@ -572,6 +600,8 @@ mod tests {
                 Some(0),
                 None,
                 None,
+                Vec::new(),
+                false,
             )
             .await
             .unwrap();

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,13 +4,13 @@ use anyhow::{Context, Result};
 use base64::Engine;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
-use serde::Deserialize;
-use std::path::Path;
-use std::time::Duration;
-#[cfg(test)]
-use std::path::PathBuf;
 #[cfg(test)]
 use reqwest_middleware::ClientWithMiddleware;
+use serde::Deserialize;
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
+use std::time::Duration;
 
 /// Embedding client backed by Ollama's `/api/embed` endpoint.
 pub struct Embedder {
@@ -82,7 +82,11 @@ impl OllamaClient {
     /// Returns the installed model names reported by Ollama.
     pub async fn list_models(&self) -> Result<Vec<String>> {
         let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
-        let (status, body) = self.client.get_text(url).await.context("call Ollama tags API")?;
+        let (status, body) = self
+            .client
+            .get_text(url)
+            .await
+            .context("call Ollama tags API")?;
         if !status.is_success() {
             anyhow::bail!("Ollama tags API error: {} - {}", status, body);
         }
@@ -351,7 +355,9 @@ mod tests {
                 body.len(),
                 body
             );
-            stream.write_all(response.as_bytes()).expect("write response");
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
         });
 
         format!("http://{}", addr)
@@ -379,10 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_embed_success() {
-        let base_url = one_shot_server(
-            "200 OK",
-            r#"{"embeddings":[[0.25,0.5,0.75]]}"#,
-        );
+        let base_url = one_shot_server("200 OK", r#"{"embeddings":[[0.25,0.5,0.75]]}"#);
 
         let embedder = Embedder::new(base_url, "embed-model".to_string());
         let embedding = embedder.embed("hello").await.unwrap();
@@ -400,10 +403,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_caption_image_success() {
-        let base_url = one_shot_server(
-            "200 OK",
-            r#"{"message":{"content":"A small orange cat."}}"#,
-        );
+        let base_url =
+            one_shot_server("200 OK", r#"{"message":{"content":"A small orange cat."}}"#);
         let captioner = VisionCaptioner::new(base_url, "vision-model".to_string());
         let dir = tempfile::tempdir().unwrap();
         let image = dir.path().join("cat.png");

--- a/src/store.rs
+++ b/src/store.rs
@@ -450,9 +450,13 @@ fn classify_source_kind(source: &str) -> SourceKind {
         .any(|candidate| ext.eq_ignore_ascii_case(candidate))
     {
         SourceKind::Image
-    } else if ["md", "markdown", "txt", "rst"]
-        .iter()
-        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+    } else if [
+        "md", "markdown", "txt", "rst", "html", "htm", "csv", "tsv", "rs", "py", "js", "ts", "tsx",
+        "jsx", "go", "java", "c", "cc", "cpp", "cxx", "h", "hpp", "sh", "bash", "toml", "yaml",
+        "yml", "json",
+    ]
+    .iter()
+    .any(|candidate| ext.eq_ignore_ascii_case(candidate))
     {
         SourceKind::Text
     } else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,6 @@
 //! LanceDB storage helpers and store metadata utilities.
 
+use crate::ingest::{file_kind, FileKind};
 use anyhow::{bail, Context, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
@@ -438,29 +439,11 @@ enum SourceKind {
 }
 
 fn classify_source_kind(source: &str) -> SourceKind {
-    let ext = Path::new(source)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .unwrap_or("");
-
-    if ext.eq_ignore_ascii_case("pdf") {
-        SourceKind::Pdf
-    } else if ["png", "jpg", "jpeg", "webp"]
-        .iter()
-        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
-    {
-        SourceKind::Image
-    } else if [
-        "md", "markdown", "txt", "rst", "html", "htm", "csv", "tsv", "rs", "py", "js", "ts", "tsx",
-        "jsx", "go", "java", "c", "cc", "cpp", "cxx", "h", "hpp", "sh", "bash", "toml", "yaml",
-        "yml", "json",
-    ]
-    .iter()
-    .any(|candidate| ext.eq_ignore_ascii_case(candidate))
-    {
-        SourceKind::Text
-    } else {
-        SourceKind::Other
+    match file_kind(Path::new(source)) {
+        FileKind::Pdf => SourceKind::Pdf,
+        FileKind::Image => SourceKind::Image,
+        FileKind::Unsupported => SourceKind::Other,
+        _ => SourceKind::Text,
     }
 }
 


### PR DESCRIPTION
## Summary
- add repeatable `--exclude` globs and hidden-file skipping for indexing
- support HTML, CSV/TSV, and common source/config files during ingestion
- document the new formats and traversal behavior in the README

## Testing
- cargo test
- cargo check

Closes #16