### PR TITLE
feat(graph): add placeholder graph query modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When upgrading across store schema changes, reindex into a fresh store or remove
 - `index --exclude <glob>` can be repeated to skip unwanted files or directories.
 - HTML is converted to readable text before chunking, and CSV/TSV rows are flattened into labeled text.
 - Images are captioned with an Ollama vision model at index time and stored as text for retrieval.
-- Queries support `--mode naive|hybrid|agentic|local|global|mix`; today `hybrid` preserves the current behavior, while the other advanced modes route through explicit placeholder hooks that currently fall back to hybrid retrieval.
+- Queries support `--mode naive|hybrid|agentic|local|global|mix`; `agentic` runs the iterative Ralph-style retrieval loop, while `local`, `global`, and `mix` use distinct placeholder graph-mode paths that still fall back to hybrid retrieval until graph indexing lands.
 - Queries use LanceDB hybrid search: semantic nearest-neighbor search plus BM25 full-text search on `chunk_text`.
 - Query-time retrieval filters support `--source`, `--path-prefix`, `--page`, and `--format`.
 - Querying refuses to mix a store with a different embedding model than the one used to build it.

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -300,7 +300,7 @@ async fn run_agentic_stub_query_command(
         mode_label(command.mode)
     )];
     let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
-    let stub_plan = placeholder_plan(command.mode, &command.question, &rewrite_set);
+    let stub_plan = placeholder_plan(command.mode, &rewrite_set);
     trace.extend(stub_plan.notes.iter().cloned());
     let hits = retrieve_candidates(runtime, command, &stub_plan.query_variants, &mut trace).await?;
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -8,6 +8,7 @@ use crate::cli::QueryModeArg;
 use crate::config::{
     ensure_store_layout, load_or_create_config, resolve_model_name, store_dir, Config,
 };
+use crate::graph::placeholder_plan;
 use crate::models::{Embedder, Generator};
 use crate::retrieval::{
     apply_rerank_order, merge_candidates, prune_candidates, RetrievalCandidate,
@@ -294,20 +295,18 @@ async fn run_agentic_stub_query_command(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<SimpleQueryResult> {
-    let mut trace = vec![
-        format!(
-            "requested {} mode routed through the graph-mode stub",
-            mode_label(command.mode)
-        ),
-        "current implementation falls back to the hybrid retrieval pipeline".to_string(),
-    ];
+    let mut trace = vec![format!(
+        "requested {} mode routed through the graph-mode placeholder path",
+        mode_label(command.mode)
+    )];
     let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
-    let hits =
-        retrieve_candidates(runtime, command, &rewrite_set.query_variants(), &mut trace).await?;
+    let stub_plan = placeholder_plan(command.mode, &command.question, &rewrite_set);
+    trace.extend(stub_plan.notes.iter().cloned());
+    let hits = retrieve_candidates(runtime, command, &stub_plan.query_variants, &mut trace).await?;
 
     Ok(SimpleQueryResult {
         requested_mode: command.mode,
-        execution_label: "hybrid",
+        execution_label: stub_plan.execution_label,
         rewrite_set,
         plan: None,
         iterations: Vec::new(),
@@ -1193,5 +1192,70 @@ mod tests {
             execution_path(QueryModeArg::Mix),
             QueryExecutionPath::AgenticStub
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_local_global_and_mix_modes_use_distinct_placeholder_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        let input = docs.join("note.txt");
+        std::fs::write(&input, "Config checks use metadata validation.").unwrap();
+
+        let index_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
+        with_test_env(dir.path(), Some(&index_server), || async {
+            index::run(
+                Some("graph-modes"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        let query_server = sequential_json_server(vec![
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"local answer [1]"}}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"global answer [1]"}}"#,
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            r#"{"message":{"content":"mix answer [1]"}}"#,
+        ]);
+        with_test_env(dir.path(), Some(&query_server), || async {
+            for mode in [QueryModeArg::Local, QueryModeArg::Global, QueryModeArg::Mix] {
+                run(
+                    Some("graph-modes"),
+                    QueryCommand {
+                        question: "How do config checks work?".to_string(),
+                        mode,
+                        top_k: 5,
+                        fetch_k: 20,
+                        max_iterations: 2,
+                        rewrite: false,
+                        rerank: false,
+                        show_context: false,
+                        show_plan: false,
+                        show_scores: false,
+                        show_citations: false,
+                        show_trace: false,
+                        source: None,
+                        path_prefix: None,
+                        page: None,
+                        format: None,
+                        gen_model: None,
+                        max_tokens: 64,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+        })
+        .await;
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,11 +9,8 @@ pub struct GraphModeStubPlan {
     pub query_variants: Vec<String>,
 }
 
-pub fn placeholder_plan(
-    mode: QueryModeArg,
-    question: &str,
-    rewrite_set: &QueryRewriteSet,
-) -> GraphModeStubPlan {
+pub fn placeholder_plan(mode: QueryModeArg, rewrite_set: &QueryRewriteSet) -> GraphModeStubPlan {
+    let question = rewrite_set.original.as_str();
     let (execution_label, notes, query_variants) = match mode {
         QueryModeArg::Local => (
             "local-placeholder",
@@ -68,14 +65,15 @@ pub fn placeholder_plan(
 }
 
 fn dedupe_queries(queries: [Option<&str>; 3]) -> Vec<String> {
-    let mut variants = BTreeSet::new();
+    let mut seen = BTreeSet::new();
+    let mut variants = Vec::new();
     for query in queries.into_iter().flatten() {
         let trimmed = query.trim();
-        if !trimmed.is_empty() {
-            variants.insert(trimmed.to_string());
+        if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
+            variants.push(trimmed.to_string());
         }
     }
-    variants.into_iter().collect()
+    variants
 }
 
 #[cfg(test)]
@@ -93,11 +91,7 @@ mod tests {
 
     #[test]
     fn test_local_placeholder_uses_local_label() {
-        let plan = placeholder_plan(
-            QueryModeArg::Local,
-            "How do config checks work?",
-            &rewrite_set(),
-        );
+        let plan = placeholder_plan(QueryModeArg::Local, &rewrite_set());
         assert_eq!(plan.execution_label, "local-placeholder");
         assert!(plan
             .notes
@@ -108,39 +102,29 @@ mod tests {
 
     #[test]
     fn test_global_placeholder_keeps_keyword_variant_without_semantic_variant() {
-        let plan = placeholder_plan(
-            QueryModeArg::Global,
-            "How do config checks work?",
-            &rewrite_set(),
-        );
+        let plan = placeholder_plan(QueryModeArg::Global, &rewrite_set());
         assert_eq!(plan.execution_label, "global-placeholder");
         assert_eq!(plan.query_variants.len(), 2);
-        assert!(plan
-            .query_variants
-            .iter()
-            .any(|query| query.contains("metadata")));
-        assert!(!plan
-            .query_variants
-            .iter()
-            .any(|query| query.contains("validation flow")));
+        assert_eq!(
+            plan.query_variants,
+            vec![
+                "How do config checks work?".to_string(),
+                "config validation metadata".to_string(),
+            ]
+        );
     }
 
     #[test]
-    fn test_mix_placeholder_combines_semantic_and_keyword_variants() {
-        let plan = placeholder_plan(
-            QueryModeArg::Mix,
-            "How do config checks work?",
-            &rewrite_set(),
-        );
+    fn test_mix_placeholder_combines_semantic_and_keyword_variants_in_order() {
+        let plan = placeholder_plan(QueryModeArg::Mix, &rewrite_set());
         assert_eq!(plan.execution_label, "mix-placeholder");
-        assert_eq!(plan.query_variants.len(), 3);
-        assert!(plan
-            .query_variants
-            .iter()
-            .any(|query| query.contains("validation flow")));
-        assert!(plan
-            .query_variants
-            .iter()
-            .any(|query| query.contains("metadata")));
+        assert_eq!(
+            plan.query_variants,
+            vec![
+                "How do config checks work?".to_string(),
+                "Explain config validation flow".to_string(),
+                "config validation metadata".to_string(),
+            ]
+        );
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -14,13 +14,7 @@ pub fn placeholder_plan(
     question: &str,
     rewrite_set: &QueryRewriteSet,
 ) -> GraphModeStubPlan {
-    let mut variants = BTreeSet::new();
-    variants.insert(question.to_string());
-    for variant in rewrite_set.query_variants() {
-        variants.insert(variant);
-    }
-
-    let (execution_label, notes) = match mode {
+    let (execution_label, notes, query_variants) = match mode {
         QueryModeArg::Local => (
             "local-placeholder",
             vec![
@@ -29,49 +23,59 @@ pub fn placeholder_plan(
                 "current implementation narrows to direct fact-style variants before hybrid retrieval"
                     .to_string(),
             ],
+            dedupe_queries([Some(question), None, None]),
         ),
-        QueryModeArg::Global => {
-            if let Some(keyword_variant) = rewrite_set.keyword_variant.as_deref() {
-                variants.insert(keyword_variant.to_string());
-            }
-            (
-                "global-placeholder",
-                vec![
-                    "global mode reserves graph-centric retrieval for a later milestone"
-                        .to_string(),
-                    "current implementation broadens the query set before hybrid retrieval"
-                        .to_string(),
-                ],
-            )
-        }
-        QueryModeArg::Mix => {
-            if let Some(semantic_variant) = rewrite_set.semantic_variant.as_deref() {
-                variants.insert(semantic_variant.to_string());
-            }
-            if let Some(keyword_variant) = rewrite_set.keyword_variant.as_deref() {
-                variants.insert(keyword_variant.to_string());
-            }
-            (
-                "mix-placeholder",
-                vec![
-                    "mix mode will later combine graph neighborhoods with chunk retrieval"
-                        .to_string(),
-                    "current implementation blends local and broad query variants before hybrid retrieval"
-                        .to_string(),
-                ],
-            )
-        }
+        QueryModeArg::Global => (
+            "global-placeholder",
+            vec![
+                "global mode reserves graph-centric retrieval for a later milestone"
+                    .to_string(),
+                "current implementation broadens the query set before hybrid retrieval"
+                    .to_string(),
+            ],
+            dedupe_queries([
+                Some(question),
+                rewrite_set.keyword_variant.as_deref(),
+                None,
+            ]),
+        ),
+        QueryModeArg::Mix => (
+            "mix-placeholder",
+            vec![
+                "mix mode will later combine graph neighborhoods with chunk retrieval"
+                    .to_string(),
+                "current implementation blends local and broad query variants before hybrid retrieval"
+                    .to_string(),
+            ],
+            dedupe_queries([
+                Some(question),
+                rewrite_set.semantic_variant.as_deref(),
+                rewrite_set.keyword_variant.as_deref(),
+            ]),
+        ),
         _ => (
             "hybrid",
             vec!["non-graph modes do not use the graph placeholder planner".to_string()],
+            dedupe_queries([Some(question), None, None]),
         ),
     };
 
     GraphModeStubPlan {
         execution_label,
         notes,
-        query_variants: variants.into_iter().collect(),
+        query_variants,
     }
+}
+
+fn dedupe_queries(queries: [Option<&str>; 3]) -> Vec<String> {
+    let mut variants = BTreeSet::new();
+    for query in queries.into_iter().flatten() {
+        let trimmed = query.trim();
+        if !trimmed.is_empty() {
+            variants.insert(trimmed.to_string());
+        }
+    }
+    variants.into_iter().collect()
 }
 
 #[cfg(test)]
@@ -99,20 +103,26 @@ mod tests {
             .notes
             .iter()
             .any(|note| note.contains("chunk-centric retrieval")));
+        assert_eq!(plan.query_variants, vec!["How do config checks work?"]);
     }
 
     #[test]
-    fn test_global_placeholder_keeps_keyword_variant() {
+    fn test_global_placeholder_keeps_keyword_variant_without_semantic_variant() {
         let plan = placeholder_plan(
             QueryModeArg::Global,
             "How do config checks work?",
             &rewrite_set(),
         );
         assert_eq!(plan.execution_label, "global-placeholder");
+        assert_eq!(plan.query_variants.len(), 2);
         assert!(plan
             .query_variants
             .iter()
             .any(|query| query.contains("metadata")));
+        assert!(!plan
+            .query_variants
+            .iter()
+            .any(|query| query.contains("validation flow")));
     }
 
     #[test]
@@ -123,6 +133,7 @@ mod tests {
             &rewrite_set(),
         );
         assert_eq!(plan.execution_label, "mix-placeholder");
+        assert_eq!(plan.query_variants.len(), 3);
         assert!(plan
             .query_variants
             .iter()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,135 @@
+use crate::cli::QueryModeArg;
+use crate::rewrite::QueryRewriteSet;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GraphModeStubPlan {
+    pub execution_label: &'static str,
+    pub notes: Vec<String>,
+    pub query_variants: Vec<String>,
+}
+
+pub fn placeholder_plan(
+    mode: QueryModeArg,
+    question: &str,
+    rewrite_set: &QueryRewriteSet,
+) -> GraphModeStubPlan {
+    let mut variants = BTreeSet::new();
+    variants.insert(question.to_string());
+    for variant in rewrite_set.query_variants() {
+        variants.insert(variant);
+    }
+
+    let (execution_label, notes) = match mode {
+        QueryModeArg::Local => (
+            "local-placeholder",
+            vec![
+                "local mode prioritizes chunk-centric retrieval while graph indexing is pending"
+                    .to_string(),
+                "current implementation narrows to direct fact-style variants before hybrid retrieval"
+                    .to_string(),
+            ],
+        ),
+        QueryModeArg::Global => {
+            if let Some(keyword_variant) = rewrite_set.keyword_variant.as_deref() {
+                variants.insert(keyword_variant.to_string());
+            }
+            (
+                "global-placeholder",
+                vec![
+                    "global mode reserves graph-centric retrieval for a later milestone"
+                        .to_string(),
+                    "current implementation broadens the query set before hybrid retrieval"
+                        .to_string(),
+                ],
+            )
+        }
+        QueryModeArg::Mix => {
+            if let Some(semantic_variant) = rewrite_set.semantic_variant.as_deref() {
+                variants.insert(semantic_variant.to_string());
+            }
+            if let Some(keyword_variant) = rewrite_set.keyword_variant.as_deref() {
+                variants.insert(keyword_variant.to_string());
+            }
+            (
+                "mix-placeholder",
+                vec![
+                    "mix mode will later combine graph neighborhoods with chunk retrieval"
+                        .to_string(),
+                    "current implementation blends local and broad query variants before hybrid retrieval"
+                        .to_string(),
+                ],
+            )
+        }
+        _ => (
+            "hybrid",
+            vec!["non-graph modes do not use the graph placeholder planner".to_string()],
+        ),
+    };
+
+    GraphModeStubPlan {
+        execution_label,
+        notes,
+        query_variants: variants.into_iter().collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rewrite_set() -> QueryRewriteSet {
+        QueryRewriteSet {
+            original: "How do config checks work?".to_string(),
+            semantic_variant: Some("Explain config validation flow".to_string()),
+            keyword_variant: Some("config validation metadata".to_string()),
+            subqueries: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_local_placeholder_uses_local_label() {
+        let plan = placeholder_plan(
+            QueryModeArg::Local,
+            "How do config checks work?",
+            &rewrite_set(),
+        );
+        assert_eq!(plan.execution_label, "local-placeholder");
+        assert!(plan
+            .notes
+            .iter()
+            .any(|note| note.contains("chunk-centric retrieval")));
+    }
+
+    #[test]
+    fn test_global_placeholder_keeps_keyword_variant() {
+        let plan = placeholder_plan(
+            QueryModeArg::Global,
+            "How do config checks work?",
+            &rewrite_set(),
+        );
+        assert_eq!(plan.execution_label, "global-placeholder");
+        assert!(plan
+            .query_variants
+            .iter()
+            .any(|query| query.contains("metadata")));
+    }
+
+    #[test]
+    fn test_mix_placeholder_combines_semantic_and_keyword_variants() {
+        let plan = placeholder_plan(
+            QueryModeArg::Mix,
+            "How do config checks work?",
+            &rewrite_set(),
+        );
+        assert_eq!(plan.execution_label, "mix-placeholder");
+        assert!(plan
+            .query_variants
+            .iter()
+            .any(|query| query.contains("validation flow")));
+        assert!(plan
+            .query_variants
+            .iter()
+            .any(|query| query.contains("metadata")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod commands;
 mod config;
 mod fsutil;
+mod graph;
 mod ingest;
 mod models;
 mod retrieval;


### PR DESCRIPTION
## Summary
- add distinct placeholder planners for local, global, and mix query modes
- route graph-oriented modes through different execution labels, trace notes, and query variant sets while still falling back to hybrid retrieval
- document the current mode behavior and cover the placeholder differences with tests

## Testing
- cargo fmt -- --check
- cargo test -q