### PR TITLE
feat(agent): add retrieval loop and support checks

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,6 +4,8 @@ use crate::rewrite::trim_json_fences;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+const SUMMARY_TEXT_MAX_CHARS: usize = 600;
+
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentQueryConfig {
@@ -287,15 +289,23 @@ fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
                 "source={} page={} text={}",
                 candidate.source_path,
                 candidate.page,
-                normalize_summary_text(&candidate.chunk_text)
+                summarize_candidate_text(&candidate.chunk_text)
             )
         })
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-fn normalize_summary_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+fn summarize_candidate_text(text: &str) -> String {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut truncated = normalized
+        .chars()
+        .take(SUMMARY_TEXT_MAX_CHARS)
+        .collect::<String>();
+    if normalized.chars().count() > SUMMARY_TEXT_MAX_CHARS {
+        truncated.push_str("...");
+    }
+    truncated
 }
 
 fn parse_question_type(value: &str) -> Result<QuestionType> {
@@ -401,5 +411,13 @@ mod tests {
     fn test_summarize_candidates_normalizes_newlines_and_spaces() {
         let summary = summarize_candidates(&[candidate("src/a.rs", "one\n\n two\tthree")]);
         assert!(summary.contains("source=src/a.rs page=0 text=one two three"));
+    }
+
+    #[test]
+    fn test_summarize_candidate_text_truncates_long_chunks() {
+        let text = format!("{} tail", "a".repeat(SUMMARY_TEXT_MAX_CHARS + 20));
+        let summarized = summarize_candidate_text(&text);
+        assert_eq!(summarized.len(), SUMMARY_TEXT_MAX_CHARS + 3);
+        assert!(summarized.ends_with("..."));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,384 @@
+use crate::models::Generator;
+use crate::retrieval::RetrievalCandidate;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentQueryConfig {
+    pub top_k: usize,
+    pub fetch_k: usize,
+    pub max_iterations: usize,
+    pub enable_rewrite: bool,
+    pub enable_rerank: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum QuestionType {
+    Lookup,
+    Compare,
+    MultiHop,
+    Summary,
+    Exploratory,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RetrievalStrategy {
+    Direct,
+    Rewrite,
+    Decompose,
+    BroadThenRerank,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct QueryPlan {
+    pub question_type: QuestionType,
+    pub strategy: RetrievalStrategy,
+    pub reasoning: String,
+    pub subqueries: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EvidenceVerdict {
+    Sufficient,
+    Partial,
+    Insufficient,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentIteration {
+    pub iteration: usize,
+    pub query_variants: Vec<String>,
+    pub retrieved_count: usize,
+    pub kept_count: usize,
+    pub sufficiency: EvidenceVerdict,
+    pub notes: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentResult {
+    pub answer: String,
+    pub contexts: Vec<RetrievalCandidate>,
+    pub plan: QueryPlan,
+    pub iterations: Vec<AgentIteration>,
+    pub support_check: SupportCheck,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SupportCheck {
+    pub supported: bool,
+    pub unsupported_claims: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EvidenceAssessment {
+    pub verdict: EvidenceVerdict,
+    pub missing_aspects: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryPlanPayload {
+    question_type: String,
+    strategy: String,
+    reasoning: Option<String>,
+    #[serde(default)]
+    subqueries: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvidencePayload {
+    verdict: String,
+    #[serde(default)]
+    missing_aspects: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupportPayload {
+    supported: bool,
+    #[serde(default)]
+    unsupported_claims: Vec<String>,
+    #[serde(default)]
+    notes: Vec<String>,
+}
+
+pub async fn build_query_plan(generator: &Generator, question: &str) -> Result<QueryPlan> {
+    let response = generator
+        .generate_json(
+            "You build retrieval plans for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
+            &format!(
+                concat!(
+                    "Return a JSON object with keys question_type, strategy, reasoning, and subqueries. ",
+                    "question_type must be one of Lookup, Compare, MultiHop, Summary, Exploratory. ",
+                    "strategy must be one of Direct, Rewrite, Decompose, BroadThenRerank. ",
+                    "subqueries must be an array and may be empty. ",
+                    "Question: {}"
+                ),
+                question,
+            ),
+            256,
+        )
+        .await
+        .context("generate query plan JSON")?;
+
+    parse_query_plan(&response)
+}
+
+pub async fn assess_evidence(
+    generator: &Generator,
+    question: &str,
+    candidates: &[RetrievalCandidate],
+) -> Result<EvidenceAssessment> {
+    let response = generator
+        .generate_json(
+            "You assess whether retrieved evidence is sufficient to answer a local RAG query. Respond with strict JSON only and no markdown fences.",
+            &format!(
+                concat!(
+                    "Return a JSON object with keys verdict and missing_aspects. ",
+                    "verdict must be one of sufficient, partial, or insufficient. ",
+                    "missing_aspects must be an array and may be empty.\n\n",
+                    "Question: {}\n\nEvidence:\n{}"
+                ),
+                question,
+                summarize_candidates(candidates),
+            ),
+            256,
+        )
+        .await
+        .context("generate evidence assessment JSON")?;
+
+    parse_evidence_assessment(&response)
+}
+
+pub async fn verify_answer_support(
+    generator: &Generator,
+    question: &str,
+    answer: &str,
+    evidence: &[RetrievalCandidate],
+) -> Result<SupportCheck> {
+    let response = generator
+        .generate_json(
+            "You verify whether an answer is supported by retrieved evidence for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
+            &format!(
+                concat!(
+                    "Return a JSON object with keys supported, unsupported_claims, and notes. ",
+                    "unsupported_claims and notes must be arrays and may be empty.\n\n",
+                    "Question: {}\n\nAnswer: {}\n\nEvidence:\n{}"
+                ),
+                question,
+                answer,
+                summarize_candidates(evidence),
+            ),
+            256,
+        )
+        .await
+        .context("generate support check JSON")?;
+
+    parse_support_check(&response)
+}
+
+pub fn fallback_query_plan(question: &str) -> QueryPlan {
+    let lower = question.to_ascii_lowercase();
+    let strategy =
+        if lower.contains(" and ") || lower.contains("interact") || lower.contains("connect") {
+            RetrievalStrategy::Decompose
+        } else {
+            RetrievalStrategy::Direct
+        };
+    let question_type = if matches!(strategy, RetrievalStrategy::Decompose) {
+        QuestionType::MultiHop
+    } else {
+        QuestionType::Lookup
+    };
+
+    QueryPlan {
+        question_type,
+        strategy,
+        reasoning: "Fallback heuristic plan based on the query wording.".to_string(),
+        subqueries: Vec::new(),
+    }
+}
+
+pub fn fallback_evidence_assessment(candidates: &[RetrievalCandidate]) -> EvidenceAssessment {
+    let verdict = if candidates.len() >= 3 {
+        EvidenceVerdict::Sufficient
+    } else if candidates.is_empty() {
+        EvidenceVerdict::Insufficient
+    } else {
+        EvidenceVerdict::Partial
+    };
+
+    EvidenceAssessment {
+        verdict,
+        missing_aspects: Vec::new(),
+    }
+}
+
+pub fn fallback_support_check(answer: &str, evidence: &[RetrievalCandidate]) -> SupportCheck {
+    let supported = !answer.trim().is_empty() && !evidence.is_empty();
+    SupportCheck {
+        supported,
+        unsupported_claims: if supported {
+            Vec::new()
+        } else {
+            vec!["Unable to confirm answer support from retrieved evidence.".to_string()]
+        },
+        notes: vec!["Fallback support heuristic used.".to_string()],
+    }
+}
+
+pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
+    let payload: QueryPlanPayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse query plan JSON")?;
+    Ok(QueryPlan {
+        question_type: parse_question_type(&payload.question_type)?,
+        strategy: parse_retrieval_strategy(&payload.strategy)?,
+        reasoning: payload.reasoning.unwrap_or_default().trim().to_string(),
+        subqueries: payload
+            .subqueries
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    })
+}
+
+pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
+    let payload: EvidencePayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse evidence assessment JSON")?;
+    Ok(EvidenceAssessment {
+        verdict: parse_evidence_verdict(&payload.verdict)?,
+        missing_aspects: payload
+            .missing_aspects
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    })
+}
+
+pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
+    let payload: SupportPayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse support check JSON")?;
+    Ok(SupportCheck {
+        supported: payload.supported,
+        unsupported_claims: payload
+            .unsupported_claims
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+        notes: payload
+            .notes
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    })
+}
+
+fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
+    candidates
+        .iter()
+        .take(6)
+        .map(|candidate| {
+            format!(
+                "source={} page={} text={}",
+                candidate.source_path, candidate.page, candidate.chunk_text
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_question_type(value: &str) -> Result<QuestionType> {
+    match value.trim() {
+        "Lookup" => Ok(QuestionType::Lookup),
+        "Compare" => Ok(QuestionType::Compare),
+        "MultiHop" => Ok(QuestionType::MultiHop),
+        "Summary" => Ok(QuestionType::Summary),
+        "Exploratory" => Ok(QuestionType::Exploratory),
+        other => anyhow::bail!("unknown question type: {other}"),
+    }
+}
+
+fn parse_retrieval_strategy(value: &str) -> Result<RetrievalStrategy> {
+    match value.trim() {
+        "Direct" => Ok(RetrievalStrategy::Direct),
+        "Rewrite" => Ok(RetrievalStrategy::Rewrite),
+        "Decompose" => Ok(RetrievalStrategy::Decompose),
+        "BroadThenRerank" => Ok(RetrievalStrategy::BroadThenRerank),
+        other => anyhow::bail!("unknown retrieval strategy: {other}"),
+    }
+}
+
+fn parse_evidence_verdict(value: &str) -> Result<EvidenceVerdict> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "sufficient" => Ok(EvidenceVerdict::Sufficient),
+        "partial" => Ok(EvidenceVerdict::Partial),
+        "insufficient" => Ok(EvidenceVerdict::Insufficient),
+        other => anyhow::bail!("unknown evidence verdict: {other}"),
+    }
+}
+
+fn trim_json_fences(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+
+    let without_prefix = trimmed
+        .trim_start_matches("```")
+        .trim_start_matches("json")
+        .trim();
+
+    without_prefix
+        .strip_suffix("```")
+        .unwrap_or(without_prefix)
+        .trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(source: &str, chunk_text: &str) -> RetrievalCandidate {
+        RetrievalCandidate {
+            id: String::new(),
+            source_path: source.to_string(),
+            chunk_text: chunk_text.to_string(),
+            metadata: String::new(),
+            page: 0,
+            chunk_index: 0,
+            vector_score: None,
+            keyword_score: None,
+            fused_score: None,
+            rerank_score: None,
+        }
+    }
+
+    #[test]
+    fn test_parse_query_plan_accepts_json_fences() {
+        let plan = parse_query_plan(
+            "```json\n{\"question_type\":\"MultiHop\",\"strategy\":\"Decompose\",\"reasoning\":\"needs two facts\",\"subqueries\":[\"config resolution\",\"metadata validation\"]}\n```",
+        )
+        .unwrap();
+
+        assert_eq!(plan.question_type, QuestionType::MultiHop);
+        assert_eq!(plan.strategy, RetrievalStrategy::Decompose);
+        assert_eq!(plan.subqueries.len(), 2);
+    }
+
+    #[test]
+    fn test_fallback_evidence_assessment_marks_partial_for_small_result_sets() {
+        let assessment = fallback_evidence_assessment(&[candidate("src/config.rs", "config")]);
+        assert_eq!(assessment.verdict, EvidenceVerdict::Partial);
+    }
+
+    #[test]
+    fn test_parse_support_check_errors_on_invalid_json() {
+        let err = parse_support_check("not json").unwrap_err().to_string();
+        assert!(err.contains("parse support check JSON"));
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,6 @@
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
+use crate::rewrite::trim_json_fences;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
@@ -281,7 +282,6 @@ pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
 fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
     candidates
         .iter()
-        .take(6)
         .map(|candidate| {
             format!(
                 "source={} page={} text={}",
@@ -293,22 +293,22 @@ fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
 }
 
 fn parse_question_type(value: &str) -> Result<QuestionType> {
-    match value.trim() {
-        "Lookup" => Ok(QuestionType::Lookup),
-        "Compare" => Ok(QuestionType::Compare),
-        "MultiHop" => Ok(QuestionType::MultiHop),
-        "Summary" => Ok(QuestionType::Summary),
-        "Exploratory" => Ok(QuestionType::Exploratory),
+    match value.trim().to_ascii_lowercase().as_str() {
+        "lookup" => Ok(QuestionType::Lookup),
+        "compare" => Ok(QuestionType::Compare),
+        "multihop" => Ok(QuestionType::MultiHop),
+        "summary" => Ok(QuestionType::Summary),
+        "exploratory" => Ok(QuestionType::Exploratory),
         other => anyhow::bail!("unknown question type: {other}"),
     }
 }
 
 fn parse_retrieval_strategy(value: &str) -> Result<RetrievalStrategy> {
-    match value.trim() {
-        "Direct" => Ok(RetrievalStrategy::Direct),
-        "Rewrite" => Ok(RetrievalStrategy::Rewrite),
-        "Decompose" => Ok(RetrievalStrategy::Decompose),
-        "BroadThenRerank" => Ok(RetrievalStrategy::BroadThenRerank),
+    match value.trim().to_ascii_lowercase().as_str() {
+        "direct" => Ok(RetrievalStrategy::Direct),
+        "rewrite" => Ok(RetrievalStrategy::Rewrite),
+        "decompose" => Ok(RetrievalStrategy::Decompose),
+        "broadthenrerank" => Ok(RetrievalStrategy::BroadThenRerank),
         other => anyhow::bail!("unknown retrieval strategy: {other}"),
     }
 }
@@ -320,23 +320,6 @@ fn parse_evidence_verdict(value: &str) -> Result<EvidenceVerdict> {
         "insufficient" => Ok(EvidenceVerdict::Insufficient),
         other => anyhow::bail!("unknown evidence verdict: {other}"),
     }
-}
-
-fn trim_json_fences(raw: &str) -> &str {
-    let trimmed = raw.trim();
-    if !trimmed.starts_with("```") {
-        return trimmed;
-    }
-
-    let without_prefix = trimmed
-        .trim_start_matches("```")
-        .trim_start_matches("json")
-        .trim();
-
-    without_prefix
-        .strip_suffix("```")
-        .unwrap_or(without_prefix)
-        .trim()
 }
 
 #[cfg(test)]
@@ -380,5 +363,31 @@ mod tests {
     fn test_parse_support_check_errors_on_invalid_json() {
         let err = parse_support_check("not json").unwrap_err().to_string();
         assert!(err.contains("parse support check JSON"));
+    }
+
+    #[test]
+    fn test_parse_query_plan_accepts_case_insensitive_values() {
+        let plan = parse_query_plan(
+            "{\"question_type\":\"lookup\",\"strategy\":\"decompose\",\"reasoning\":\"ok\",\"subqueries\":[]}",
+        )
+        .unwrap();
+
+        assert_eq!(plan.question_type, QuestionType::Lookup);
+        assert_eq!(plan.strategy, RetrievalStrategy::Decompose);
+    }
+
+    #[test]
+    fn test_summarize_candidates_includes_all_candidates() {
+        let summary = summarize_candidates(&[
+            candidate("a", "one"),
+            candidate("b", "two"),
+            candidate("c", "three"),
+            candidate("d", "four"),
+            candidate("e", "five"),
+            candidate("f", "six"),
+            candidate("g", "seven"),
+        ]);
+
+        assert!(summary.contains("source=g page=0 text=seven"));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -285,11 +285,17 @@ fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
         .map(|candidate| {
             format!(
                 "source={} page={} text={}",
-                candidate.source_path, candidate.page, candidate.chunk_text
+                candidate.source_path,
+                candidate.page,
+                normalize_summary_text(&candidate.chunk_text)
             )
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn normalize_summary_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn parse_question_type(value: &str) -> Result<QuestionType> {
@@ -389,5 +395,11 @@ mod tests {
         ]);
 
         assert!(summary.contains("source=g page=0 text=seven"));
+    }
+
+    #[test]
+    fn test_summarize_candidates_normalizes_newlines_and_spaces() {
+        let summary = summarize_candidates(&[candidate("src/a.rs", "one\n\n two\tthree")]);
+        assert!(summary.contains("source=src/a.rs page=0 text=one two three"));
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -192,7 +192,6 @@ async fn run_agentic_query_command(
     let mut iterations = Vec::new();
     let mut previous_keys = Vec::new();
     let mut active_queries = initial_agent_queries(&command.question, &plan, &rewrite_set);
-    let mut hits = Vec::new();
     let mut accumulated_hits = Vec::new();
 
     for iteration in 1..=command.max_iterations.max(1) {
@@ -202,7 +201,7 @@ async fn run_agentic_query_command(
         ));
         let iteration_hits =
             retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
-        hits = iteration_hits.clone();
+        let retrieved_count = iteration_hits.len();
         accumulated_hits = merge_candidates([accumulated_hits, iteration_hits]);
         let kept_hits = prune_candidates(accumulated_hits.clone(), command.top_k);
         let assessment = match assess_evidence(&generator, &command.question, &kept_hits).await {
@@ -219,7 +218,7 @@ async fn run_agentic_query_command(
         iterations.push(AgentIteration {
             iteration,
             query_variants: active_queries.clone(),
-            retrieved_count: hits.len(),
+            retrieved_count,
             kept_count: kept_hits.len(),
             sufficiency: assessment.verdict.clone(),
             notes: notes.clone(),
@@ -266,7 +265,7 @@ async fn run_agentic_query_command(
                     "support verification failed; using heuristic fallback ({})",
                     err.root_cause()
                 ));
-                fallback_support_check(&answer, &hits)
+                fallback_support_check(&answer, &final_hits)
             }
         };
     if support_check.supported {

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,3 +1,8 @@
+use crate::agent::{
+    assess_evidence, build_query_plan, fallback_evidence_assessment, fallback_query_plan,
+    fallback_support_check, verify_answer_support, AgentIteration, EvidenceAssessment,
+    EvidenceVerdict, QueryPlan, RetrievalStrategy, SupportCheck,
+};
 use crate::citation::{labeled_contexts, render_citations};
 use crate::cli::QueryModeArg;
 use crate::config::{
@@ -53,6 +58,10 @@ struct SimpleQueryResult {
     requested_mode: QueryModeArg,
     execution_label: &'static str,
     rewrite_set: QueryRewriteSet,
+    plan: Option<QueryPlan>,
+    iterations: Vec<AgentIteration>,
+    support_check: Option<SupportCheck>,
+    answer: Option<String>,
     hits: Vec<RetrievalCandidate>,
     trace: Vec<String>,
 }
@@ -71,6 +80,7 @@ struct RerankItem {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum QueryExecutionPath {
     Simple,
+    Agentic,
     AgenticStub,
 }
 
@@ -79,7 +89,10 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
 
     let result = match execution_path(command.mode) {
         QueryExecutionPath::Simple => run_simple_query(&runtime, &command).await?,
-        QueryExecutionPath::AgenticStub => run_agentic_query_command(&runtime, &command).await?,
+        QueryExecutionPath::Agentic => run_agentic_query_command(&runtime, &command).await?,
+        QueryExecutionPath::AgenticStub => {
+            run_agentic_stub_query_command(&runtime, &command).await?
+        }
     };
 
     if result.hits.is_empty() {
@@ -93,7 +106,10 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
     print_citations(&command, &result);
     print_contexts(&command, &result);
 
-    let answer = generate_answer(&runtime, &command, &result).await?;
+    let answer = match &result.answer {
+        Some(answer) => answer.clone(),
+        None => generate_answer(&runtime, &command, &result).await?,
+    };
     println!();
     println!("{}", store::strip_thinking(&answer).trim());
     Ok(())
@@ -136,6 +152,10 @@ async fn run_simple_query(
         requested_mode: command.mode,
         execution_label: mode_label(command.mode),
         rewrite_set,
+        plan: None,
+        iterations: Vec::new(),
+        support_check: None,
+        answer: None,
         hits,
         trace,
     })
@@ -145,16 +165,132 @@ async fn run_agentic_query_command(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<SimpleQueryResult> {
+    let generator = Generator::new(
+        runtime.cfg.ollama.base_url.clone(),
+        runtime.gen_model_name.clone(),
+    );
+    let mut trace = vec![format!(
+        "mode {} uses the agentic retrieval loop",
+        mode_label(command.mode)
+    )];
+    let plan = match build_query_plan(&generator, &command.question).await {
+        Ok(plan) => {
+            trace.push("planner produced a structured query plan".to_string());
+            plan
+        }
+        Err(err) => {
+            trace.push(format!(
+                "planner failed; falling back to heuristic plan ({})",
+                err.root_cause()
+            ));
+            fallback_query_plan(&command.question)
+        }
+    };
+
+    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+    let mut iterations = Vec::new();
+    let mut previous_keys = Vec::new();
+    let mut active_queries = initial_agent_queries(&command.question, &plan, &rewrite_set);
+    let mut hits = Vec::new();
+
+    for iteration in 1..=command.max_iterations.max(1) {
+        trace.push(format!(
+            "iteration {iteration}: querying {} variant(s)",
+            active_queries.len()
+        ));
+        hits = retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
+        let assessment = match assess_evidence(&generator, &command.question, &hits).await {
+            Ok(assessment) => assessment,
+            Err(err) => {
+                trace.push(format!(
+                    "evidence assessment failed; using heuristic fallback ({})",
+                    err.root_cause()
+                ));
+                fallback_evidence_assessment(&hits)
+            }
+        };
+        let notes = assessment_notes(&assessment);
+        iterations.push(AgentIteration {
+            iteration,
+            query_variants: active_queries.clone(),
+            retrieved_count: hits.len(),
+            kept_count: hits.len(),
+            sufficiency: assessment.verdict.clone(),
+            notes: notes.clone(),
+        });
+        for note in notes {
+            trace.push(format!("iteration {iteration}: {note}"));
+        }
+
+        if matches!(assessment.verdict, EvidenceVerdict::Sufficient) {
+            trace.push(format!("iteration {iteration}: evidence marked sufficient"));
+            break;
+        }
+        if iteration >= command.max_iterations.max(1) {
+            trace.push("iteration budget exhausted".to_string());
+            break;
+        }
+
+        let current_keys = hits.iter().map(|hit| hit.dedupe_key()).collect::<Vec<_>>();
+        if !previous_keys.is_empty() && current_keys == previous_keys {
+            trace.push("retrieval produced no material evidence change; halting".to_string());
+            break;
+        }
+        previous_keys = current_keys;
+
+        let next_queries =
+            refine_agent_queries(&command.question, &plan, &rewrite_set, &assessment);
+        if next_queries == active_queries {
+            trace.push("no better follow-up queries available; halting".to_string());
+            break;
+        }
+        active_queries = next_queries;
+    }
+
+    let answer = generate_answer_from_hits(runtime, command, &hits).await?;
+    let support_check =
+        match verify_answer_support(&generator, &command.question, &answer, &hits).await {
+            Ok(check) => check,
+            Err(err) => {
+                trace.push(format!(
+                    "support verification failed; using heuristic fallback ({})",
+                    err.root_cause()
+                ));
+                fallback_support_check(&answer, &hits)
+            }
+        };
+    if support_check.supported {
+        trace.push("answer support verification passed".to_string());
+    } else {
+        trace.push(format!(
+            "answer support verification found {} unsupported claim(s)",
+            support_check.unsupported_claims.len()
+        ));
+    }
+
+    Ok(SimpleQueryResult {
+        requested_mode: command.mode,
+        execution_label: "agentic",
+        rewrite_set,
+        plan: Some(plan),
+        iterations,
+        support_check: Some(support_check),
+        answer: Some(answer),
+        hits,
+        trace,
+    })
+}
+
+async fn run_agentic_stub_query_command(
+    runtime: &QueryRuntime,
+    command: &QueryCommand,
+) -> Result<SimpleQueryResult> {
     let mut trace = vec![
         format!(
-            "requested {} mode routed through the agentic query stub",
+            "requested {} mode routed through the graph-mode stub",
             mode_label(command.mode)
         ),
         "current implementation falls back to the hybrid retrieval pipeline".to_string(),
-        format!(
-            "max_iterations reserved for future agent loops: {}",
-            command.max_iterations
-        ),
     ];
     let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
     let hits =
@@ -164,6 +300,10 @@ async fn run_agentic_query_command(
         requested_mode: command.mode,
         execution_label: "hybrid",
         rewrite_set,
+        plan: None,
+        iterations: Vec::new(),
+        support_check: None,
+        answer: None,
         hits,
         trace,
     })
@@ -376,6 +516,14 @@ fn print_query_plan(command: &QueryCommand, result: &SimpleQueryResult) {
         "  query_variants: {}",
         result.rewrite_set.query_variants().join(" | ")
     );
+    if let Some(plan) = &result.plan {
+        println!("  question_type: {}", question_type_label(plan));
+        println!("  strategy: {}", strategy_label(plan));
+        println!("  reasoning: {}", plan.reasoning);
+        if !plan.subqueries.is_empty() {
+            println!("  subqueries: {}", plan.subqueries.join(" | "));
+        }
+    }
     println!();
 }
 
@@ -387,6 +535,25 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
     println!("Query trace:");
     for entry in &result.trace {
         println!("  - {entry}");
+    }
+    for iteration in &result.iterations {
+        println!(
+            "  - iteration {} summary: verdict={}, queries={}, kept={}",
+            iteration.iteration,
+            evidence_verdict_label(&iteration.sufficiency),
+            iteration.query_variants.join(" | "),
+            iteration.kept_count
+        );
+    }
+    if let Some(check) = &result.support_check {
+        println!(
+            "  - support_check: {}",
+            if check.supported {
+                "supported"
+            } else {
+                "unsupported"
+            }
+        );
     }
     println!("  - retrieved_hits: {}", result.hits.len());
     println!();
@@ -442,11 +609,19 @@ async fn generate_answer(
     command: &QueryCommand,
     result: &SimpleQueryResult,
 ) -> Result<String> {
+    generate_answer_from_hits(runtime, command, &result.hits).await
+}
+
+async fn generate_answer_from_hits(
+    runtime: &QueryRuntime,
+    command: &QueryCommand,
+    hits: &[RetrievalCandidate],
+) -> Result<String> {
     let generator = Generator::new(
         runtime.cfg.ollama.base_url.clone(),
         runtime.gen_model_name.clone(),
     );
-    let contexts = labeled_contexts(&result.hits);
+    let contexts = labeled_contexts(hits);
     generator
         .generate_answer(&contexts, &command.question, command.max_tokens)
         .await
@@ -583,10 +758,99 @@ fn format_score(score: Option<f32>) -> String {
         .unwrap_or_else(|| "unavailable".to_string())
 }
 
+fn initial_agent_queries(
+    question: &str,
+    plan: &QueryPlan,
+    rewrite_set: &QueryRewriteSet,
+) -> Vec<String> {
+    match plan.strategy {
+        RetrievalStrategy::Decompose if !plan.subqueries.is_empty() => plan.subqueries.clone(),
+        _ => rewrite_set.query_variants(),
+    }
+    .into_iter()
+    .chain(std::iter::once(question.to_string()))
+    .collect::<std::collections::BTreeSet<_>>()
+    .into_iter()
+    .collect()
+}
+
+fn refine_agent_queries(
+    question: &str,
+    plan: &QueryPlan,
+    rewrite_set: &QueryRewriteSet,
+    assessment: &EvidenceAssessment,
+) -> Vec<String> {
+    if !assessment.missing_aspects.is_empty() {
+        return assessment
+            .missing_aspects
+            .iter()
+            .cloned()
+            .chain(std::iter::once(question.to_string()))
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+    }
+
+    if matches!(plan.strategy, RetrievalStrategy::Decompose) && !plan.subqueries.is_empty() {
+        return plan
+            .subqueries
+            .iter()
+            .cloned()
+            .chain(rewrite_set.query_variants())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+    }
+
+    rewrite_set.query_variants()
+}
+
+fn assessment_notes(assessment: &EvidenceAssessment) -> Vec<String> {
+    let mut notes = vec![format!(
+        "evidence verdict={}",
+        evidence_verdict_label(&assessment.verdict)
+    )];
+    if !assessment.missing_aspects.is_empty() {
+        notes.push(format!(
+            "missing_aspects={}",
+            assessment.missing_aspects.join(" | ")
+        ));
+    }
+    notes
+}
+
+fn evidence_verdict_label(verdict: &EvidenceVerdict) -> &'static str {
+    match verdict {
+        EvidenceVerdict::Sufficient => "sufficient",
+        EvidenceVerdict::Partial => "partial",
+        EvidenceVerdict::Insufficient => "insufficient",
+    }
+}
+
+fn question_type_label(plan: &QueryPlan) -> &'static str {
+    match plan.question_type {
+        crate::agent::QuestionType::Lookup => "Lookup",
+        crate::agent::QuestionType::Compare => "Compare",
+        crate::agent::QuestionType::MultiHop => "MultiHop",
+        crate::agent::QuestionType::Summary => "Summary",
+        crate::agent::QuestionType::Exploratory => "Exploratory",
+    }
+}
+
+fn strategy_label(plan: &QueryPlan) -> &'static str {
+    match plan.strategy {
+        RetrievalStrategy::Direct => "Direct",
+        RetrievalStrategy::Rewrite => "Rewrite",
+        RetrievalStrategy::Decompose => "Decompose",
+        RetrievalStrategy::BroadThenRerank => "BroadThenRerank",
+    }
+}
+
 fn execution_path(mode: QueryModeArg) -> QueryExecutionPath {
     match mode {
         QueryModeArg::Naive | QueryModeArg::Hybrid => QueryExecutionPath::Simple,
-        QueryModeArg::Agentic | QueryModeArg::Local | QueryModeArg::Global | QueryModeArg::Mix => {
+        QueryModeArg::Agentic => QueryExecutionPath::Agentic,
+        QueryModeArg::Local | QueryModeArg::Global | QueryModeArg::Mix => {
             QueryExecutionPath::AgenticStub
         }
     }
@@ -736,6 +1000,79 @@ mod tests {
         .await;
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_agentic_mode_retries_when_evidence_is_partial() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        let input = docs.join("note.txt");
+        std::fs::write(
+            &input,
+            "Config resolution interacts with metadata validation during query execution.",
+        )
+        .unwrap();
+
+        let index_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
+        with_test_env(dir.path(), Some(&index_server), || async {
+            index::run(
+                Some("agentic-retry"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        let query_server = sequential_json_server(vec![
+            r#"{"message":{"content":"{\"question_type\":\"MultiHop\",\"strategy\":\"Decompose\",\"reasoning\":\"needs two facts\",\"subqueries\":[\"config resolution\",\"metadata validation\"]}"}}"#,
+            r#"{"message":{"content":"{\"semantic_variant\":\"How does config resolution interact with metadata validation?\",\"keyword_variant\":\"config resolution metadata validation\",\"subqueries\":[\"config resolution\",\"metadata validation\"]}"}}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"{\"verdict\":\"partial\",\"missing_aspects\":[\"interaction between config resolution and metadata validation\"]}"}}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"{\"verdict\":\"sufficient\",\"missing_aspects\":[]}"}}"#,
+            r#"{"message":{"content":"Config resolution interacts with metadata validation during query execution. [1]"}}"#,
+            r#"{"message":{"content":"{\"supported\":true,\"unsupported_claims\":[],\"notes\":[\"evidence covers the answer\"]}"}}"#,
+        ]);
+        with_test_env(dir.path(), Some(&query_server), || async {
+            run(
+                Some("agentic-retry"),
+                QueryCommand {
+                    question: "How do config resolution and metadata validation interact?"
+                        .to_string(),
+                    mode: QueryModeArg::Agentic,
+                    top_k: 5,
+                    fetch_k: 20,
+                    max_iterations: 2,
+                    rewrite: true,
+                    rerank: false,
+                    show_context: false,
+                    show_plan: false,
+                    show_scores: false,
+                    show_citations: false,
+                    show_trace: false,
+                    source: None,
+                    path_prefix: None,
+                    page: None,
+                    format: None,
+                    gen_model: None,
+                    max_tokens: 64,
+                },
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    }
+
     #[test]
     fn test_parse_rerank_payload_accepts_json_fences() {
         let ranked = parse_rerank_payload(
@@ -833,7 +1170,7 @@ mod tests {
         );
         assert_eq!(
             execution_path(QueryModeArg::Agentic),
-            QueryExecutionPath::AgenticStub
+            QueryExecutionPath::Agentic
         );
         assert_eq!(
             execution_path(QueryModeArg::Local),

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -19,6 +19,7 @@ use arrow_array::{Float32Array, Float64Array, Int32Array, RecordBatch, StringArr
 use futures::TryStreamExt;
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 const RERANK_MAX_TEXT_CHARS: usize = 600;
@@ -192,21 +193,26 @@ async fn run_agentic_query_command(
     let mut previous_keys = Vec::new();
     let mut active_queries = initial_agent_queries(&command.question, &plan, &rewrite_set);
     let mut hits = Vec::new();
+    let mut accumulated_hits = Vec::new();
 
     for iteration in 1..=command.max_iterations.max(1) {
         trace.push(format!(
             "iteration {iteration}: querying {} variant(s)",
             active_queries.len()
         ));
-        hits = retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
-        let assessment = match assess_evidence(&generator, &command.question, &hits).await {
+        let iteration_hits =
+            retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
+        hits = iteration_hits.clone();
+        accumulated_hits = merge_candidates([accumulated_hits, iteration_hits]);
+        let kept_hits = prune_candidates(accumulated_hits.clone(), command.top_k);
+        let assessment = match assess_evidence(&generator, &command.question, &kept_hits).await {
             Ok(assessment) => assessment,
             Err(err) => {
                 trace.push(format!(
                     "evidence assessment failed; using heuristic fallback ({})",
                     err.root_cause()
                 ));
-                fallback_evidence_assessment(&hits)
+                fallback_evidence_assessment(&kept_hits)
             }
         };
         let notes = assessment_notes(&assessment);
@@ -214,7 +220,7 @@ async fn run_agentic_query_command(
             iteration,
             query_variants: active_queries.clone(),
             retrieved_count: hits.len(),
-            kept_count: hits.len(),
+            kept_count: kept_hits.len(),
             sufficiency: assessment.verdict.clone(),
             notes: notes.clone(),
         });
@@ -231,7 +237,10 @@ async fn run_agentic_query_command(
             break;
         }
 
-        let current_keys = hits.iter().map(|hit| hit.dedupe_key()).collect::<Vec<_>>();
+        let current_keys = kept_hits
+            .iter()
+            .map(|hit| hit.dedupe_key())
+            .collect::<Vec<_>>();
         if !previous_keys.is_empty() && current_keys == previous_keys {
             trace.push("retrieval produced no material evidence change; halting".to_string());
             break;
@@ -247,9 +256,10 @@ async fn run_agentic_query_command(
         active_queries = next_queries;
     }
 
-    let answer = generate_answer_from_hits(runtime, command, &hits).await?;
+    let final_hits = prune_candidates(accumulated_hits, command.top_k);
+    let answer = generate_answer_from_hits(runtime, command, &final_hits).await?;
     let support_check =
-        match verify_answer_support(&generator, &command.question, &answer, &hits).await {
+        match verify_answer_support(&generator, &command.question, &answer, &final_hits).await {
             Ok(check) => check,
             Err(err) => {
                 trace.push(format!(
@@ -276,7 +286,7 @@ async fn run_agentic_query_command(
         iterations,
         support_check: Some(support_check),
         answer: Some(answer),
-        hits,
+        hits: final_hits,
         trace,
     })
 }
@@ -769,7 +779,7 @@ fn initial_agent_queries(
     }
     .into_iter()
     .chain(std::iter::once(question.to_string()))
-    .collect::<std::collections::BTreeSet<_>>()
+    .collect::<BTreeSet<_>>()
     .into_iter()
     .collect()
 }
@@ -786,7 +796,7 @@ fn refine_agent_queries(
             .iter()
             .cloned()
             .chain(std::iter::once(question.to_string()))
-            .collect::<std::collections::BTreeSet<_>>()
+            .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
     }
@@ -797,7 +807,7 @@ fn refine_agent_queries(
             .iter()
             .cloned()
             .chain(rewrite_set.query_variants())
-            .collect::<std::collections::BTreeSet<_>>()
+            .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod app;
 mod citation;
 mod cli;


### PR DESCRIPTION
## Summary
- add strict-JSON planning, evidence assessment, and answer support verification helpers with heuristic fallbacks
- route  through a real iterative retrieval loop with decomposition-aware retry behavior
- expose agentic plans and iteration summaries while keeping local/global/mix on the existing stub path for the later graph PR

## Testing
- cargo fmt -- --check
- cargo test -q