### PR TITLE
fix(jsonutil): extract shared trim_json_fences and improve error messages

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,6 @@
+use crate::jsonutil::{parse_json, trim_json_fences};
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
-use crate::rewrite::trim_json_fences;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
@@ -184,7 +184,8 @@ pub async fn verify_answer_support(
 pub fn fallback_query_plan(question: &str) -> QueryPlan {
     let lower = question.to_ascii_lowercase();
     let strategy =
-        if lower.contains(" and ") || lower.contains("interact") || lower.contains("connect") { //FIXME: not language agnostic. should be handeled by agent 
+        if lower.contains(" and ") || lower.contains("interact") || lower.contains("connect") {
+            //FIXME: not language agnostic. should be handeled by agent
             RetrievalStrategy::Decompose
         } else {
             RetrievalStrategy::Direct
@@ -194,7 +195,6 @@ pub fn fallback_query_plan(question: &str) -> QueryPlan {
     } else {
         QuestionType::Lookup
     };
-
     QueryPlan {
         question_type,
         strategy,
@@ -232,8 +232,7 @@ pub fn fallback_support_check(answer: &str, evidence: &[RetrievalCandidate]) -> 
 }
 
 pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
-    let payload: QueryPlanPayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse query plan JSON")?;
+    let payload: QueryPlanPayload = parse_json(raw, "parse query plan JSON")?;
     Ok(QueryPlan {
         question_type: parse_question_type(&payload.question_type)?,
         strategy: parse_retrieval_strategy(&payload.strategy)?,
@@ -248,8 +247,7 @@ pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
 }
 
 pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
-    let payload: EvidencePayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse evidence assessment JSON")?;
+    let payload: EvidencePayload = parse_json(raw, "parse evidence assessment JSON")?;
     Ok(EvidenceAssessment {
         verdict: parse_evidence_verdict(&payload.verdict)?,
         missing_aspects: payload
@@ -262,8 +260,7 @@ pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
 }
 
 pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
-    let payload: SupportPayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse support check JSON")?;
+    let payload: SupportPayload = parse_json(raw, "parse support check JSON")?;
     Ok(SupportCheck {
         supported: payload.supported,
         unsupported_claims: payload
@@ -387,7 +384,6 @@ mod tests {
             "{\"question_type\":\"lookup\",\"strategy\":\"decompose\",\"reasoning\":\"ok\",\"subqueries\":[]}",
         )
         .unwrap();
-
         assert_eq!(plan.question_type, QuestionType::Lookup);
         assert_eq!(plan.strategy, RetrievalStrategy::Decompose);
     }
@@ -419,5 +415,14 @@ mod tests {
         let summarized = summarize_candidate_text(&text);
         assert_eq!(summarized.len(), SUMMARY_TEXT_MAX_CHARS + 3);
         assert!(summarized.ends_with("..."));
+    }
+
+    #[test]
+    fn test_parse_evidence_assessment_includes_raw_snippet_in_error() {
+        let err = parse_evidence_assessment("not json at all")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("parse evidence assessment JSON"));
+        assert!(err.contains("not json"));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,4 @@
-use crate::jsonutil::{parse_json, trim_json_fences};
+use crate::jsonutil::parse_json;
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
 use anyhow::{Context, Result};

--- a/src/jsonutil.rs
+++ b/src/jsonutil.rs
@@ -19,6 +19,7 @@ pub fn trim_json_fences(raw: &str) -> &str {
 
     let without_prefix = trimmed
         .trim_start_matches("```")
+        .trim_start()
         .trim_start_matches("json")
         .trim();
 
@@ -31,14 +32,14 @@ pub fn trim_json_fences(raw: &str) -> &str {
 /// Parses a JSON payload from an LLM response, stripping fences if present.
 ///
 /// Includes a snippet of the raw content in error messages so failures are actionable.
-pub fn parse_json<T: DeserializeOwned>(raw: &str, context: &'static str) -> Result<T> {
+pub fn parse_json<T: DeserializeOwned>(raw: &str, context: &str) -> Result<T> {
     let cleaned = trim_json_fences(raw);
     serde_json::from_str(cleaned).with_context(|| {
         let snippet = cleaned
             .chars()
             .take(200)
             .collect::<String>()
-            .replace('\n', " ");
+            .replace(['\n', '\r'], " ");
         format!("{context} — raw content (first 200 chars): {snippet}")
     })
 }

--- a/src/jsonutil.rs
+++ b/src/jsonutil.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_parse_json_includes_raw_snippet_in_error() {
-        #[derive(serde::Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Foo {
             a: i32,
         }

--- a/src/jsonutil.rs
+++ b/src/jsonutil.rs
@@ -1,0 +1,123 @@
+//! Shared JSON utilities for parsing LLM-generated payloads.
+//!
+//! LLM responses often include markdown fences and whitespace that must be stripped
+//! before deserialization. This module provides consistent parsing with error messages
+//! that include the raw content for easier debugging.
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+
+/// Strips markdown JSON code fences from LLM output.
+///
+/// Handles both fenced (` """json ... """ `) and unfenced responses.
+/// Returns the inner JSON text, trimmed of surrounding whitespace.
+pub fn trim_json_fences(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+
+    let without_prefix = trimmed
+        .trim_start_matches("```")
+        .trim_start_matches("json")
+        .trim();
+
+    without_prefix
+        .strip_suffix("```")
+        .unwrap_or(without_prefix)
+        .trim()
+}
+
+/// Parses a JSON payload from an LLM response, stripping fences if present.
+///
+/// Includes a snippet of the raw content in error messages so failures are actionable.
+pub fn parse_json<T: DeserializeOwned>(raw: &str, context: &'static str) -> Result<T> {
+    let cleaned = trim_json_fences(raw);
+    serde_json::from_str(cleaned).with_context(|| {
+        let snippet = cleaned
+            .chars()
+            .take(200)
+            .collect::<String>()
+            .replace('\n', " ");
+        format!("{context} — raw content (first 200 chars): {snippet}")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trim_json_fences_leaves_plain_json_untouched() {
+        assert_eq!(trim_json_fences(r#"{"a":1}"#), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_trim_json_fences_handles_json_fence() {
+        let input = "```json\n{\"a\":1}\n```";
+        assert_eq!(trim_json_fences(input), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_trim_json_fences_handles_fence_without_json_tag() {
+        let input = "```\n{\"a\":1}\n```";
+        assert_eq!(trim_json_fences(input), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_trim_json_fences_handles_extra_whitespace() {
+        let input = "  ```json  \n  {\"a\":1}  \n  ```  ";
+        assert_eq!(trim_json_fences(input), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_trim_json_fences_handles_plain_json_with_whitespace() {
+        assert_eq!(trim_json_fences("  {\"a\":1}  "), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_trim_json_fences_handles_empty_input() {
+        assert_eq!(trim_json_fences(""), "");
+        assert_eq!(trim_json_fences("   "), "");
+    }
+
+    #[test]
+    fn test_parse_json_includes_raw_snippet_in_error() {
+        #[derive(serde::Deserialize)]
+        struct Foo {
+            a: i32,
+        }
+
+        let err = parse_json::<Foo>("not json at all", "parse foo").unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("parse foo"));
+        assert!(err_msg.contains("not json"));
+    }
+
+    #[test]
+    fn test_parse_json_accepts_fenced_input() {
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct Payload {
+            value: String,
+        }
+
+        let result = parse_json::<Payload>(
+            "```json\n{\"value\":\"hello\"}
+```",
+            "test parse",
+        )
+        .unwrap();
+        assert_eq!(result.value, "hello");
+    }
+
+    #[test]
+    fn test_parse_json_accepts_plain_json() {
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct Payload {
+            value: String,
+        }
+
+        let result = parse_json::<Payload>(r#"{"value":"hello"}"#, "test parse").unwrap();
+        assert_eq!(result.value, "hello");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod fsutil;
 mod graph;
 mod ingest;
+mod jsonutil;
 mod models;
 mod retrieval;
 mod rewrite;

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,4 +1,4 @@
-use crate::jsonutil::{parse_json, trim_json_fences};
+use crate::jsonutil::parse_json;
 use crate::models::Generator;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -96,7 +96,7 @@ fn parse_query_rewrite_payload(raw: &str) -> Result<QueryRewritePayload> {
 
 /// Provided for backwards compatibility — prefer [`jsonutil::trim_json_fences`].
 pub fn trim_json_fences(raw: &str) -> &str {
-    jsonutil::trim_json_fences(raw)
+    crate::jsonutil::trim_json_fences(raw)
 }
 
 fn clean_optional(value: Option<String>) -> Option<String> {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,3 +1,4 @@
+use crate::jsonutil::{parse_json, trim_json_fences};
 use crate::models::Generator;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -71,12 +72,11 @@ pub async fn rewrite_query_for_retrieval(
         )
         .await
         .context("generate query rewrite JSON")?;
-
     parse_query_rewrite_set(&response, question)
 }
 
 pub fn parse_query_rewrite_set(raw: &str, question: &str) -> Result<QueryRewriteSet> {
-    let payload = parse_payload(raw).context("parse query rewrite payload")?;
+    let payload = parse_query_rewrite_payload(raw)?;
     Ok(QueryRewriteSet {
         original: question.to_string(),
         semantic_variant: clean_optional(payload.semantic_variant),
@@ -90,26 +90,13 @@ pub fn parse_query_rewrite_set(raw: &str, question: &str) -> Result<QueryRewrite
     })
 }
 
-fn parse_payload(raw: &str) -> Result<QueryRewritePayload> {
-    let trimmed = trim_json_fences(raw);
-    serde_json::from_str(trimmed).context("deserialize rewrite JSON")
+fn parse_query_rewrite_payload(raw: &str) -> Result<QueryRewritePayload> {
+    parse_json(raw, "parse query rewrite payload")
 }
 
+/// Provided for backwards compatibility — prefer [`jsonutil::trim_json_fences`].
 pub fn trim_json_fences(raw: &str) -> &str {
-    let trimmed = raw.trim();
-    if !trimmed.starts_with("```") {
-        return trimmed;
-    }
-
-    let without_prefix = trimmed
-        .trim_start_matches("```")
-        .trim_start_matches("json")
-        .trim();
-
-    without_prefix
-        .strip_suffix("```")
-        .unwrap_or(without_prefix)
-        .trim()
+    jsonutil::trim_json_fences(raw)
 }
 
 fn clean_optional(value: Option<String>) -> Option<String> {


### PR DESCRIPTION
Deduplicate `trim_json_fences` which was copied in both `rewrite.rs` and `agent.rs`.

## Changes

### New `src/jsonutil.rs` module
- `trim_json_fences`: shared fence-stripping logic for LLM JSON output
- `parse_json`: generic JSON parser that includes raw content (first 200 chars) in error messages so LLM misformatting is actionable

### `src/rewrite.rs`
- Use `jsonutil::parse_json` instead of local `parse_payload`
- Keep backward-compatible `pub trim_json_fences` re-export

### `src/agent.rs`
- Use `jsonutil::parse_json` for all three parse functions  
- Add test verifying raw snippet appears in parse errors

## Motivation

When the LLM misformats JSON, users previously saw only a generic `parse query rewrite payload` error with no indication of what the raw content was. The new `parse_json` helper includes a 200-char snippet of the cleaned content in the error message for faster debugging.