### PR TITLE
feat(cli): add json output for report commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,6 +4568,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "time",
  "tokio",
  "toml",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+time = { version = "0.3", features = ["formatting"] }
 toml = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 walkdir = "2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,11 +73,11 @@ pub async fn run(cli: Cli) -> Result<()> {
             .await?
         }
         Command::Config { command } => match command {
-            ConfigCommand::Show => commands::config::show(name).await?,
+            ConfigCommand::Show { json } => commands::config::show(name, json).await?,
             ConfigCommand::Set { key, value } => commands::config::set(name, key, value).await?,
         },
-        Command::Stat => commands::stat::run(name).await?,
-        Command::Doctor => commands::doctor::run(name).await?,
+        Command::Stat { json } => commands::stat::run(name, json).await?,
+        Command::Doctor { json } => commands::doctor::run(name, json).await?,
     }
 
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,16 +123,28 @@ pub enum Command {
         command: ConfigCommand,
     },
     /// Shows a summary of indexed content and store usage.
-    Stat,
+    Stat {
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Checks store layout and runtime dependencies.
-    Doctor,
+    Doctor {
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
 }
 
 /// Configuration subcommands.
 #[derive(Subcommand, Debug)]
 pub enum ConfigCommand {
     /// Prints the effective configuration for the selected store.
-    Show,
+    Show {
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Sets a config key in `~/.config/ragcli/<name>/config.toml`.
     Set {
         /// Configuration key such as `models.embed` or `ollama.base_url`.
@@ -212,6 +224,29 @@ mod tests {
                 assert_eq!(max_iterations, 2);
             }
             command => panic!("expected query command, got {command:?}"),
+        }
+    }
+
+    #[test]
+    fn test_json_flags_parse_for_supported_commands() {
+        let stat = Cli::try_parse_from(["ragcli", "stat", "--json"]).unwrap();
+        match stat.command {
+            Command::Stat { json } => assert!(json),
+            command => panic!("expected stat command, got {command:?}"),
+        }
+
+        let doctor = Cli::try_parse_from(["ragcli", "doctor", "--json"]).unwrap();
+        match doctor.command {
+            Command::Doctor { json } => assert!(json),
+            command => panic!("expected doctor command, got {command:?}"),
+        }
+
+        let config = Cli::try_parse_from(["ragcli", "config", "show", "--json"]).unwrap();
+        match config.command {
+            Command::Config {
+                command: ConfigCommand::Show { json },
+            } => assert!(json),
+            command => panic!("expected config show command, got {command:?}"),
         }
     }
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,23 +1,53 @@
 use crate::config::{
     self, ensure_store_layout, load_or_create_config_with_sources, load_or_create_file_config,
-    save_config, store_dir,
+    save_config, store_dir, Config, ConfigSources,
 };
 use anyhow::Result;
+use serde::Serialize;
 
-pub async fn show(name: Option<&str>) -> Result<()> {
+#[derive(Debug, Serialize)]
+pub struct ConfigShowReport {
+    pub store: String,
+    pub config_path: String,
+    pub config: Config,
+    pub sources: ConfigSources,
+    pub active_overrides: Vec<String>,
+}
+
+pub async fn show(name: Option<&str>, json: bool) -> Result<()> {
+    let report = build_show_report(name)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_show_human(&report)?;
+    }
+    Ok(())
+}
+
+fn build_show_report(name: Option<&str>) -> Result<ConfigShowReport> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let (cfg, sources) = load_or_create_config_with_sources(&store)?;
+    let active_overrides = sources.overrides();
 
-    println!("Store: {}", store.display());
-    println!("Config: {}", config::config_path(&store).display());
+    Ok(ConfigShowReport {
+        store: store.display().to_string(),
+        config_path: config::config_path(&store).display().to_string(),
+        config: cfg,
+        sources,
+        active_overrides,
+    })
+}
+
+fn print_show_human(report: &ConfigShowReport) -> Result<()> {
+    println!("Store: {}", report.store);
+    println!("Config: {}", report.config_path);
     println!();
-    println!("{}", toml::to_string_pretty(&cfg)?);
+    println!("{}", toml::to_string_pretty(&report.config)?);
 
-    let overrides = sources.overrides();
-    if !overrides.is_empty() {
+    if !report.active_overrides.is_empty() {
         println!("Active environment overrides:");
-        for override_entry in overrides {
+        for override_entry in &report.active_overrides {
             println!("  {}", override_entry);
         }
     }
@@ -54,11 +84,23 @@ mod tests {
             )
             .await
             .unwrap();
-            show(Some("test-store")).await.unwrap();
+            show(Some("test-store"), false).await.unwrap();
 
             let store = store_dir(Some("test-store")).unwrap();
             let cfg = load_or_create_file_config(&store).unwrap();
             assert_eq!(cfg.models.chat, "chat-z");
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_show_report_serializes_to_json() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let report = build_show_report(Some("json-store")).unwrap();
+            let json = serde_json::to_string(&report).unwrap();
+            assert!(json.contains("\"config\""));
+            assert!(json.contains("\"active_overrides\""));
         })
         .await;
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -2,10 +2,52 @@ use crate::config::{self, ensure_store_layout, load_or_create_config, status, st
 use crate::models::OllamaClient;
 use crate::store;
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub async fn run(name: Option<&str>) -> Result<()> {
+#[derive(Debug, Serialize)]
+pub struct PathStatusReport {
+    pub path: String,
+    pub status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelInstallReport {
+    pub embed_model_installed: bool,
+    pub chat_model_installed: bool,
+    pub vision_model_installed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DoctorReport {
+    pub time: u64,
+    pub base: PathStatusReport,
+    pub store: PathStatusReport,
+    pub config: PathStatusReport,
+    pub ollama_url: String,
+    pub embed_model: String,
+    pub chat_model: String,
+    pub vision_model: String,
+    pub ollama_reachable: bool,
+    pub ollama_error: Option<String>,
+    pub installed_models: Option<ModelInstallReport>,
+    pub metadata: PathStatusReport,
+    pub metadata_summary: Option<String>,
+    pub subdirectories: Vec<(String, PathStatusReport)>,
+}
+
+pub async fn run(name: Option<&str>, json: bool) -> Result<()> {
+    let report = build_report(name).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+    Ok(())
+}
+
+async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let cfg = load_or_create_config(&store)?;
@@ -15,59 +57,116 @@ pub async fn run(name: Option<&str>) -> Result<()> {
         .context("system time before unix epoch")?
         .as_secs();
 
+    let ollama = OllamaClient::new(cfg.ollama.base_url.clone());
+    let (ollama_reachable, ollama_error, installed_models) = match ollama.list_models().await {
+        Ok(models) => (
+            true,
+            None,
+            Some(ModelInstallReport {
+                embed_model_installed: models.iter().any(|model| model == &cfg.models.embed),
+                chat_model_installed: models.iter().any(|model| model == &cfg.models.chat),
+                vision_model_installed: models.iter().any(|model| model == &cfg.models.vision),
+            }),
+        ),
+        Err(err) => (false, Some(err.to_string()), None),
+    };
+
+    let metadata_path = store::metadata_path(&store);
+    let metadata_summary = if metadata_path.exists() {
+        Some(fs::read_to_string(&metadata_path)?.replace('\n', " "))
+    } else {
+        None
+    };
+
+    let subdirectories = ["lancedb", "meta", "cache", "models"]
+        .into_iter()
+        .map(|sub| {
+            let path = store.join(sub);
+            (
+                sub.to_string(),
+                PathStatusReport {
+                    path: path.display().to_string(),
+                    status: status(path.exists()),
+                },
+            )
+        })
+        .collect();
+
+    Ok(DoctorReport {
+        time: now,
+        base: PathStatusReport {
+            path: base.display().to_string(),
+            status: status(base.exists()),
+        },
+        store: PathStatusReport {
+            path: store.display().to_string(),
+            status: status(store.exists()),
+        },
+        config: PathStatusReport {
+            path: config::config_path(&store).display().to_string(),
+            status: status(config::config_path(&store).exists()),
+        },
+        ollama_url: cfg.ollama.base_url,
+        embed_model: cfg.models.embed,
+        chat_model: cfg.models.chat,
+        vision_model: cfg.models.vision,
+        ollama_reachable,
+        ollama_error,
+        installed_models,
+        metadata: PathStatusReport {
+            path: metadata_path.display().to_string(),
+            status: status(metadata_path.exists()),
+        },
+        metadata_summary,
+        subdirectories,
+    })
+}
+
+fn print_human(report: &DoctorReport) {
     println!("Doctor report");
-    println!("  time: {}", now);
-    println!("  base: {} ({})", base.display(), status(base.exists()));
-    println!("  store: {} ({})", store.display(), status(store.exists()));
+    println!("  time: {}", report.time);
+    println!("  base: {} ({})", report.base.path, report.base.status);
+    println!("  store: {} ({})", report.store.path, report.store.status);
     println!(
         "  config: {} ({})",
-        config::config_path(&store).display(),
-        status(config::config_path(&store).exists())
+        report.config.path, report.config.status
     );
-    println!("  ollama url: {}", cfg.ollama.base_url);
-    println!("  embed model: {}", cfg.models.embed);
-    println!("  chat model: {}", cfg.models.chat);
-    println!("  vision model: {}", cfg.models.vision);
+    println!("  ollama url: {}", report.ollama_url);
+    println!("  embed model: {}", report.embed_model);
+    println!("  chat model: {}", report.chat_model);
+    println!("  vision model: {}", report.vision_model);
 
-    let ollama = OllamaClient::new(cfg.ollama.base_url.clone());
-    match ollama.list_models().await {
-        Ok(models) => {
-            println!("  ollama: reachable");
+    if report.ollama_reachable {
+        println!("  ollama: reachable");
+        if let Some(installed_models) = &report.installed_models {
             println!(
                 "  embed model installed: {}",
-                status(models.iter().any(|model| model == &cfg.models.embed))
+                status(installed_models.embed_model_installed)
             );
             println!(
                 "  chat model installed: {}",
-                status(models.iter().any(|model| model == &cfg.models.chat))
+                status(installed_models.chat_model_installed)
             );
             println!(
                 "  vision model installed: {}",
-                status(models.iter().any(|model| model == &cfg.models.vision))
+                status(installed_models.vision_model_installed)
             );
         }
-        Err(err) => {
-            println!("  ollama: unreachable ({})", err);
-        }
+    } else if let Some(err) = &report.ollama_error {
+        println!("  ollama: unreachable ({})", err);
     }
 
-    let metadata_path = store::metadata_path(&store);
     println!(
         "  metadata: {} ({})",
-        metadata_path.display(),
-        status(metadata_path.exists())
+        report.metadata.path, report.metadata.status
     );
-    if metadata_path.exists() {
-        let metadata = fs::read_to_string(&metadata_path)?;
-        println!("  metadata summary: {}", metadata.replace('\n', " "));
+    if let Some(metadata_summary) = &report.metadata_summary {
+        println!("  metadata summary: {}", metadata_summary);
     }
 
-    for sub in ["lancedb", "meta", "cache", "models"] {
-        let path = store.join(sub);
-        println!("  {}: {} ({})", sub, path.display(), status(path.exists()));
+    for (name, path_status) in &report.subdirectories {
+        println!("  {}: {} ({})", name, path_status.path, path_status.status);
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -76,23 +175,29 @@ mod tests {
     use crate::test_support::{sequential_json_server, with_test_env};
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_run_succeeds_on_empty_store() {
+    async fn test_build_report_succeeds_on_empty_store() {
         let dir = tempfile::tempdir().unwrap();
         with_test_env(dir.path(), None, || async {
-            run(Some("empty")).await.unwrap();
+            let report = build_report(Some("empty")).await.unwrap();
+            assert_eq!(report.store.status, "exists");
+            assert!(serde_json::to_string(&report)
+                .unwrap()
+                .contains("\"ollama_reachable\""));
         })
         .await;
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_run_succeeds_with_reachable_mock_ollama() {
+    async fn test_build_report_succeeds_with_reachable_mock_ollama() {
         let dir = tempfile::tempdir().unwrap();
         let server = sequential_json_server(vec![
             r#"{"models":[{"name":"nomic-embed-text-v2-moe:latest"},{"name":"qwen3.5:4b"}]}"#,
         ]);
 
         with_test_env(dir.path(), Some(&server), || async {
-            run(Some("reachable")).await.unwrap();
+            let report = build_report(Some("reachable")).await.unwrap();
+            assert!(report.ollama_reachable);
+            assert!(report.installed_models.is_some());
         })
         .await;
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -13,6 +13,13 @@ pub struct PathStatusReport {
 }
 
 #[derive(Debug, Serialize)]
+pub struct NamedPathStatusReport {
+    pub name: String,
+    pub path: String,
+    pub status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ModelInstallReport {
     pub embed_model_installed: bool,
     pub chat_model_installed: bool,
@@ -34,7 +41,7 @@ pub struct DoctorReport {
     pub installed_models: Option<ModelInstallReport>,
     pub metadata: PathStatusReport,
     pub metadata_summary: Option<String>,
-    pub subdirectories: Vec<(String, PathStatusReport)>,
+    pub subdirectories: Vec<NamedPathStatusReport>,
 }
 
 pub async fn run(name: Option<&str>, json: bool) -> Result<()> {
@@ -82,13 +89,11 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
         .into_iter()
         .map(|sub| {
             let path = store.join(sub);
-            (
-                sub.to_string(),
-                PathStatusReport {
-                    path: path.display().to_string(),
-                    status: status(path.exists()),
-                },
-            )
+            NamedPathStatusReport {
+                name: sub.to_string(),
+                path: path.display().to_string(),
+                status: status(path.exists()),
+            }
         })
         .collect();
 
@@ -164,8 +169,11 @@ fn print_human(report: &DoctorReport) {
         println!("  metadata summary: {}", metadata_summary);
     }
 
-    for (name, path_status) in &report.subdirectories {
-        println!("  {}: {} ({})", name, path_status.path, path_status.status);
+    for subdirectory in &report.subdirectories {
+        println!(
+            "  {}: {} ({})",
+            subdirectory.name, subdirectory.path, subdirectory.status
+        );
     }
 }
 
@@ -198,6 +206,7 @@ mod tests {
             let report = build_report(Some("reachable")).await.unwrap();
             assert!(report.ollama_reachable);
             assert!(report.installed_models.is_some());
+            assert_eq!(report.subdirectories[0].name, "lancedb");
         })
         .await;
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,4 +1,6 @@
-use crate::config::{self, ensure_store_layout, load_or_create_config, status, store_dir};
+use crate::config::{
+    self, ensure_store_layout, load_or_create_config, status, store_dir, STORE_SUBDIRECTORIES,
+};
 use crate::models::OllamaClient;
 use crate::store;
 use anyhow::{Context, Result};
@@ -85,7 +87,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
         None
     };
 
-    let subdirectories = ["lancedb", "meta", "cache", "models"]
+    let subdirectories = STORE_SUBDIRECTORIES
         .into_iter()
         .map(|sub| {
             let path = store.join(sub);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -45,6 +45,7 @@ pub struct DoctorReport {
     pub installed_models: Option<ModelInstallReport>,
     pub metadata: PathStatusReport,
     pub metadata_summary: Option<String>,
+    pub metadata_error: Option<String>,
     pub subdirectories: Vec<NamedPathStatusReport>,
 }
 
@@ -83,10 +84,13 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
     };
 
     let metadata_path = store::metadata_path(&store);
-    let metadata_summary = if metadata_path.exists() {
-        Some(fs::read_to_string(&metadata_path)?.replace('\n', " "))
+    let (metadata_summary, metadata_error) = if metadata_path.exists() {
+        match fs::read_to_string(&metadata_path) {
+            Ok(contents) => (Some(contents.replace('\n', " ")), None),
+            Err(err) => (None, Some(err.to_string())),
+        }
     } else {
-        None
+        (None, None)
     };
 
     let subdirectories = STORE_SUBDIRECTORIES
@@ -127,6 +131,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
             status: status(metadata_path.exists()),
         },
         metadata_summary,
+        metadata_error,
         subdirectories,
     })
 }
@@ -171,6 +176,9 @@ fn print_human(report: &DoctorReport) {
     );
     if let Some(metadata_summary) = &report.metadata_summary {
         println!("  metadata summary: {}", metadata_summary);
+    }
+    if let Some(metadata_error) = &report.metadata_error {
+        println!("  metadata error: {}", metadata_error);
     }
 
     for subdirectory in &report.subdirectories {
@@ -226,6 +234,22 @@ mod tests {
             assert!(report.ollama_reachable);
             assert!(report.installed_models.is_some());
             assert_eq!(report.subdirectories[0].name, "lancedb");
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_report_keeps_running_when_metadata_read_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("broken-metadata")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            fs::create_dir_all(store::metadata_path(&store)).unwrap();
+
+            let report = build_report(Some("broken-metadata")).await.unwrap();
+
+            assert!(report.metadata_summary.is_none());
+            assert!(report.metadata_error.is_some());
         })
         .await;
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,6 +7,8 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 #[derive(Debug, Serialize)]
 pub struct PathStatusReport {
@@ -131,7 +133,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
 
 fn print_human(report: &DoctorReport) {
     println!("Doctor report");
-    println!("  time: {}", report.time);
+    println!("  time: {}", format_unix_timestamp(report.time));
     println!("  base: {} ({})", report.base.path, report.base.status);
     println!("  store: {} ({})", report.store.path, report.store.status);
     println!(
@@ -179,10 +181,25 @@ fn print_human(report: &DoctorReport) {
     }
 }
 
+fn format_unix_timestamp(timestamp: u64) -> String {
+    match OffsetDateTime::from_unix_timestamp(timestamp as i64)
+        .ok()
+        .and_then(|time| time.format(&Rfc3339).ok())
+    {
+        Some(formatted) => formatted,
+        None => timestamp.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::{sequential_json_server, with_test_env};
+
+    #[test]
+    fn test_format_unix_timestamp_uses_rfc3339_when_possible() {
+        assert_eq!(format_unix_timestamp(0), "1970-01-01T00:00:00Z");
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_build_report_succeeds_on_empty_store() {

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -105,7 +105,7 @@ mod tests {
             )
             .await
             .unwrap();
-            stat::run(Some("e2e")).await.unwrap();
+            stat::run(Some("e2e"), false).await.unwrap();
         })
         .await;
     }

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -1,4 +1,4 @@
-use crate::config::{ensure_store_layout, load_or_create_config, store_dir};
+use crate::config::{ensure_store_layout, load_or_create_config, store_dir, STORE_SUBDIRECTORIES};
 use crate::store::{
     collect_store_stats, connect_db, load_metadata, StoreMetadata, StoreStats, DEFAULT_TABLE_NAME,
 };
@@ -7,6 +7,7 @@ use futures::TryStreamExt;
 use lancedb::query::ExecutableQuery;
 use serde::Serialize;
 use std::path::Path;
+use walkdir::WalkDir;
 
 #[derive(Debug, Serialize)]
 pub struct DiskUsageReport {
@@ -59,13 +60,7 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
     }
 
     let stats = collect_store_stats(&batches, 5)?;
-    let disk_usage = DiskUsageReport {
-        total_bytes: dir_size_bytes(&store)?,
-        lancedb_bytes: dir_size_bytes(&store.join("lancedb"))?,
-        meta_bytes: dir_size_bytes(&store.join("meta"))?,
-        cache_bytes: dir_size_bytes(&store.join("cache"))?,
-        models_bytes: dir_size_bytes(&store.join("models"))?,
-    };
+    let disk_usage = collect_disk_usage(&store)?;
 
     Ok(StatReport {
         store: store.display().to_string(),
@@ -162,6 +157,50 @@ pub fn dir_size_bytes(path: &Path) -> Result<u64> {
     Ok(total)
 }
 
+fn collect_disk_usage(store: &Path) -> Result<DiskUsageReport> {
+    let mut report = DiskUsageReport {
+        total_bytes: 0,
+        lancedb_bytes: 0,
+        meta_bytes: 0,
+        cache_bytes: 0,
+        models_bytes: 0,
+    };
+
+    if !store.exists() {
+        return Ok(report);
+    }
+
+    for entry in WalkDir::new(store) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let bytes = entry.metadata()?.len();
+        report.total_bytes += bytes;
+
+        let Ok(relative_path) = entry.path().strip_prefix(store) else {
+            continue;
+        };
+        let Some(first_component) = relative_path.components().next() else {
+            continue;
+        };
+        let Some(name) = first_component.as_os_str().to_str() else {
+            continue;
+        };
+
+        match name {
+            "lancedb" => report.lancedb_bytes += bytes,
+            "meta" => report.meta_bytes += bytes,
+            "cache" => report.cache_bytes += bytes,
+            "models" => report.models_bytes += bytes,
+            _ => {}
+        }
+    }
+
+    Ok(report)
+}
+
 pub fn fmt_bytes(bytes: u64) -> String {
     const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
     let mut value = bytes as f64;
@@ -218,6 +257,31 @@ mod tests {
         assert_eq!(dir_size_bytes(&dir.path().join("missing")).unwrap(), 0);
         assert_eq!(dir_size_bytes(&file).unwrap(), 3);
         assert_eq!(dir_size_bytes(dir.path()).unwrap(), 8);
+    }
+
+    #[test]
+    fn test_collect_disk_usage_walks_store_once_and_keeps_root_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        for subdirectory in STORE_SUBDIRECTORIES {
+            std::fs::create_dir_all(store.join(subdirectory)).unwrap();
+        }
+        std::fs::write(store.join("config.toml"), b"abc").unwrap();
+        std::fs::write(store.join("lancedb").join("data.bin"), b"12345").unwrap();
+        std::fs::write(store.join("meta").join("store.toml"), b"12").unwrap();
+        std::fs::write(store.join("cache").join("blob.bin"), b"1234").unwrap();
+        std::fs::write(store.join("models").join("weights.gguf"), b"123456").unwrap();
+        std::fs::create_dir_all(store.join("other")).unwrap();
+        std::fs::write(store.join("other").join("extra.bin"), b"1234567").unwrap();
+
+        let report = collect_disk_usage(&store).unwrap();
+
+        assert_eq!(report.total_bytes, 27);
+        assert_eq!(report.lancedb_bytes, 5);
+        assert_eq!(report.meta_bytes, 2);
+        assert_eq!(report.cache_bytes, 4);
+        assert_eq!(report.models_bytes, 6);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -25,6 +25,7 @@ pub struct StatReport {
     pub stats: StoreStats,
     pub metadata: Option<StoreMetadata>,
     pub disk_usage: DiskUsageReport,
+    pub warnings: Vec<String>,
 }
 
 pub async fn run(name: Option<&str>, json: bool) -> Result<()> {
@@ -60,7 +61,7 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
     }
 
     let stats = collect_store_stats(&batches, 5)?;
-    let disk_usage = collect_disk_usage(&store)?;
+    let (disk_usage, warnings) = collect_disk_usage(&store);
 
     Ok(StatReport {
         store: store.display().to_string(),
@@ -68,6 +69,7 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
         stats,
         metadata,
         disk_usage,
+        warnings,
     })
 }
 
@@ -124,6 +126,9 @@ fn print_human(report: &StatReport) {
     println!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
     println!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
     println!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
+    for warning in &report.warnings {
+        println!("  warning: {}", warning);
+    }
 
     if !report.stats.top_sources.is_empty() {
         println!("  top sources by chunk count:");
@@ -157,7 +162,7 @@ pub fn dir_size_bytes(path: &Path) -> Result<u64> {
     Ok(total)
 }
 
-fn collect_disk_usage(store: &Path) -> Result<DiskUsageReport> {
+fn collect_disk_usage(store: &Path) -> (DiskUsageReport, Vec<String>) {
     let mut report = DiskUsageReport {
         total_bytes: 0,
         lancedb_bytes: 0,
@@ -165,18 +170,35 @@ fn collect_disk_usage(store: &Path) -> Result<DiskUsageReport> {
         cache_bytes: 0,
         models_bytes: 0,
     };
+    let mut warnings = Vec::new();
 
     if !store.exists() {
-        return Ok(report);
+        return (report, warnings);
     }
 
     for entry in WalkDir::new(store) {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                warnings.push(format!("skipped unreadable path: {err}"));
+                continue;
+            }
+        };
         if !entry.file_type().is_file() {
             continue;
         }
 
-        let bytes = entry.metadata()?.len();
+        let bytes = match entry.metadata() {
+            Ok(metadata) => metadata.len(),
+            Err(err) => {
+                warnings.push(format!(
+                    "skipped unreadable file {}: {}",
+                    entry.path().display(),
+                    err
+                ));
+                continue;
+            }
+        };
         report.total_bytes += bytes;
 
         let Ok(relative_path) = entry.path().strip_prefix(store) else {
@@ -198,7 +220,7 @@ fn collect_disk_usage(store: &Path) -> Result<DiskUsageReport> {
         }
     }
 
-    Ok(report)
+    (report, warnings)
 }
 
 pub fn fmt_bytes(bytes: u64) -> String {
@@ -275,8 +297,9 @@ mod tests {
         std::fs::create_dir_all(store.join("other")).unwrap();
         std::fs::write(store.join("other").join("extra.bin"), b"1234567").unwrap();
 
-        let report = collect_disk_usage(&store).unwrap();
+        let (report, warnings) = collect_disk_usage(&store);
 
+        assert!(warnings.is_empty());
         assert_eq!(report.total_bytes, 27);
         assert_eq!(report.lancedb_bytes, 5);
         assert_eq!(report.meta_bytes, 2);

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -131,7 +131,7 @@ fn print_human(report: &StatReport) {
             println!(
                 "    - {}  [{} chunks, ~{} tokens]",
                 source.source_path,
-                source.chunks,
+                fmt_count(source.chunks),
                 fmt_count(source.estimated_tokens)
             );
         }

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -1,22 +1,49 @@
 use crate::config::{ensure_store_layout, load_or_create_config, store_dir};
-use crate::store::{collect_store_stats, connect_db, load_metadata};
+use crate::store::{
+    collect_store_stats, connect_db, load_metadata, StoreMetadata, StoreStats, DEFAULT_TABLE_NAME,
+};
 use anyhow::Result;
 use futures::TryStreamExt;
 use lancedb::query::ExecutableQuery;
+use serde::Serialize;
 use std::path::Path;
 
-pub async fn run(name: Option<&str>) -> Result<()> {
+#[derive(Debug, Serialize)]
+pub struct DiskUsageReport {
+    pub total_bytes: u64,
+    pub lancedb_bytes: u64,
+    pub meta_bytes: u64,
+    pub cache_bytes: u64,
+    pub models_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatReport {
+    pub store: String,
+    pub ollama_url: String,
+    pub stats: StoreStats,
+    pub metadata: Option<StoreMetadata>,
+    pub disk_usage: DiskUsageReport,
+}
+
+pub async fn run(name: Option<&str>, json: bool) -> Result<()> {
+    let report = build_report(name).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+    Ok(())
+}
+
+async fn build_report(name: Option<&str>) -> Result<StatReport> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let cfg = load_or_create_config(&store)?;
     let metadata = load_metadata(&store).ok();
     let db = connect_db(&store).await?;
 
-    let table = match db
-        .open_table(crate::store::DEFAULT_TABLE_NAME)
-        .execute()
-        .await
-    {
+    let table = match db.open_table(DEFAULT_TABLE_NAME).execute().await {
         Ok(table) => Some(table),
         Err(_) => None,
     };
@@ -32,44 +59,56 @@ pub async fn run(name: Option<&str>) -> Result<()> {
     }
 
     let stats = collect_store_stats(&batches, 5)?;
-    let total_store_bytes = dir_size_bytes(&store)?;
-    let lancedb_bytes = dir_size_bytes(&store.join("lancedb"))?;
-    let meta_bytes = dir_size_bytes(&store.join("meta"))?;
-    let cache_bytes = dir_size_bytes(&store.join("cache"))?;
-    let models_bytes = dir_size_bytes(&store.join("models"))?;
+    let disk_usage = DiskUsageReport {
+        total_bytes: dir_size_bytes(&store)?,
+        lancedb_bytes: dir_size_bytes(&store.join("lancedb"))?,
+        meta_bytes: dir_size_bytes(&store.join("meta"))?,
+        cache_bytes: dir_size_bytes(&store.join("cache"))?,
+        models_bytes: dir_size_bytes(&store.join("models"))?,
+    };
 
+    Ok(StatReport {
+        store: store.display().to_string(),
+        ollama_url: cfg.ollama.base_url,
+        stats,
+        metadata,
+        disk_usage,
+    })
+}
+
+fn print_human(report: &StatReport) {
     println!("Store summary");
-    println!("  store: {}", store.display());
-    println!("  ollama url: {}", cfg.ollama.base_url);
-    println!("  rows embedded: {}", stats.total_chunks);
-    println!("  source files: {}", stats.unique_sources);
+    println!("  store: {}", report.store);
+    println!("  ollama url: {}", report.ollama_url);
+    println!("  rows embedded: {}", report.stats.total_chunks);
+    println!("  source files: {}", report.stats.unique_sources);
     println!(
         "  content mix: {} text, {} pdf, {} image, {} other",
-        stats.content_kinds.text_files,
-        stats.content_kinds.pdf_files,
-        stats.content_kinds.image_files,
-        stats.content_kinds.other_files
+        report.stats.content_kinds.text_files,
+        report.stats.content_kinds.pdf_files,
+        report.stats.content_kinds.image_files,
+        report.stats.content_kinds.other_files
     );
-    println!("  pdf pages: {}", stats.pdf_pages);
-    println!("  embedded chars: {}", fmt_count(stats.total_chars));
+    println!("  pdf pages: {}", report.stats.pdf_pages);
+    println!("  embedded chars: {}", fmt_count(report.stats.total_chars));
     println!(
         "  estimated embedded tokens: ~{}",
-        fmt_count(stats.estimated_tokens)
+        fmt_count(report.stats.estimated_tokens)
     );
 
-    if stats.total_chunks > 0 {
+    if report.stats.total_chunks > 0 {
         println!(
             "  avg chunk: {} chars, ~{} tokens",
-            stats.total_chars / stats.total_chunks,
-            stats.estimated_tokens / stats.total_chunks
+            report.stats.total_chars / report.stats.total_chunks,
+            report.stats.estimated_tokens / report.stats.total_chunks
         );
         println!(
             "  chunk range: {}..{} chars",
-            stats.min_chunk_chars, stats.max_chunk_chars
+            report.stats.min_chunk_chars, report.stats.max_chunk_chars
         );
     }
 
-    if let Some(metadata) = metadata {
+    if let Some(metadata) = &report.metadata {
         println!(
             "  embedding: {} (dim {})",
             metadata.embed_model, metadata.embedding_dim
@@ -82,15 +121,18 @@ pub async fn run(name: Option<&str>) -> Result<()> {
         println!("  embedding: metadata missing");
     }
 
-    println!("  disk usage: {}", fmt_bytes(total_store_bytes));
-    println!("    lancedb: {}", fmt_bytes(lancedb_bytes));
-    println!("    meta: {}", fmt_bytes(meta_bytes));
-    println!("    cache: {}", fmt_bytes(cache_bytes));
-    println!("    models: {}", fmt_bytes(models_bytes));
+    println!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
+    println!(
+        "    lancedb: {}",
+        fmt_bytes(report.disk_usage.lancedb_bytes)
+    );
+    println!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
+    println!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
+    println!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
 
-    if !stats.top_sources.is_empty() {
+    if !report.stats.top_sources.is_empty() {
         println!("  top sources by chunk count:");
-        for source in &stats.top_sources {
+        for source in &report.stats.top_sources {
             println!(
                 "    - {}  [{} chunks, ~{} tokens]",
                 source.source_path,
@@ -99,8 +141,6 @@ pub async fn run(name: Option<&str>) -> Result<()> {
             );
         }
     }
-
-    Ok(())
 }
 
 pub fn dir_size_bytes(path: &Path) -> Result<u64> {
@@ -181,10 +221,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_run_succeeds_on_empty_store() {
+    async fn test_build_report_supports_empty_store() {
         let dir = tempfile::tempdir().unwrap();
         with_test_env(dir.path(), None, || async {
-            run(Some("empty")).await.unwrap();
+            let report = build_report(Some("empty")).await.unwrap();
+            assert_eq!(report.stats.total_chunks, 0);
+            assert!(serde_json::to_string(&report)
+                .unwrap()
+                .contains("\"stats\""));
         })
         .await;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ impl Default for Config {
 }
 
 /// Indicates where a resolved config value came from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ConfigValueSource {
     /// The value came from the store config file.
     File,
@@ -104,7 +104,7 @@ pub enum ConfigValueSource {
 }
 
 /// Tracks the source of config values after environment overrides are applied.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ConfigSources {
     /// Source of `ollama.base_url`.
     pub ollama_base_url: ConfigValueSource,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_STORE_NAME: &str = "default";
+pub const STORE_SUBDIRECTORIES: [&str; 4] = ["lancedb", "meta", "cache", "models"];
 pub const ENV_OLLAMA_URL: &str = "RAGCLI_OLLAMA_URL";
 pub const ENV_EMBED_MODEL: &str = "RAGCLI_EMBED_MODEL";
 pub const ENV_CHAT_MODEL: &str = "RAGCLI_CHAT_MODEL";
@@ -167,10 +168,9 @@ pub fn config_path(store: &Path) -> PathBuf {
 
 /// Ensures the on-disk directory layout for a store exists.
 pub fn ensure_store_layout(store: &Path) -> Result<()> {
-    fs::create_dir_all(store.join("lancedb"))?;
-    fs::create_dir_all(store.join("meta"))?;
-    fs::create_dir_all(store.join("cache"))?;
-    fs::create_dir_all(store.join("models"))?;
+    for subdirectory in STORE_SUBDIRECTORIES {
+        fs::create_dir_all(store.join(subdirectory))?;
+    }
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,7 @@ impl Default for Config {
 
 /// Indicates where a resolved config value came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", content = "env_var")]
 pub enum ConfigValueSource {
     /// The value came from the store config file.
     File,
@@ -447,6 +448,18 @@ overlap = 200
                 format!("ollama.base_url <- {}", ENV_OLLAMA_URL),
                 format!("models.chat <- {}", ENV_CHAT_MODEL),
             ]
+        );
+    }
+
+    #[test]
+    fn test_config_value_source_serializes_with_consistent_shape() {
+        let file = serde_json::to_value(ConfigValueSource::File).unwrap();
+        let env = serde_json::to_value(ConfigValueSource::Env(ENV_CHAT_MODEL)).unwrap();
+
+        assert_eq!(file, serde_json::json!({"kind": "File"}));
+        assert_eq!(
+            env,
+            serde_json::json!({"kind": "Env", "env_var": ENV_CHAT_MODEL})
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -62,7 +62,7 @@ pub struct StoreMetadata {
 }
 
 /// Counts of source files by content kind.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub struct ContentKindCounts {
     /// Number of text or Markdown files.
     pub text_files: usize,
@@ -75,7 +75,7 @@ pub struct ContentKindCounts {
 }
 
 /// Per-source chunk statistics.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub struct SourceChunkStat {
     /// Source file path.
     pub source_path: String,
@@ -88,7 +88,7 @@ pub struct SourceChunkStat {
 }
 
 /// Aggregate statistics for a store.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub struct StoreStats {
     /// Total number of stored chunks.
     pub total_chunks: usize,

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -1,0 +1,29 @@
+use serde_json::Value;
+use std::process::Command;
+
+#[test]
+fn test_config_show_json_outputs_machine_readable_report() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ragcli"))
+        .args(["config", "show", "--json"])
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("RAGCLI_CHAT_MODEL", "test-chat")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let report: Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(report["config"]["models"]["chat"], "test-chat");
+    assert_eq!(report["sources"]["models_chat"]["kind"], "Env");
+    assert_eq!(
+        report["sources"]["models_chat"]["env_var"],
+        "RAGCLI_CHAT_MODEL"
+    );
+    assert_eq!(
+        report["active_overrides"][0],
+        "models.chat <- RAGCLI_CHAT_MODEL"
+    );
+}


### PR DESCRIPTION
## Summary
- add `--json` output for `stat`, `doctor`, and `config show`
- build typed report structs before printing so command logic is less coupled to stdout
- keep the existing human-readable output as the default and add tests for the new JSON paths

## Testing
- cargo test -q

Closes #10