### PR TITLE
feat(query): add rewrite, rerank, and citations

### DIFF
--- a/src/citation.rs
+++ b/src/citation.rs
@@ -1,0 +1,60 @@
+use crate::retrieval::RetrievalCandidate;
+
+pub fn labeled_contexts(candidates: &[RetrievalCandidate]) -> Vec<String> {
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(idx, candidate)| {
+            let label = idx + 1;
+            let location = match candidate.page {
+                page if page > 0 => format!("source={}, page={page}", candidate.source_path),
+                _ => format!("source={}", candidate.source_path),
+            };
+            format!("[{label}] {location}\n{}", candidate.chunk_text)
+        })
+        .collect()
+}
+
+pub fn render_citations(candidates: &[RetrievalCandidate]) -> Vec<String> {
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(idx, candidate)| match candidate.page {
+            page if page > 0 => format!("[{}] {} (page: {})", idx + 1, candidate.source_path, page),
+            _ => format!("[{}] {}", idx + 1, candidate.source_path),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::retrieval::RetrievalCandidate;
+
+    fn candidate(source_path: &str, page: i32, chunk_text: &str) -> RetrievalCandidate {
+        RetrievalCandidate {
+            id: String::new(),
+            source_path: source_path.to_string(),
+            chunk_text: chunk_text.to_string(),
+            metadata: String::new(),
+            page,
+            chunk_index: 0,
+            vector_score: None,
+            keyword_score: None,
+            fused_score: None,
+            rerank_score: None,
+        }
+    }
+
+    #[test]
+    fn test_labeled_contexts_include_numeric_labels() {
+        let contexts = labeled_contexts(&[candidate("src/config.rs", 0, "config text")]);
+        assert_eq!(contexts, vec!["[1] source=src/config.rs\nconfig text"]);
+    }
+
+    #[test]
+    fn test_render_citations_includes_page_when_present() {
+        let citations = render_citations(&[candidate("book.pdf", 4, "page text")]);
+        assert_eq!(citations, vec!["[1] book.pdf (page: 4)"]);
+    }
+}

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -511,17 +511,19 @@ async fn rerank_with_model(
         )
         .await
         .context("generate rerank JSON")?;
-    let ranked_ids = parse_rerank_payload(&response)?;
+    let ranked_positions = parse_rerank_payload(&response)?;
+    let ranked_ids = resolve_rerank_positions(candidates, &ranked_positions);
     Ok(apply_rerank_order(candidates, &ranked_ids, top_n))
 }
 
 fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> String {
     let items = candidates
         .iter()
-        .map(|candidate| {
+        .enumerate()
+        .map(|(idx, candidate)| {
             format!(
                 "id={}\nsource={}\ntext={}",
-                candidate.dedupe_key(),
+                idx + 1,
                 candidate.source_path,
                 truncate_for_rerank(&candidate.chunk_text)
             )
@@ -533,6 +535,7 @@ fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> Str
         concat!(
             "Return a JSON object with key ranked_ids. ",
             "ranked_ids must be an array of objects with keys id and score. ",
+            "Use the numeric candidate ids exactly as provided. ",
             "Include only the most relevant candidates in descending order.\n\n",
             "Question: {}\n\nCandidates:\n{}"
         ),
@@ -540,15 +543,30 @@ fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> Str
     )
 }
 
-fn parse_rerank_payload(raw: &str) -> Result<Vec<(String, f32)>> {
+fn parse_rerank_payload(raw: &str) -> Result<Vec<(usize, f32)>> {
     let trimmed = trim_json_fences(raw);
     let payload: RerankPayload = serde_json::from_str(trimmed).context("parse rerank JSON")?;
     Ok(payload
         .ranked_ids
         .into_iter()
-        .map(|item| (item.id.trim().to_string(), item.score))
-        .filter(|(id, _)| !id.is_empty())
+        .filter_map(|item| {
+            let id = item.id.trim().parse::<usize>().ok()?;
+            Some((id, item.score))
+        })
         .collect())
+}
+
+fn resolve_rerank_positions(
+    candidates: &[RetrievalCandidate],
+    ranked_positions: &[(usize, f32)],
+) -> Vec<(String, f32)> {
+    ranked_positions
+        .iter()
+        .filter_map(|(position, score)| {
+            let candidate = candidates.get(position.saturating_sub(1))?;
+            Some((candidate.dedupe_key(), *score))
+        })
+        .collect()
 }
 
 fn truncate_for_rerank(text: &str) -> String {
@@ -721,11 +739,47 @@ mod tests {
     #[test]
     fn test_parse_rerank_payload_accepts_json_fences() {
         let ranked = parse_rerank_payload(
-            "```json\n{\"ranked_ids\":[{\"id\":\"a\",\"score\":0.9},{\"id\":\"b\",\"score\":0.3}]}\n```",
+            "```json\n{\"ranked_ids\":[{\"id\":\"1\",\"score\":0.9},{\"id\":\"2\",\"score\":0.3}]}\n```",
         )
         .unwrap();
 
-        assert_eq!(ranked, vec![("a".to_string(), 0.9), ("b".to_string(), 0.3)]);
+        assert_eq!(ranked, vec![(1, 0.9), (2, 0.3)]);
+    }
+
+    #[test]
+    fn test_resolve_rerank_positions_maps_numeric_ids_to_candidates() {
+        let candidates = vec![
+            RetrievalCandidate {
+                id: "alpha".to_string(),
+                source_path: "src/a.rs".to_string(),
+                chunk_text: "a".to_string(),
+                metadata: String::new(),
+                page: 0,
+                chunk_index: 0,
+                vector_score: Some(0.1),
+                keyword_score: None,
+                fused_score: Some(0.1),
+                rerank_score: None,
+            },
+            RetrievalCandidate {
+                id: "beta".to_string(),
+                source_path: "src/b.rs".to_string(),
+                chunk_text: "b".to_string(),
+                metadata: String::new(),
+                page: 0,
+                chunk_index: 1,
+                vector_score: Some(0.2),
+                keyword_score: None,
+                fused_score: Some(0.2),
+                rerank_score: None,
+            },
+        ];
+
+        let resolved = resolve_rerank_positions(&candidates, &[(2, 0.8), (1, 0.4)]);
+        assert_eq!(
+            resolved,
+            vec![("beta".to_string(), 0.8), ("alpha".to_string(), 0.4)]
+        );
     }
 
     #[test]

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,7 +7,7 @@ use crate::models::{Embedder, Generator};
 use crate::retrieval::{
     apply_rerank_order, merge_candidates, prune_candidates, RetrievalCandidate,
 };
-use crate::rewrite::{rewrite_query_for_retrieval, QueryRewriteSet};
+use crate::rewrite::{rewrite_query_for_retrieval, trim_json_fences, QueryRewriteSet};
 use crate::store::{self, build_retrieval_filter, connect_db, ensure_fts_index, load_metadata};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Float64Array, Int32Array, RecordBatch, StringArray};
@@ -15,6 +15,9 @@ use futures::TryStreamExt;
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use std::path::PathBuf;
+
+const RERANK_MAX_TEXT_CHARS: usize = 600;
+const RERANK_RESPONSE_TOKENS: usize = 384;
 
 #[derive(Debug)]
 pub struct QueryCommand {
@@ -294,6 +297,8 @@ fn extract_candidates(batches: &[RecordBatch]) -> Result<Vec<RetrievalCandidate>
             .and_then(|column| column.as_any().downcast_ref::<Int32Array>());
 
         for row in 0..batch.num_rows() {
+            let vector_score = vector_score_at(batch, row);
+            let fused_score = relevance_score_at(batch, row).or(vector_score);
             hits.push(RetrievalCandidate {
                 id: id_col
                     .map(|column| column.value(row).to_string())
@@ -307,9 +312,9 @@ fn extract_candidates(batches: &[RecordBatch]) -> Result<Vec<RetrievalCandidate>
                 chunk_index: chunk_index_col
                     .map(|column| column.value(row))
                     .unwrap_or_default(),
-                vector_score: score_at(batch, row),
-                keyword_score: None,
-                fused_score: score_at(batch, row),
+                vector_score,
+                keyword_score: relevance_score_at(batch, row),
+                fused_score,
                 rerank_score: None,
             });
         }
@@ -318,8 +323,8 @@ fn extract_candidates(batches: &[RecordBatch]) -> Result<Vec<RetrievalCandidate>
     Ok(hits)
 }
 
-fn score_at(batch: &RecordBatch, row: usize) -> Option<f32> {
-    for name in ["_score", "score", "_distance", "distance"] {
+fn relevance_score_at(batch: &RecordBatch, row: usize) -> Option<f32> {
+    for name in ["_score", "score"] {
         let column = batch.column_by_name(name)?;
         if let Some(values) = column.as_any().downcast_ref::<Float32Array>() {
             return Some(values.value(row));
@@ -329,6 +334,29 @@ fn score_at(batch: &RecordBatch, row: usize) -> Option<f32> {
         }
     }
     None
+}
+
+fn vector_score_at(batch: &RecordBatch, row: usize) -> Option<f32> {
+    if let Some(score) = relevance_score_at(batch, row) {
+        return Some(score);
+    }
+
+    for name in ["_distance", "distance"] {
+        let column = batch.column_by_name(name)?;
+        let distance = if let Some(values) = column.as_any().downcast_ref::<Float32Array>() {
+            values.value(row)
+        } else if let Some(values) = column.as_any().downcast_ref::<Float64Array>() {
+            values.value(row) as f32
+        } else {
+            continue;
+        };
+        return Some(distance_to_similarity(distance));
+    }
+    None
+}
+
+fn distance_to_similarity(distance: f32) -> f32 {
+    1.0 / (1.0 + distance.max(0.0))
 }
 
 fn print_query_plan(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -479,7 +507,7 @@ async fn rerank_with_model(
         .generate_json(
             "You rerank retrieval candidates for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
             &prompt,
-            256,
+            RERANK_RESPONSE_TOKENS,
         )
         .await
         .context("generate rerank JSON")?;
@@ -495,7 +523,7 @@ fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> Str
                 "id={}\nsource={}\ntext={}",
                 candidate.dedupe_key(),
                 candidate.source_path,
-                candidate.chunk_text
+                truncate_for_rerank(&candidate.chunk_text)
             )
         })
         .collect::<Vec<_>>()
@@ -523,21 +551,12 @@ fn parse_rerank_payload(raw: &str) -> Result<Vec<(String, f32)>> {
         .collect())
 }
 
-fn trim_json_fences(raw: &str) -> &str {
-    let trimmed = raw.trim();
-    if !trimmed.starts_with("```") {
-        return trimmed;
+fn truncate_for_rerank(text: &str) -> String {
+    let mut truncated = text.chars().take(RERANK_MAX_TEXT_CHARS).collect::<String>();
+    if text.chars().count() > RERANK_MAX_TEXT_CHARS {
+        truncated.push_str("...");
     }
-
-    let without_prefix = trimmed
-        .trim_start_matches("```")
-        .trim_start_matches("json")
-        .trim();
-
-    without_prefix
-        .strip_suffix("```")
-        .unwrap_or(without_prefix)
-        .trim()
+    truncated
 }
 
 fn format_score(score: Option<f32>) -> String {
@@ -707,6 +726,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(ranked, vec![("a".to_string(), 0.9), ("b".to_string(), 0.3)]);
+    }
+
+    #[test]
+    fn test_distance_to_similarity_makes_smaller_distances_score_higher() {
+        assert!(distance_to_similarity(0.2) > distance_to_similarity(0.8));
+    }
+
+    #[test]
+    fn test_truncate_for_rerank_limits_candidate_text() {
+        let text = "a".repeat(RERANK_MAX_TEXT_CHARS + 25);
+        let truncated = truncate_for_rerank(&text);
+        assert_eq!(truncated.len(), RERANK_MAX_TEXT_CHARS + 3);
+        assert!(truncated.ends_with("..."));
     }
 
     #[test]

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,8 +1,13 @@
+use crate::citation::{labeled_contexts, render_citations};
 use crate::cli::QueryModeArg;
 use crate::config::{
     ensure_store_layout, load_or_create_config, resolve_model_name, store_dir, Config,
 };
 use crate::models::{Embedder, Generator};
+use crate::retrieval::{
+    apply_rerank_order, merge_candidates, prune_candidates, RetrievalCandidate,
+};
+use crate::rewrite::{rewrite_query_for_retrieval, QueryRewriteSet};
 use crate::store::{self, build_retrieval_filter, connect_db, ensure_fts_index, load_metadata};
 use anyhow::{Context, Result};
 use arrow_array::{Float32Array, Float64Array, Int32Array, RecordBatch, StringArray};
@@ -40,21 +45,24 @@ struct QueryRuntime {
     embed_model_name: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-struct QueryHit {
-    context: String,
-    source_path: String,
-    page: Option<i32>,
-    format: Option<String>,
-    score: Option<f64>,
-}
-
 #[derive(Debug)]
 struct SimpleQueryResult {
     requested_mode: QueryModeArg,
     execution_label: &'static str,
-    hits: Vec<QueryHit>,
+    rewrite_set: QueryRewriteSet,
+    hits: Vec<RetrievalCandidate>,
     trace: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RerankPayload {
+    ranked_ids: Vec<RerankItem>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RerankItem {
+    id: String,
+    score: f32,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -113,16 +121,20 @@ async fn run_simple_query(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<SimpleQueryResult> {
-    let hits = retrieve_hits(runtime, &command.question, command).await?;
+    let mut trace = vec![format!(
+        "mode {} uses the current hybrid retrieval pipeline",
+        mode_label(command.mode)
+    )];
+    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+    let hits =
+        retrieve_candidates(runtime, command, &rewrite_set.query_variants(), &mut trace).await?;
 
     Ok(SimpleQueryResult {
         requested_mode: command.mode,
         execution_label: mode_label(command.mode),
+        rewrite_set,
         hits,
-        trace: vec![format!(
-            "mode {} uses the current hybrid retrieval pipeline",
-            mode_label(command.mode)
-        )],
+        trace,
     })
 }
 
@@ -130,31 +142,95 @@ async fn run_agentic_query_command(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<SimpleQueryResult> {
-    let hits = retrieve_hits(runtime, &command.question, command).await?;
+    let mut trace = vec![
+        format!(
+            "requested {} mode routed through the agentic query stub",
+            mode_label(command.mode)
+        ),
+        "current implementation falls back to the hybrid retrieval pipeline".to_string(),
+        format!(
+            "max_iterations reserved for future agent loops: {}",
+            command.max_iterations
+        ),
+    ];
+    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+    let hits =
+        retrieve_candidates(runtime, command, &rewrite_set.query_variants(), &mut trace).await?;
 
     Ok(SimpleQueryResult {
         requested_mode: command.mode,
         execution_label: "hybrid",
+        rewrite_set,
         hits,
-        trace: vec![
-            format!(
-                "requested {} mode routed through the agentic query stub",
-                mode_label(command.mode)
-            ),
-            "current implementation falls back to the hybrid retrieval pipeline".to_string(),
-            format!(
-                "max_iterations reserved for future agent loops: {}",
-                command.max_iterations
-            ),
-        ],
+        trace,
     })
 }
 
-async fn retrieve_hits(
+async fn build_rewrite_set(
+    runtime: &QueryRuntime,
+    command: &QueryCommand,
+    trace: &mut Vec<String>,
+) -> QueryRewriteSet {
+    if !command.rewrite {
+        trace.push("rewrite disabled; using original query only".to_string());
+        return QueryRewriteSet::fallback(&command.question);
+    }
+
+    let generator = Generator::new(
+        runtime.cfg.ollama.base_url.clone(),
+        runtime.gen_model_name.clone(),
+    );
+    match rewrite_query_for_retrieval(&generator, &command.question).await {
+        Ok(rewrite_set) => {
+            let variants = rewrite_set.query_variants();
+            trace.push(format!(
+                "rewrite enabled; {} retrieval query variant(s) prepared",
+                variants.len()
+            ));
+            for variant in variants.iter().skip(1) {
+                trace.push(format!("rewrite variant: {variant}"));
+            }
+            rewrite_set
+        }
+        Err(err) => {
+            trace.push(format!(
+                "rewrite failed; falling back to original query ({})",
+                err.root_cause()
+            ));
+            QueryRewriteSet::fallback(&command.question)
+        }
+    }
+}
+
+async fn retrieve_candidates(
+    runtime: &QueryRuntime,
+    command: &QueryCommand,
+    queries: &[String],
+    trace: &mut Vec<String>,
+) -> Result<Vec<RetrievalCandidate>> {
+    let mut groups = Vec::new();
+    for query in queries {
+        groups.push(retrieve_candidates_for_query(runtime, query, command).await?);
+    }
+
+    let merged = merge_candidates(groups);
+    trace.push(format!(
+        "merged {} candidate(s) across {} retrieval query variant(s)",
+        merged.len(),
+        queries.len()
+    ));
+
+    let reranked = rerank_candidates(runtime, command, merged, trace).await;
+    let pruned = prune_candidates(reranked, command.top_k);
+    trace.push(format!("kept {} candidate(s) after pruning", pruned.len()));
+    Ok(pruned)
+}
+
+async fn retrieve_candidates_for_query(
     runtime: &QueryRuntime,
     question: &str,
     command: &QueryCommand,
-) -> Result<Vec<QueryHit>> {
+) -> Result<Vec<RetrievalCandidate>> {
     let db = connect_db(&runtime.store).await?;
     let table = db
         .open_table(store::DEFAULT_TABLE_NAME)
@@ -185,16 +261,16 @@ async fn retrieve_hits(
     }
 
     let batches: Vec<RecordBatch> = query.execute().await?.try_collect::<Vec<_>>().await?;
-
-    let mut hits = extract_hits(&batches)?;
-    hits.truncate(command.top_k);
-    Ok(hits)
+    extract_candidates(&batches)
 }
 
-fn extract_hits(batches: &[RecordBatch]) -> Result<Vec<QueryHit>> {
+fn extract_candidates(batches: &[RecordBatch]) -> Result<Vec<RetrievalCandidate>> {
     let mut hits = Vec::new();
 
     for batch in batches {
+        let id_col = batch
+            .column_by_name("id")
+            .and_then(|column| column.as_any().downcast_ref::<StringArray>());
         let text_col = batch
             .column_by_name("chunk_text")
             .context("chunk_text column missing")?
@@ -207,24 +283,34 @@ fn extract_hits(batches: &[RecordBatch]) -> Result<Vec<QueryHit>> {
             .as_any()
             .downcast_ref::<StringArray>()
             .context("source_path column type")?;
+        let metadata_col = batch
+            .column_by_name("metadata")
+            .and_then(|column| column.as_any().downcast_ref::<StringArray>());
         let page_col = batch
             .column_by_name("page")
             .and_then(|column| column.as_any().downcast_ref::<Int32Array>());
-        let format_col = batch
-            .column_by_name("format")
-            .and_then(|column| column.as_any().downcast_ref::<StringArray>());
+        let chunk_index_col = batch
+            .column_by_name("chunk_index")
+            .and_then(|column| column.as_any().downcast_ref::<Int32Array>());
 
         for row in 0..batch.num_rows() {
-            let source_path = source_col.value(row).to_string();
-            let context = format!("Source: {}\n{}", source_path, text_col.value(row));
-            hits.push(QueryHit {
-                context,
-                source_path,
-                page: page_col
+            hits.push(RetrievalCandidate {
+                id: id_col
+                    .map(|column| column.value(row).to_string())
+                    .unwrap_or_default(),
+                source_path: source_col.value(row).to_string(),
+                chunk_text: text_col.value(row).to_string(),
+                metadata: metadata_col
+                    .map(|column| column.value(row).to_string())
+                    .unwrap_or_default(),
+                page: page_col.map(|column| column.value(row)).unwrap_or_default(),
+                chunk_index: chunk_index_col
                     .map(|column| column.value(row))
-                    .filter(|page| *page > 0),
-                format: format_col.map(|column| column.value(row).to_string()),
-                score: score_at(batch, row),
+                    .unwrap_or_default(),
+                vector_score: score_at(batch, row),
+                keyword_score: None,
+                fused_score: score_at(batch, row),
+                rerank_score: None,
             });
         }
     }
@@ -232,14 +318,14 @@ fn extract_hits(batches: &[RecordBatch]) -> Result<Vec<QueryHit>> {
     Ok(hits)
 }
 
-fn score_at(batch: &RecordBatch, row: usize) -> Option<f64> {
+fn score_at(batch: &RecordBatch, row: usize) -> Option<f32> {
     for name in ["_score", "score", "_distance", "distance"] {
         let column = batch.column_by_name(name)?;
         if let Some(values) = column.as_any().downcast_ref::<Float32Array>() {
-            return Some(values.value(row) as f64);
+            return Some(values.value(row));
         }
         if let Some(values) = column.as_any().downcast_ref::<Float64Array>() {
-            return Some(values.value(row));
+            return Some(values.value(row) as f32);
         }
     }
     None
@@ -258,6 +344,10 @@ fn print_query_plan(command: &QueryCommand, result: &SimpleQueryResult) {
     println!("  max_iterations: {}", command.max_iterations);
     println!("  rewrite: {}", command.rewrite);
     println!("  rerank: {}", command.rerank);
+    println!(
+        "  query_variants: {}",
+        result.rewrite_set.query_variants().join(" | ")
+    );
     println!();
 }
 
@@ -281,10 +371,14 @@ fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
 
     println!("Scores:");
     for (idx, hit) in result.hits.iter().enumerate() {
-        match hit.score {
-            Some(score) => println!("  [{}] {:.6} {}", idx + 1, score, hit.source_path),
-            None => println!("  [{}] unavailable {}", idx + 1, hit.source_path),
-        }
+        println!(
+            "  [{}] best={:.6} fused={} rerank={} {}",
+            idx + 1,
+            hit.best_score().unwrap_or_default(),
+            format_score(hit.fused_score),
+            format_score(hit.rerank_score),
+            hit.source_path
+        );
     }
     println!();
 }
@@ -295,23 +389,8 @@ fn print_citations(command: &QueryCommand, result: &SimpleQueryResult) {
     }
 
     println!("Citations:");
-    for (idx, hit) in result.hits.iter().enumerate() {
-        match (&hit.format, hit.page) {
-            (Some(format), Some(page)) => {
-                println!(
-                    "  [{}] {} (format: {}, page: {})",
-                    idx + 1,
-                    hit.source_path,
-                    format,
-                    page
-                )
-            }
-            (Some(format), None) => {
-                println!("  [{}] {} (format: {})", idx + 1, hit.source_path, format)
-            }
-            (None, Some(page)) => println!("  [{}] {} (page: {})", idx + 1, hit.source_path, page),
-            (None, None) => println!("  [{}] {}", idx + 1, hit.source_path),
-        }
+    for citation in render_citations(&result.hits) {
+        println!("  {citation}");
     }
     println!();
 }
@@ -323,7 +402,7 @@ fn print_contexts(command: &QueryCommand, result: &SimpleQueryResult) {
 
     println!("Retrieved context:");
     for (idx, hit) in result.hits.iter().enumerate() {
-        let compact = hit.context.replace('\n', " ");
+        let compact = retrieval_context(hit).replace('\n', " ");
         let preview: String = compact.chars().take(220).collect();
         println!("  [{}] {}", idx + 1, preview);
     }
@@ -339,14 +418,132 @@ async fn generate_answer(
         runtime.cfg.ollama.base_url.clone(),
         runtime.gen_model_name.clone(),
     );
-    let contexts = result
-        .hits
-        .iter()
-        .map(|hit| hit.context.clone())
-        .collect::<Vec<_>>();
+    let contexts = labeled_contexts(&result.hits);
     generator
         .generate_answer(&contexts, &command.question, command.max_tokens)
         .await
+}
+
+fn retrieval_context(hit: &RetrievalCandidate) -> String {
+    format!("Source: {}\n{}", hit.source_path, hit.chunk_text)
+}
+
+async fn rerank_candidates(
+    runtime: &QueryRuntime,
+    command: &QueryCommand,
+    candidates: Vec<RetrievalCandidate>,
+    trace: &mut Vec<String>,
+) -> Vec<RetrievalCandidate> {
+    if !command.rerank || candidates.len() <= 1 {
+        trace.push("rerank disabled; using fused retrieval order".to_string());
+        return candidates;
+    }
+
+    let generator = Generator::new(
+        runtime.cfg.ollama.base_url.clone(),
+        runtime.gen_model_name.clone(),
+    );
+    match rerank_with_model(
+        &generator,
+        &command.question,
+        &candidates,
+        command.fetch_k.min(candidates.len()),
+    )
+    .await
+    {
+        Ok(reranked) => {
+            trace.push(format!(
+                "rerank enabled; reordered {} candidate(s)",
+                reranked.len()
+            ));
+            reranked
+        }
+        Err(err) => {
+            trace.push(format!(
+                "rerank failed; falling back to fused retrieval order ({})",
+                err.root_cause()
+            ));
+            candidates
+        }
+    }
+}
+
+async fn rerank_with_model(
+    generator: &Generator,
+    question: &str,
+    candidates: &[RetrievalCandidate],
+    top_n: usize,
+) -> Result<Vec<RetrievalCandidate>> {
+    let prompt = build_rerank_prompt(question, candidates);
+    let response = generator
+        .generate_json(
+            "You rerank retrieval candidates for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
+            &prompt,
+            256,
+        )
+        .await
+        .context("generate rerank JSON")?;
+    let ranked_ids = parse_rerank_payload(&response)?;
+    Ok(apply_rerank_order(candidates, &ranked_ids, top_n))
+}
+
+fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> String {
+    let items = candidates
+        .iter()
+        .map(|candidate| {
+            format!(
+                "id={}\nsource={}\ntext={}",
+                candidate.dedupe_key(),
+                candidate.source_path,
+                candidate.chunk_text
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    format!(
+        concat!(
+            "Return a JSON object with key ranked_ids. ",
+            "ranked_ids must be an array of objects with keys id and score. ",
+            "Include only the most relevant candidates in descending order.\n\n",
+            "Question: {}\n\nCandidates:\n{}"
+        ),
+        question, items
+    )
+}
+
+fn parse_rerank_payload(raw: &str) -> Result<Vec<(String, f32)>> {
+    let trimmed = trim_json_fences(raw);
+    let payload: RerankPayload = serde_json::from_str(trimmed).context("parse rerank JSON")?;
+    Ok(payload
+        .ranked_ids
+        .into_iter()
+        .map(|item| (item.id.trim().to_string(), item.score))
+        .filter(|(id, _)| !id.is_empty())
+        .collect())
+}
+
+fn trim_json_fences(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+
+    let without_prefix = trimmed
+        .trim_start_matches("```")
+        .trim_start_matches("json")
+        .trim();
+
+    without_prefix
+        .strip_suffix("```")
+        .unwrap_or(without_prefix)
+        .trim()
+}
+
+fn format_score(score: Option<f32>) -> String {
+    score
+        .map(|value| format!("{value:.6}"))
+        .unwrap_or_else(|| "unavailable".to_string())
 }
 
 fn execution_path(mode: QueryModeArg) -> QueryExecutionPath {
@@ -436,6 +633,80 @@ mod tests {
             .unwrap();
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_rewrite_falls_back_to_original_query_when_json_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        let input = docs.join("note.txt");
+        std::fs::write(
+            &input,
+            "Configuration resolution happens during query execution.",
+        )
+        .unwrap();
+
+        let index_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
+        with_test_env(dir.path(), Some(&index_server), || async {
+            index::run(
+                Some("rewrite-fallback"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        let query_server = sequential_json_server(vec![
+            r#"{"message":{"content":"not json"}}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"Configuration resolution happens during query execution."}}"#,
+        ]);
+        with_test_env(dir.path(), Some(&query_server), || async {
+            run(
+                Some("rewrite-fallback"),
+                QueryCommand {
+                    question: "How does config resolution work?".to_string(),
+                    mode: QueryModeArg::Hybrid,
+                    top_k: 5,
+                    fetch_k: 20,
+                    max_iterations: 2,
+                    rewrite: true,
+                    rerank: false,
+                    show_context: false,
+                    show_plan: false,
+                    show_scores: false,
+                    show_citations: false,
+                    show_trace: false,
+                    source: None,
+                    path_prefix: None,
+                    page: None,
+                    format: None,
+                    gen_model: None,
+                    max_tokens: 64,
+                },
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    }
+
+    #[test]
+    fn test_parse_rerank_payload_accepts_json_fences() {
+        let ranked = parse_rerank_payload(
+            "```json\n{\"ranked_ids\":[{\"id\":\"a\",\"score\":0.9},{\"id\":\"b\",\"score\":0.3}]}\n```",
+        )
+        .unwrap();
+
+        assert_eq!(ranked, vec![("a".to_string(), 0.9), ("b".to_string(), 0.3)]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 mod app;
+mod citation;
 mod cli;
 mod commands;
 mod config;
 mod fsutil;
 mod ingest;
 mod models;
+mod retrieval;
+mod rewrite;
 mod source_kind;
 mod store;
 #[cfg(test)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,12 +4,8 @@ use anyhow::{Context, Result};
 use base64::Engine;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
-#[cfg(test)]
-use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
 use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
 use std::time::Duration;
 
 /// Embedding client backed by Ollama's `/api/embed` endpoint.
@@ -41,8 +37,6 @@ pub struct OllamaClient {
 
 enum HttpClient {
     Reqwest(Client),
-    #[cfg(test)]
-    Middleware(ClientWithMiddleware),
 }
 
 #[derive(Debug, Deserialize)]
@@ -144,15 +138,6 @@ impl Generator {
         }
     }
 
-    #[cfg(test)]
-    fn new_with_client(base_url: String, model: String, client: ClientWithMiddleware) -> Self {
-        Self {
-            client: HttpClient::Middleware(client),
-            base_url,
-            model,
-        }
-    }
-
     /// Generates an answer grounded in retrieved contexts.
     pub async fn generate_answer(
         &self,
@@ -160,10 +145,32 @@ impl Generator {
         question: &str,
         max_tokens: usize,
     ) -> Result<String> {
-        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
-        let system_prompt = "You are a helpful assistant. Use the provided context to answer the question. If the answer is not in the context, say you don't know. Respond with only the final answer and no chain-of-thought.";
-        let user_prompt = build_user_prompt(contexts, question);
+        self.generate_with_prompts(
+            "You are a helpful assistant. Answer only from the provided evidence. Cite supported claims with bracketed evidence labels like [1] or [2]. If the evidence is insufficient, say you don't know. Respond with only the final answer and no chain-of-thought.",
+            &build_user_prompt(contexts, question),
+            max_tokens,
+        )
+        .await
+    }
 
+    /// Generates a strict-JSON response for structured tasks.
+    pub async fn generate_json(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        self.generate_with_prompts(system_prompt, user_prompt, max_tokens)
+            .await
+    }
+
+    async fn generate_with_prompts(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        max_tokens: usize,
+    ) -> Result<String> {
+        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
         let request_body = serde_json::json!({
             "model": self.model,
             "stream": false,
@@ -261,12 +268,6 @@ impl HttpClient {
                 .send()
                 .await
                 .context("send HTTP GET request")?,
-            #[cfg(test)]
-            Self::Middleware(client) => client
-                .get(url)
-                .send()
-                .await
-                .context("send HTTP GET request")?,
         };
 
         let status = response.status();
@@ -285,14 +286,6 @@ impl HttpClient {
                 .post(url)
                 .header(CONTENT_TYPE, "application/json")
                 .body(body.clone())
-                .send()
-                .await
-                .context("send HTTP POST request")?,
-            #[cfg(test)]
-            Self::Middleware(client) => client
-                .post(url)
-                .header(CONTENT_TYPE, "application/json")
-                .body(body)
                 .send()
                 .await
                 .context("send HTTP POST request")?,
@@ -317,28 +310,9 @@ fn build_user_prompt(contexts: &[String], question: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest_middleware::ClientBuilder;
-    use reqwest_vcr::{VCRMiddleware, VCRMode};
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
-
-    fn replay_client(cassette_name: &str) -> ClientWithMiddleware {
-        let cassette = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("cassettes")
-            .join(cassette_name);
-        let middleware = VCRMiddleware::try_from(cassette)
-            .expect("load VCR cassette")
-            .with_mode(VCRMode::Replay)
-            .with_modify_request(|request| {
-                request.headers.clear();
-            });
-
-        ClientBuilder::new(reqwest::Client::new())
-            .with(middleware)
-            .build()
-    }
 
     fn one_shot_server(status_line: &str, body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
@@ -415,22 +389,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_generate_answer_replays_from_cassette() {
-        let generator = Generator::new_with_client(
-            "http://ollama.test".to_string(),
-            "llama3.2".to_string(),
-            replay_client("ollama-chat-success.vcr.json"),
+    async fn test_generate_answer_success() {
+        let base_url = one_shot_server(
+            "200 OK",
+            r#"{"message":{"content":"A cat sits on a windowsill. [1]"}}"#,
         );
+        let generator = Generator::new(base_url, "llama3.2".to_string());
 
         let answer = generator
             .generate_answer(
-                &[String::from("A cat sits on a windowsill.")],
+                &[String::from(
+                    "[1] source=note.txt\nA cat sits on a windowsill.",
+                )],
                 "What animal is described?",
                 64,
             )
             .await
-            .expect("replay Ollama chat response");
+            .expect("generate Ollama chat response");
 
-        assert_eq!(answer, "A cat sits on a windowsill.");
+        assert_eq!(answer, "A cat sits on a windowsill. [1]");
     }
 }

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1,0 +1,230 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RetrievalCandidate {
+    pub id: String,
+    pub source_path: String,
+    pub chunk_text: String,
+    pub metadata: String,
+    pub page: i32,
+    pub chunk_index: i32,
+    pub vector_score: Option<f32>,
+    pub keyword_score: Option<f32>,
+    pub fused_score: Option<f32>,
+    pub rerank_score: Option<f32>,
+}
+
+impl RetrievalCandidate {
+    pub fn best_score(&self) -> Option<f32> {
+        self.rerank_score
+            .or(self.fused_score)
+            .or(self.vector_score)
+            .or(self.keyword_score)
+    }
+
+    pub fn dedupe_key(&self) -> String {
+        if !self.id.is_empty() {
+            return self.id.clone();
+        }
+
+        format!(
+            "{}::{}::{}::{}",
+            self.source_path, self.page, self.chunk_index, self.chunk_text
+        )
+    }
+}
+
+pub fn merge_candidates(
+    groups: impl IntoIterator<Item = Vec<RetrievalCandidate>>,
+) -> Vec<RetrievalCandidate> {
+    let mut merged: BTreeMap<String, RetrievalCandidate> = BTreeMap::new();
+
+    for group in groups {
+        for candidate in group {
+            let key = candidate.dedupe_key();
+            match merged.get_mut(&key) {
+                Some(existing) => merge_candidate(existing, candidate),
+                None => {
+                    merged.insert(key, candidate);
+                }
+            }
+        }
+    }
+
+    let mut out: Vec<_> = merged.into_values().collect();
+    out.sort_by(compare_candidates);
+    out
+}
+
+pub fn prune_candidates(
+    candidates: Vec<RetrievalCandidate>,
+    top_k: usize,
+) -> Vec<RetrievalCandidate> {
+    let mut candidates = candidates;
+    candidates.sort_by(compare_candidates);
+
+    let mut kept = Vec::new();
+    let mut previous_score = None;
+    for candidate in candidates.into_iter().take(top_k) {
+        let current_score = candidate.best_score();
+        if kept.len() >= 2 && should_autocut(previous_score, current_score) {
+            break;
+        }
+        previous_score = current_score;
+        kept.push(candidate);
+    }
+
+    kept
+}
+
+pub fn apply_rerank_order(
+    candidates: &[RetrievalCandidate],
+    reranked_ids: &[(String, f32)],
+    top_n: usize,
+) -> Vec<RetrievalCandidate> {
+    let mut by_key: BTreeMap<String, RetrievalCandidate> = candidates
+        .iter()
+        .cloned()
+        .map(|candidate| (candidate.dedupe_key(), candidate))
+        .collect();
+    let mut reranked = Vec::new();
+
+    for (id, score) in reranked_ids.iter().take(top_n) {
+        if let Some(mut candidate) = by_key.remove(id) {
+            candidate.rerank_score = Some(*score);
+            reranked.push(candidate);
+        }
+    }
+
+    reranked.extend(by_key.into_values());
+    reranked.sort_by(compare_candidates);
+    reranked.truncate(top_n);
+    reranked
+}
+
+fn merge_candidate(existing: &mut RetrievalCandidate, next: RetrievalCandidate) {
+    existing.vector_score = max_option(existing.vector_score, next.vector_score);
+    existing.keyword_score = max_option(existing.keyword_score, next.keyword_score);
+    existing.fused_score = max_option(existing.fused_score, next.fused_score);
+    existing.rerank_score = max_option(existing.rerank_score, next.rerank_score);
+
+    if existing.metadata.is_empty() && !next.metadata.is_empty() {
+        existing.metadata = next.metadata;
+    }
+    if existing.id.is_empty() && !next.id.is_empty() {
+        existing.id = next.id;
+    }
+}
+
+fn max_option(left: Option<f32>, right: Option<f32>) -> Option<f32> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn should_autocut(previous_score: Option<f32>, current_score: Option<f32>) -> bool {
+    match (previous_score, current_score) {
+        (Some(previous), Some(current)) if previous > 0.0 => current / previous < 0.6,
+        _ => false,
+    }
+}
+
+fn compare_candidates(left: &RetrievalCandidate, right: &RetrievalCandidate) -> Ordering {
+    let left_score = left.best_score().unwrap_or(f32::NEG_INFINITY);
+    let right_score = right.best_score().unwrap_or(f32::NEG_INFINITY);
+
+    right_score
+        .partial_cmp(&left_score)
+        .unwrap_or(Ordering::Equal)
+        .then_with(|| left.source_path.cmp(&right.source_path))
+        .then_with(|| left.chunk_index.cmp(&right.chunk_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(id: &str, source: &str, chunk_index: i32, score: f32) -> RetrievalCandidate {
+        RetrievalCandidate {
+            id: id.to_string(),
+            source_path: source.to_string(),
+            chunk_text: format!("chunk-{chunk_index}"),
+            metadata: String::new(),
+            page: 0,
+            chunk_index,
+            vector_score: Some(score),
+            keyword_score: None,
+            fused_score: None,
+            rerank_score: None,
+        }
+    }
+
+    #[test]
+    fn test_merge_candidates_dedupes_and_keeps_best_score() {
+        let merged = merge_candidates([
+            vec![
+                candidate("a", "src/a.rs", 0, 0.2),
+                candidate("b", "src/b.rs", 1, 0.4),
+            ],
+            vec![candidate("a", "src/a.rs", 0, 0.9)],
+        ]);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].id, "a");
+        assert_eq!(merged[0].vector_score, Some(0.9));
+        assert_eq!(merged[1].id, "b");
+    }
+
+    #[test]
+    fn test_best_score_prefers_more_specific_scores() {
+        let candidate = RetrievalCandidate {
+            id: "a".to_string(),
+            source_path: "src/a.rs".to_string(),
+            chunk_text: "chunk".to_string(),
+            metadata: String::new(),
+            page: 0,
+            chunk_index: 0,
+            vector_score: Some(0.1),
+            keyword_score: Some(0.2),
+            fused_score: Some(0.3),
+            rerank_score: Some(0.4),
+        };
+
+        assert_eq!(candidate.best_score(), Some(0.4));
+    }
+
+    #[test]
+    fn test_prune_candidates_autocuts_after_score_cliff() {
+        let kept = prune_candidates(
+            vec![
+                candidate("a", "src/a.rs", 0, 0.95),
+                candidate("b", "src/b.rs", 1, 0.9),
+                candidate("c", "src/c.rs", 2, 0.4),
+            ],
+            3,
+        );
+
+        assert_eq!(kept.len(), 2);
+        assert_eq!(kept[0].id, "a");
+        assert_eq!(kept[1].id, "b");
+    }
+
+    #[test]
+    fn test_apply_rerank_order_promotes_ranked_candidates() {
+        let reranked = apply_rerank_order(
+            &[
+                candidate("a", "src/a.rs", 0, 0.2),
+                candidate("b", "src/b.rs", 1, 0.9),
+            ],
+            &[("a".to_string(), 0.8), ("b".to_string(), 0.1)],
+            2,
+        );
+
+        assert_eq!(reranked[0].id, "a");
+        assert_eq!(reranked[0].rerank_score, Some(0.8));
+    }
+}

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -95,7 +95,7 @@ fn parse_payload(raw: &str) -> Result<QueryRewritePayload> {
     serde_json::from_str(trimmed).context("deserialize rewrite JSON")
 }
 
-fn trim_json_fences(raw: &str) -> &str {
+pub fn trim_json_fences(raw: &str) -> &str {
     let trimmed = raw.trim();
     if !trimmed.starts_with("```") {
         return trimmed;
@@ -159,5 +159,10 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("parse query rewrite payload"));
+    }
+
+    #[test]
+    fn test_trim_json_fences_leaves_plain_json_untouched() {
+        assert_eq!(trim_json_fences("{\"a\":1}"), "{\"a\":1}");
     }
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,0 +1,163 @@
+use crate::models::Generator;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct QueryRewriteSet {
+    pub original: String,
+    pub semantic_variant: Option<String>,
+    pub keyword_variant: Option<String>,
+    pub subqueries: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryRewritePayload {
+    semantic_variant: Option<String>,
+    keyword_variant: Option<String>,
+    #[serde(default)]
+    subqueries: Vec<String>,
+}
+
+impl QueryRewriteSet {
+    pub fn fallback(question: &str) -> Self {
+        Self {
+            original: question.to_string(),
+            semantic_variant: None,
+            keyword_variant: None,
+            subqueries: Vec::new(),
+        }
+    }
+
+    pub fn query_variants(&self) -> Vec<String> {
+        let mut seen = BTreeSet::new();
+        let mut variants = Vec::new();
+
+        for candidate in [
+            Some(self.original.as_str()),
+            self.semantic_variant.as_deref(),
+            self.keyword_variant.as_deref(),
+        ] {
+            let Some(candidate) = candidate.map(str::trim).filter(|value| !value.is_empty()) else {
+                continue;
+            };
+            if seen.insert(candidate.to_string()) {
+                variants.push(candidate.to_string());
+            }
+        }
+
+        variants
+    }
+}
+
+pub async fn rewrite_query_for_retrieval(
+    generator: &Generator,
+    question: &str,
+) -> Result<QueryRewriteSet> {
+    let response = generator
+        .generate_json(
+            "You rewrite retrieval queries for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
+            &format!(
+                concat!(
+                    "Return a JSON object with keys semantic_variant, keyword_variant, and subqueries. ",
+                    "semantic_variant should restate the question for semantic retrieval. ",
+                    "keyword_variant should contain sparse retrieval keywords. ",
+                    "subqueries should be an array and may be empty. ",
+                    "Question: {}"
+                ),
+                question,
+            ),
+            256,
+        )
+        .await
+        .context("generate query rewrite JSON")?;
+
+    parse_query_rewrite_set(&response, question)
+}
+
+pub fn parse_query_rewrite_set(raw: &str, question: &str) -> Result<QueryRewriteSet> {
+    let payload = parse_payload(raw).context("parse query rewrite payload")?;
+    Ok(QueryRewriteSet {
+        original: question.to_string(),
+        semantic_variant: clean_optional(payload.semantic_variant),
+        keyword_variant: clean_optional(payload.keyword_variant),
+        subqueries: payload
+            .subqueries
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    })
+}
+
+fn parse_payload(raw: &str) -> Result<QueryRewritePayload> {
+    let trimmed = trim_json_fences(raw);
+    serde_json::from_str(trimmed).context("deserialize rewrite JSON")
+}
+
+fn trim_json_fences(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+
+    let without_prefix = trimmed
+        .trim_start_matches("```")
+        .trim_start_matches("json")
+        .trim();
+
+    without_prefix
+        .strip_suffix("```")
+        .unwrap_or(without_prefix)
+        .trim()
+}
+
+fn clean_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_query_rewrite_set_accepts_json_fences() {
+        let rewrite = parse_query_rewrite_set(
+            "```json\n{\"semantic_variant\":\"Explain config resolution\",\"keyword_variant\":\"config resolve model\",\"subqueries\":[]}\n```",
+            "How does config resolution work?",
+        )
+        .unwrap();
+
+        assert_eq!(rewrite.original, "How does config resolution work?");
+        assert_eq!(
+            rewrite.semantic_variant.as_deref(),
+            Some("Explain config resolution")
+        );
+        assert_eq!(
+            rewrite.keyword_variant.as_deref(),
+            Some("config resolve model")
+        );
+    }
+
+    #[test]
+    fn test_query_variants_dedupes_and_skips_empty_entries() {
+        let rewrite = QueryRewriteSet {
+            original: "question".to_string(),
+            semantic_variant: Some("question".to_string()),
+            keyword_variant: Some("keywords".to_string()),
+            subqueries: Vec::new(),
+        };
+
+        assert_eq!(rewrite.query_variants(), vec!["question", "keywords"]);
+    }
+
+    #[test]
+    fn test_parse_query_rewrite_set_errors_on_invalid_json() {
+        let err = parse_query_rewrite_set("not json", "question")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("parse query rewrite payload"));
+    }
+}


### PR DESCRIPTION
## Summary
- add strict-JSON query rewriting with graceful fallback to the original question
- merge and dedupe multi-query retrieval candidates, then rerank and prune them before answering
- label evidence for grounded answer generation and expose readable citations and richer score output

## Testing
- cargo fmt -- --check
- cargo test -q