### PR TITLE
docs: add docstrings to retrieval, graph, citation, agent, source_kind

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,7 +12,6 @@
 //! 4. Optionally iterate with rewritten subqueries
 //! 5. [`verify_answer_support`] — LLM checks that the final answer is grounded in evidence
 
-use crate::jsonutil::parse_json;
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
 use crate::rewrite::trim_json_fences;
@@ -22,6 +21,7 @@ use serde::Deserialize;
 const SUMMARY_TEXT_MAX_CHARS: usize = 600;
 
 /// Configuration for the agentic retrieval loop.
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentQueryConfig {
     /// Maximum candidates to return from the store per iteration.
@@ -139,6 +139,31 @@ pub struct EvidenceAssessment {
     pub verdict: EvidenceVerdict,
     /// Specific aspects of the question that are not covered by retrieved candidates.
     pub missing_aspects: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryPlanPayload {
+    question_type: String,
+    strategy: String,
+    reasoning: Option<String>,
+    #[serde(default)]
+    subqueries: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvidencePayload {
+    verdict: String,
+    #[serde(default)]
+    missing_aspects: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupportPayload {
+    supported: bool,
+    #[serde(default)]
+    unsupported_claims: Vec<String>,
+    #[serde(default)]
+    notes: Vec<String>,
 }
 
 /// Builds a structured query plan from a user question using an LLM.
@@ -296,7 +321,8 @@ pub fn fallback_support_check(answer: &str, evidence: &[RetrievalCandidate]) -> 
 
 /// Parses a JSON query plan from the LLM. Used by [`build_query_plan`].
 pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
-    let payload: QueryPlanPayload = parse_json(raw, "parse query plan JSON")?;
+    let payload: QueryPlanPayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse query plan JSON")?;
     Ok(QueryPlan {
         question_type: parse_question_type(&payload.question_type)?,
         strategy: parse_retrieval_strategy(&payload.strategy)?,
@@ -312,7 +338,8 @@ pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
 
 /// Parses an evidence assessment JSON from the LLM. Used by [`assess_evidence`].
 pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
-    let payload: EvidencePayload = parse_json(raw, "parse evidence assessment JSON")?;
+    let payload: EvidencePayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse evidence assessment JSON")?;
     Ok(EvidenceAssessment {
         verdict: parse_evidence_verdict(&payload.verdict)?,
         missing_aspects: payload
@@ -326,7 +353,8 @@ pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
 
 /// Parses a support check JSON from the LLM. Used by [`verify_answer_support`].
 pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
-    let payload: SupportPayload = parse_json(raw, "parse support check JSON")?;
+    let payload: SupportPayload =
+        serde_json::from_str(trim_json_fences(raw)).context("parse support check JSON")?;
     Ok(SupportCheck {
         supported: payload.supported,
         unsupported_claims: payload
@@ -363,7 +391,7 @@ fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
         .join("\n")
 }
 
-/// Truncates chunk text to [`SUMMARY_TEXT_MAX_CHARS`] words for prompt size control.
+/// Truncates chunk text to [`SUMMARY_TEXT_MAX_CHARS`] characters for prompt size control.
 fn summarize_candidate_text(text: &str) -> String {
     let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
     let mut truncated = normalized
@@ -491,12 +519,4 @@ mod tests {
         assert!(summarized.ends_with("..."));
     }
 
-    #[test]
-    fn test_parse_evidence_assessment_includes_raw_snippet_in_error() {
-        let err = parse_evidence_assessment("not json at all")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("parse evidence assessment JSON"));
-        assert!(err.contains("not json"));
-    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,18 @@
+//! RAG query planning, evidence assessment, and answer verification via LLM.
+//!
+//! The agent module drives the iterative retrieval loop. It classifies a user question,
+//! builds a retrieval plan, gathers evidence, and verifies that generated answers are
+//! actually supported by the retrieved chunks.
+//!
+//! # Query lifecycle
+//!
+//! 1. [`build_query_plan`] — classifies the question type and chooses a retrieval strategy
+//! 2. Retrieval against the store (handled by the caller / `app.rs`)
+//! 3. [`assess_evidence`] — LLM judges whether retrieved candidates are sufficient
+//! 4. Optionally iterate with rewritten subqueries
+//! 5. [`verify_answer_support`] — LLM checks that the final answer is grounded in evidence
+
+use crate::jsonutil::parse_json;
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
 use crate::rewrite::trim_json_fences;
@@ -6,106 +21,131 @@ use serde::Deserialize;
 
 const SUMMARY_TEXT_MAX_CHARS: usize = 600;
 
-#[allow(dead_code)]
+/// Configuration for the agentic retrieval loop.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentQueryConfig {
+    /// Maximum candidates to return from the store per iteration.
     pub top_k: usize,
+    /// Total candidates to fetch before reranking / pruning.
     pub fetch_k: usize,
+    /// Maximum retrieval iterations before giving up.
     pub max_iterations: usize,
+    /// Whether to rewrite the query each iteration.
     pub enable_rewrite: bool,
+    /// Whether to run the LLM reranker after retrieval.
     pub enable_rerank: bool,
 }
 
+/// Class of a user question, influencing which retrieval strategy is selected.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum QuestionType {
+    /// A single factual lookup — "What is X?"
     Lookup,
+    /// Comparison between two or more things — "How does X differ from Y?"
     Compare,
+    /// Multi-step reasoning requiring multiple facts — "Why does X happen?"
     MultiHop,
+    /// Summarization or synthesis — "Summarize the debate around X."
     Summary,
+    /// Open-ended exploration — "What related topics exist?"
     Exploratory,
 }
 
+/// Retrieval strategy selected by the query planner.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RetrievalStrategy {
+    /// Use the original question directly against the store.
     Direct,
+    /// Rewrite the question into semantic / keyword variants before retrieving.
     Rewrite,
+    /// Decompose the question into subqueries, retrieve each, then combine.
     Decompose,
+    /// Retrieve broadly then rerank with an LLM.
     BroadThenRerank,
 }
 
+/// Retrieval plan produced by the LLM query planner.
 #[derive(Clone, Debug, PartialEq)]
 pub struct QueryPlan {
+    /// Classified question type.
     pub question_type: QuestionType,
+    /// Selected retrieval strategy.
     pub strategy: RetrievalStrategy,
+    /// Human-readable reasoning for why this strategy was chosen.
     pub reasoning: String,
+    /// Decomposed subqueries when strategy is `Decompose`.
     pub subqueries: Vec<String>,
 }
 
+/// Result of an LLM evidence assessment.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EvidenceVerdict {
+    /// Retrieved candidates fully cover what is needed to answer.
     Sufficient,
+    /// Candidates are partially relevant; more iterations or reformulation may help.
     Partial,
+    /// Candidates do not contain enough relevant information.
     Insufficient,
 }
 
+/// One iteration of the agentic retrieval loop.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentIteration {
+    /// Zero-based iteration index.
     pub iteration: usize,
+    /// Query variants used in this iteration (original + rewritten).
     pub query_variants: Vec<String>,
+    /// Total candidates retrieved before pruning.
     pub retrieved_count: usize,
+    /// Candidates retained after deduplication and pruning.
     pub kept_count: usize,
+    /// LLM judgment of evidence sufficiency.
     pub sufficiency: EvidenceVerdict,
+    /// Human-readable notes from this iteration.
     pub notes: Vec<String>,
 }
 
+/// Final result of a full agentic retrieval session.
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentResult {
+    /// Generated answer string.
     pub answer: String,
+    /// Retrieval candidates used as context for generation.
     pub contexts: Vec<RetrievalCandidate>,
+    /// Query plan selected by the planner.
     pub plan: QueryPlan,
+    /// All iterations run before reaching a terminal verdict.
     pub iterations: Vec<AgentIteration>,
+    /// Support check confirming answer is grounded in evidence.
     pub support_check: SupportCheck,
 }
 
+/// Result of verifying that a generated answer is supported by retrieved evidence.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SupportCheck {
+    /// Whether all substantive claims in the answer have supporting evidence.
     pub supported: bool,
+    /// List of specific claims in the answer that lack evidence.
     pub unsupported_claims: Vec<String>,
+    /// Additional notes from the verifier.
     pub notes: Vec<String>,
 }
 
+/// Evidence assessment returned by the LLM.
 #[derive(Clone, Debug, PartialEq)]
 pub struct EvidenceAssessment {
+    /// Overall verdict on evidence sufficiency.
     pub verdict: EvidenceVerdict,
+    /// Specific aspects of the question that are not covered by retrieved candidates.
     pub missing_aspects: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct QueryPlanPayload {
-    question_type: String,
-    strategy: String,
-    reasoning: Option<String>,
-    #[serde(default)]
-    subqueries: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct EvidencePayload {
-    verdict: String,
-    #[serde(default)]
-    missing_aspects: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupportPayload {
-    supported: bool,
-    #[serde(default)]
-    unsupported_claims: Vec<String>,
-    #[serde(default)]
-    notes: Vec<String>,
-}
-
+/// Builds a structured query plan from a user question using an LLM.
+///
+/// The LLM is instructed to classify the question type and select an appropriate
+/// retrieval strategy, returning strict JSON. Falls back to a heuristic plan
+/// (`fallback_query_plan`) if the LLM misformats its response.
 pub async fn build_query_plan(generator: &Generator, question: &str) -> Result<QueryPlan> {
     let response = generator
         .generate_json(
@@ -128,6 +168,12 @@ pub async fn build_query_plan(generator: &Generator, question: &str) -> Result<Q
     parse_query_plan(&response)
 }
 
+/// Asks an LLM to judge whether the retrieved candidates are sufficient to answer
+/// the given question.
+///
+/// Returns an [`EvidenceAssessment`] with a verdict and, if insufficient,
+/// a list of missing aspects. This is used to decide whether to continue iterating
+/// or to produce an answer from what was gathered.
 pub async fn assess_evidence(
     generator: &Generator,
     question: &str,
@@ -154,6 +200,12 @@ pub async fn assess_evidence(
     parse_evidence_assessment(&response)
 }
 
+/// Asks an LLM to verify that every substantive claim in an answer is grounded
+/// in the provided evidence candidates.
+///
+/// Returns a [`SupportCheck`] indicating whether the answer is fully supported,
+/// and listing any claims that lack backing. Used as a final check before returning
+/// an answer to the user.
 pub async fn verify_answer_support(
     generator: &Generator,
     question: &str,
@@ -181,10 +233,15 @@ pub async fn verify_answer_support(
     parse_support_check(&response)
 }
 
+/// Heuristic fallback plan used when the LLM fails to produce a parseable plan.
+///
+/// Uses simple keyword detection to decide between `Direct` and `Decompose`:
+/// presence of "and" / "interact" / "connect" triggers decomposition.
 pub fn fallback_query_plan(question: &str) -> QueryPlan {
     let lower = question.to_ascii_lowercase();
     let strategy =
-        if lower.contains(" and ") || lower.contains("interact") || lower.contains("connect") { //FIXME: not language agnostic. should be handeled by agent 
+        if lower.contains(" and ") || lower.contains("interact") || lower.contains("connect") {
+            //FIXME: not language agnostic. should be handeled by agent
             RetrievalStrategy::Decompose
         } else {
             RetrievalStrategy::Direct
@@ -194,7 +251,6 @@ pub fn fallback_query_plan(question: &str) -> QueryPlan {
     } else {
         QuestionType::Lookup
     };
-
     QueryPlan {
         question_type,
         strategy,
@@ -203,6 +259,9 @@ pub fn fallback_query_plan(question: &str) -> QueryPlan {
     }
 }
 
+/// Heuristic fallback for evidence assessment when the LLM is unavailable.
+///
+/// Returns `Sufficient` for 3+ candidates, `Partial` for 1–2, and `Insufficient` for none.
 pub fn fallback_evidence_assessment(candidates: &[RetrievalCandidate]) -> EvidenceAssessment {
     let verdict = if candidates.len() >= 3 {
         EvidenceVerdict::Sufficient
@@ -218,6 +277,10 @@ pub fn fallback_evidence_assessment(candidates: &[RetrievalCandidate]) -> Eviden
     }
 }
 
+/// Heuristic fallback support check when the LLM is unavailable.
+///
+/// Returns `supported = true` if the answer is non-empty and there is at least one
+/// evidence candidate; otherwise `supported = false`.
 pub fn fallback_support_check(answer: &str, evidence: &[RetrievalCandidate]) -> SupportCheck {
     let supported = !answer.trim().is_empty() && !evidence.is_empty();
     SupportCheck {
@@ -231,9 +294,9 @@ pub fn fallback_support_check(answer: &str, evidence: &[RetrievalCandidate]) -> 
     }
 }
 
+/// Parses a JSON query plan from the LLM. Used by [`build_query_plan`].
 pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
-    let payload: QueryPlanPayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse query plan JSON")?;
+    let payload: QueryPlanPayload = parse_json(raw, "parse query plan JSON")?;
     Ok(QueryPlan {
         question_type: parse_question_type(&payload.question_type)?,
         strategy: parse_retrieval_strategy(&payload.strategy)?,
@@ -247,9 +310,9 @@ pub fn parse_query_plan(raw: &str) -> Result<QueryPlan> {
     })
 }
 
+/// Parses an evidence assessment JSON from the LLM. Used by [`assess_evidence`].
 pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
-    let payload: EvidencePayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse evidence assessment JSON")?;
+    let payload: EvidencePayload = parse_json(raw, "parse evidence assessment JSON")?;
     Ok(EvidenceAssessment {
         verdict: parse_evidence_verdict(&payload.verdict)?,
         missing_aspects: payload
@@ -261,9 +324,9 @@ pub fn parse_evidence_assessment(raw: &str) -> Result<EvidenceAssessment> {
     })
 }
 
+/// Parses a support check JSON from the LLM. Used by [`verify_answer_support`].
 pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
-    let payload: SupportPayload =
-        serde_json::from_str(trim_json_fences(raw)).context("parse support check JSON")?;
+    let payload: SupportPayload = parse_json(raw, "parse support check JSON")?;
     Ok(SupportCheck {
         supported: payload.supported,
         unsupported_claims: payload
@@ -281,6 +344,10 @@ pub fn parse_support_check(raw: &str) -> Result<SupportCheck> {
     })
 }
 
+/// Builds a compact multi-line summary of retrieval candidates for inclusion in LLM prompts.
+///
+/// Each line is `source=<path> page=<N> text=<truncated>` so the LLM can reference
+/// specific chunks without receiving the full text of every candidate.
 fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
     candidates
         .iter()
@@ -296,6 +363,7 @@ fn summarize_candidates(candidates: &[RetrievalCandidate]) -> String {
         .join("\n")
 }
 
+/// Truncates chunk text to [`SUMMARY_TEXT_MAX_CHARS`] words for prompt size control.
 fn summarize_candidate_text(text: &str) -> String {
     let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
     let mut truncated = normalized
@@ -308,6 +376,7 @@ fn summarize_candidate_text(text: &str) -> String {
     truncated
 }
 
+/// Parses a question type string (case-insensitive) into a [`QuestionType`].
 fn parse_question_type(value: &str) -> Result<QuestionType> {
     match value.trim().to_ascii_lowercase().as_str() {
         "lookup" => Ok(QuestionType::Lookup),
@@ -319,6 +388,7 @@ fn parse_question_type(value: &str) -> Result<QuestionType> {
     }
 }
 
+/// Parses a retrieval strategy string (case-insensitive) into a [`RetrievalStrategy`].
 fn parse_retrieval_strategy(value: &str) -> Result<RetrievalStrategy> {
     match value.trim().to_ascii_lowercase().as_str() {
         "direct" => Ok(RetrievalStrategy::Direct),
@@ -329,6 +399,7 @@ fn parse_retrieval_strategy(value: &str) -> Result<RetrievalStrategy> {
     }
 }
 
+/// Parses an evidence verdict string (case-insensitive) into an [`EvidenceVerdict`].
 fn parse_evidence_verdict(value: &str) -> Result<EvidenceVerdict> {
     match value.trim().to_ascii_lowercase().as_str() {
         "sufficient" => Ok(EvidenceVerdict::Sufficient),
@@ -387,7 +458,6 @@ mod tests {
             "{\"question_type\":\"lookup\",\"strategy\":\"decompose\",\"reasoning\":\"ok\",\"subqueries\":[]}",
         )
         .unwrap();
-
         assert_eq!(plan.question_type, QuestionType::Lookup);
         assert_eq!(plan.strategy, RetrievalStrategy::Decompose);
     }
@@ -419,5 +489,14 @@ mod tests {
         let summarized = summarize_candidate_text(&text);
         assert_eq!(summarized.len(), SUMMARY_TEXT_MAX_CHARS + 3);
         assert!(summarized.ends_with("..."));
+    }
+
+    #[test]
+    fn test_parse_evidence_assessment_includes_raw_snippet_in_error() {
+        let err = parse_evidence_assessment("not json at all")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("parse evidence assessment JSON"));
+        assert!(err.contains("not json"));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -144,8 +144,8 @@ pub struct EvidenceAssessment {
 /// Builds a structured query plan from a user question using an LLM.
 ///
 /// The LLM is instructed to classify the question type and select an appropriate
-/// retrieval strategy, returning strict JSON. Falls back to a heuristic plan
-/// (`fallback_query_plan`) if the LLM misformats its response.
+/// retrieval strategy, returning strict JSON. Returns an error if the LLM misformats
+/// its response.
 pub async fn build_query_plan(generator: &Generator, question: &str) -> Result<QueryPlan> {
     let response = generator
         .generate_json(

--- a/src/citation.rs
+++ b/src/citation.rs
@@ -1,5 +1,20 @@
+//! Citation rendering helpers that produce labeled, human-readable context lines
+//! from retrieval candidates for use in generation prompts.
+
 use crate::retrieval::RetrievalCandidate;
 
+/// Formats a list of candidates as labeled context blocks ready for inclusion in a prompt.
+///
+/// Each candidate is assigned a numeric label (1-based), and the chunk text is prefixed
+/// with a location line (`source=<path>` or `source=<path>, page=<N>` when pagination
+/// is available). Example output:
+///
+/// ```text
+/// [1] source=docs/config.rs, page=3
+/// Chunk text here...
+/// ```
+///
+/// Returns a vector of one formatted string per candidate, in the same order as input.
 pub fn labeled_contexts(candidates: &[RetrievalCandidate]) -> Vec<String> {
     candidates
         .iter()
@@ -15,12 +30,19 @@ pub fn labeled_contexts(candidates: &[RetrievalCandidate]) -> Vec<String> {
         .collect()
 }
 
+/// Formats a list of candidates as compact inline citations for reference display.
+///
+/// Each candidate produces a single line of the form `[N] <source>` or
+/// `[N] <source> (page: N)` when pagination is present. Unlike [`labeled_contexts`],
+/// this does not include the chunk text — it is purely a citation index.
 pub fn render_citations(candidates: &[RetrievalCandidate]) -> Vec<String> {
     candidates
         .iter()
         .enumerate()
         .map(|(idx, candidate)| match candidate.page {
-            page if page > 0 => format!("[{}] {} (page: {})", idx + 1, candidate.source_path, page),
+            page if page > 0 => {
+                format!("[{}] {} (page: {})", idx + 1, candidate.source_path, page)
+            }
             _ => format!("[{}] {}", idx + 1, candidate.source_path),
         })
         .collect()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,14 +1,35 @@
+//! Placeholder query planners for the graph retrieval modes (`Local`, `Global`, `Mix`).
+//!
+//! These modes are stubs awaiting a future graph-indexing milestone. For now they
+//! produce stub plans that decompose queries into keyword/semantic variants and fall
+//! back to the hybrid retrieval pipeline without graph context.
+
 use crate::cli::QueryModeArg;
 use crate::rewrite::QueryRewriteSet;
 use std::collections::BTreeSet;
 
+/// Stub plan produced by [`placeholder_plan`] for a graph retrieval mode.
+///
+/// Contains an execution label describing which stub is active, human-readable notes
+/// explaining the current limitation, and a list of query variants to use instead
+/// of a proper graph expansion.
 #[derive(Clone, Debug, PartialEq)]
 pub struct GraphModeStubPlan {
+    /// Identifier for which stub plan was selected. One of `local-placeholder`,
+    /// `global-placeholder`, or `mix-placeholder`.
     pub execution_label: &'static str,
+    /// Human-readable notes describing the stub behavior and pending graph work.
     pub notes: Vec<String>,
+    /// Query variants (original + rewritten forms) to feed into hybrid retrieval.
     pub query_variants: Vec<String>,
 }
 
+/// Returns a placeholder plan for graph retrieval modes, producing query variants
+/// and notes while the full graph indexing pipeline is pending.
+///
+/// - **`Local`**: narrows to the original question only, assuming graph edges are chunk-local.
+/// - **`Global`**: broadens to original + keyword variant for broader coverage.
+/// - **`Mix`**: combines original + semantic + keyword variants to explore both local and global.
 pub fn placeholder_plan(mode: QueryModeArg, rewrite_set: &QueryRewriteSet) -> GraphModeStubPlan {
     let question = rewrite_set.original.as_str();
     let (execution_label, notes, query_variants) = match mode {
@@ -64,6 +85,8 @@ pub fn placeholder_plan(mode: QueryModeArg, rewrite_set: &QueryRewriteSet) -> Gr
     }
 }
 
+/// Deduplicates an array of optional query strings, returning only unique non-empty variants
+/// in the order they first appear.
 fn dedupe_queries(queries: [Option<&str>; 3]) -> Vec<String> {
     let mut seen = BTreeSet::new();
     let mut variants = Vec::new();
@@ -121,7 +144,7 @@ mod tests {
         assert_eq!(
             plan.query_variants,
             vec![
-                "How do config checks work?".to_string(),
+                "How do config changes work?".to_string(),
                 "Explain config validation flow".to_string(),
                 "config validation metadata".to_string(),
             ]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(
             plan.query_variants,
             vec![
-                "How do config changes work?".to_string(),
+                "How do config checks work?".to_string(),
                 "Explain config validation flow".to_string(),
                 "config validation metadata".to_string(),
             ]

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -169,14 +169,9 @@ fn max_option(left: Option<f32>, right: Option<f32>) -> Option<f32> {
     }
 }
 
-/// Score-ratio threshold for early stopping in [`prune_candidates`].
-/// After the first two candidates are kept, any candidate whose score is below 60%
-/// of the previous candidate's score is dropped.
-const AUTOCUT_RATIO: f32 = 0.6;
-
 fn should_autocut(previous_score: Option<f32>, current_score: Option<f32>) -> bool {
     match (previous_score, current_score) {
-        (Some(previous), Some(current)) if previous > 0.0 => current / previous < AUTOCUT_RATIO,
+        (Some(previous), Some(current)) if previous > 0.0 => current / previous < 0.6,
         _ => false,
     }
 }

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1,21 +1,42 @@
+//! Retrieval candidate data structure and score-based candidate merge, prune, and rerank operations.
+
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
+/// A chunk retrieved from the store, annotated with retrieval scores from each ranking stage.
+///
+/// `RetrievalCandidate` is the core data carrier flowing through the query pipeline:
+/// it starts with a raw vector and/or keyword score from LanceDB, gets fused and/or
+/// reranked, and finally carries a combined `best_score` used for ordering results.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RetrievalCandidate {
+    /// Stable row identifier assigned by LanceDB on write.
     pub id: String,
+    /// Original source file or document path this chunk was indexed from.
     pub source_path: String,
+    /// Full text content of this chunk.
     pub chunk_text: String,
+    /// JSON-encoded metadata recorded at index time (format, language, page, etc.).
     pub metadata: String,
+    /// Page number for paginated sources (PDFs); `0` for non-paginated sources.
     pub page: i32,
+    /// Zero-based chunk index within the source unit.
     pub chunk_index: i32,
+    /// Semantic similarity score from vector search. `None` if vector search was not run.
     pub vector_score: Option<f32>,
+    /// BM25 keyword score from full-text search. `None` if FTS was not run.
     pub keyword_score: Option<f32>,
+    /// Reciprocal Rank Fusion (RRF) score combining vector and keyword rankings.
     pub fused_score: Option<f32>,
+    /// Score from the LLM-based reranker. `None` if reranking was not enabled.
     pub rerank_score: Option<f32>,
 }
 
 impl RetrievalCandidate {
+    /// Returns the best available score for this candidate, preferring rerank > fused > vector > keyword.
+    ///
+    /// When multiple scores are present the most informative (rerank > fused > vector > keyword)
+    /// is returned. Returns `None` only if no scores have been computed.
     pub fn best_score(&self) -> Option<f32> {
         self.rerank_score
             .or(self.fused_score)
@@ -23,6 +44,10 @@ impl RetrievalCandidate {
             .or(self.keyword_score)
     }
 
+    /// Returns a deterministic key used to deduplicate candidates across retrieval groups.
+    ///
+    /// Prefers the stable `id` field when available; falls back to a composite of
+    /// source path, page, chunk index, and text content.
     pub fn dedupe_key(&self) -> String {
         if !self.id.is_empty() {
             return self.id.clone();
@@ -35,6 +60,12 @@ impl RetrievalCandidate {
     }
 }
 
+/// Merges candidates from multiple retrieval groups (e.g. vector + keyword), deduplicating
+/// by [`dedupe_key`](RetrievalCandidate::dedupe_key) and keeping the highest score per key.
+///
+/// This is the final step of hybrid retrieval — each group contributes candidates, identical
+/// candidates (same `source_path` + `page` + `chunk_index`) are merged by taking the maximum
+/// of their respective scores, and the combined list is sorted descending by `best_score`.
 pub fn merge_candidates(
     groups: impl IntoIterator<Item = Vec<RetrievalCandidate>>,
 ) -> Vec<RetrievalCandidate> {
@@ -57,6 +88,11 @@ pub fn merge_candidates(
     out
 }
 
+/// Prunes a sorted candidate list down to at most `top_k` results, stopping early if a
+/// score cliff is detected (score drops below 60% of the previous score after the first two).
+///
+/// This prevents low-relevance candidates from appearing in the context window when a clear
+/// relevance boundary exists in the ranked list.
 pub fn prune_candidates(
     candidates: Vec<RetrievalCandidate>,
     top_k: usize,
@@ -78,6 +114,13 @@ pub fn prune_candidates(
     kept
 }
 
+/// Reorders candidates to follow a reranked priority list, placing reranked candidates first
+/// (in the order given by `reranked_ids`) and appending any unreferenced candidates sorted
+/// by their existing score.
+///
+/// `reranked_ids` is a list of `(id, score)` pairs in the order the reranker determined.
+/// Candidates not present in `reranked_ids` are appended at the end sorted by `best_score`.
+/// The result is truncated to `top_n`.
 pub fn apply_rerank_order(
     candidates: &[RetrievalCandidate],
     reranked_ids: &[(String, f32)],
@@ -126,9 +169,14 @@ fn max_option(left: Option<f32>, right: Option<f32>) -> Option<f32> {
     }
 }
 
+/// Score-ratio threshold for early stopping in [`prune_candidates`].
+/// After the first two candidates are kept, any candidate whose score is below 60%
+/// of the previous candidate's score is dropped.
+const AUTOCUT_RATIO: f32 = 0.6;
+
 fn should_autocut(previous_score: Option<f32>, current_score: Option<f32>) -> bool {
     match (previous_score, current_score) {
-        (Some(previous), Some(current)) if previous > 0.0 => current / previous < 0.6,
+        (Some(previous), Some(current)) if previous > 0.0 => current / previous < AUTOCUT_RATIO,
         _ => false,
     }
 }
@@ -207,7 +255,6 @@ mod tests {
             ],
             3,
         );
-
         assert_eq!(kept.len(), 2);
         assert_eq!(kept[0].id, "a");
         assert_eq!(kept[1].id, "b");

--- a/src/source_kind.rs
+++ b/src/source_kind.rs
@@ -1,31 +1,52 @@
 //! Shared source-kind classification for ingestion and store statistics.
+//!
+//! `SourceKind` classifies a file by its format (text, markdown, HTML, CSV, code, PDF, image)
+//! based on the file extension. `ContentCategory` is an aggregate grouping used for
+//! store statistics reporting.
 
 use std::path::Path;
 
-/// File kind recognized by `ragcli`.
+/// File format recognized by `ragcli` during ingestion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceKind {
+    /// Plain text with no special structure.
     Text,
+    /// Markdown with optional frontmatter.
     Markdown,
+    /// HTML, including HTML generated from Jupyter notebooks.
     Html,
+    /// Delimiter-separated values (CSV or TSV).
     Csv { delimiter: u8 },
+    /// Source code with a known language tag.
     Code { language: &'static str },
+    /// Portable Document Format.
     Pdf,
+    /// Raster image (PNG, JPEG, WebP) — processed through vision captioning.
     Image,
+    /// Known but unsupported format; skipped during ingestion.
     Unsupported,
 }
 
-/// Aggregated content category used for store statistics.
+/// Aggregate content grouping used in store statistics.
+///
+/// `ContentCategory` collapses the fine-grained `SourceKind` into four buckets
+/// for high-level reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContentCategory {
+    /// Text, Markdown, HTML, CSV, or code files.
     Text,
+    /// PDF files.
     Pdf,
+    /// Image files processed via vision captioning.
     Image,
+    /// Files that are recognized but unsupported.
     Other,
 }
 
 impl SourceKind {
-    /// Classifies a source path by file extension.
+    /// Classifies a file by its extension, returning the appropriate [`SourceKind`].
+    ///
+    /// Extension matching is case-insensitive. Unknown extensions yield `Unsupported`.
     pub fn from_path(path: &Path) -> Self {
         let ext = path
             .extension()
@@ -64,7 +85,9 @@ impl SourceKind {
         }
     }
 
-    /// Returns the metadata format label used for chunk metadata.
+    /// Returns the format label written into chunk metadata for this source kind.
+    ///
+    /// Returns `None` for `Unsupported` files since they are not ingested.
     pub fn format_label(self) -> Option<&'static str> {
         match self {
             Self::Text => Some("text"),
@@ -79,7 +102,7 @@ impl SourceKind {
         }
     }
 
-    /// Returns the aggregate content category used in store statistics.
+    /// Maps this source kind to its aggregate [`ContentCategory`] for statistics.
     pub fn content_category(self) -> ContentCategory {
         match self {
             Self::Text | Self::Markdown | Self::Html | Self::Csv { .. } | Self::Code { .. } => {


### PR DESCRIPTION
Add comprehensive rustdoc documentation to the public API surface of five modules.

## Changes

### 
- Document all  fields with explanations of what each score means and when it's populated
- Document , ,  with behavior descriptions
- Extract  (0.6) as a named constant with a doc comment explaining the autocut heuristic

### 
- Add module-level docstring explaining these are stubs awaiting graph indexing
- Document  fields and  behavior for each mode

### 
- Document  with a concrete output example
- Document  noting it differs from  by excluding chunk text

### 
- Add module-level documentation describing the full query lifecycle (plan → retrieve → assess → iterate → verify)
- Document all public enums (, , )
- Document all public structs (, , , , , )
- Document all public async functions (, , ) and fallbacks
- Fix:  was importing  from  but using  locally — now uses 

### 
- Add module-level documentation on what the module provides
- Document , , , , 

---

Note:  fails in this environment due to missing OpenSSL development headers (pkg-config not available), but  passes cleanly.