### PR TITLE
feat(index): skip unchanged files during re-indexing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             pdf_parser,
             exclude,
             include_hidden,
+            force,
         } => {
             commands::index::run(
                 name,
@@ -24,6 +25,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 pdf_parser,
                 exclude,
                 include_hidden,
+                force,
             )
             .await?
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,9 @@ pub enum Command {
         /// Includes hidden files and directories during traversal.
         #[arg(long, default_value_t = false)]
         include_hidden: bool,
+        /// Re-embeds files even when their stored fingerprint is unchanged.
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
     /// Queries the local store and generates an answer.
     Query {
@@ -224,6 +227,18 @@ mod tests {
                 assert_eq!(max_iterations, 2);
             }
             command => panic!("expected query command, got {command:?}"),
+        }
+    }
+
+    #[test]
+    fn test_index_force_flag_parses() {
+        let cli = Cli::try_parse_from(["ragcli", "index", "./docs", "--force"]).unwrap();
+        match cli.command {
+            Command::Index { path, force, .. } => {
+                assert_eq!(path, PathBuf::from("./docs"));
+                assert!(force);
+            }
+            command => panic!("expected index command, got {command:?}"),
         }
     }
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -5,7 +5,7 @@ use crate::config::{
 };
 use crate::ingest::{ingest_path, PdfParser};
 use crate::models::{Embedder, VisionCaptioner};
-use crate::store::{connect_db, ensure_metadata, replace_source_rows};
+use crate::store::{connect_db, ensure_metadata, load_source_fingerprints, replace_source_rows};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -19,6 +19,7 @@ pub async fn run(
     pdf_parser: Option<PdfParserArg>,
     exclude: Vec<String>,
     include_hidden: bool,
+    force: bool,
 ) -> Result<()> {
     let started = Instant::now();
     let store = store_dir(name)?;
@@ -37,6 +38,12 @@ pub async fn run(
         cfg.ollama.base_url.clone(),
         resolve_model_name(&store, &cfg.models.vision),
     );
+    let db = connect_db(&store).await?;
+    let existing_fingerprints = if force {
+        Default::default()
+    } else {
+        load_source_fingerprints(&db).await?
+    };
     let result = ingest_path(
         &path,
         size,
@@ -49,6 +56,8 @@ pub async fn run(
         },
         &exclude,
         include_hidden,
+        &existing_fingerprints,
+        force,
     )
     .await?;
 
@@ -56,8 +65,9 @@ pub async fn run(
         ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
     }
 
-    let db = connect_db(&store).await?;
-    replace_source_rows(&db, &result.rows, &result.source_paths).await?;
+    if !result.source_paths.is_empty() {
+        replace_source_rows(&db, &result.rows, &result.source_paths).await?;
+    }
 
     println!("Index complete");
     println!("  store: {}", store.display());
@@ -81,7 +91,10 @@ pub async fn run(
 mod tests {
     use super::*;
     use crate::commands::stat;
+    use crate::store::{connect_db, extract_contexts, DEFAULT_TABLE_NAME};
     use crate::test_support::{sequential_json_server, with_test_env};
+    use futures::TryStreamExt;
+    use lancedb::query::ExecutableQuery;
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_run_indexes_file_with_mock_ollama() {
@@ -102,10 +115,123 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                false,
             )
             .await
             .unwrap();
             stat::run(Some("e2e"), false).await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_skips_unchanged_file_without_reembedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        let input = docs.join("note.txt");
+        std::fs::write(&input, "The project is a local RAG CLI.").unwrap();
+
+        let first_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
+        with_test_env(dir.path(), Some(&first_server), || async {
+            run(
+                Some("e2e"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        with_test_env(dir.path(), Some("http://127.0.0.1:9"), || async {
+            run(
+                Some("e2e"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_replaces_rows_when_file_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        let input = docs.join("note.txt");
+        std::fs::write(&input, "old content").unwrap();
+
+        let first_server = sequential_json_server(vec![r#"{"embeddings":[[0.1,0.2]]}"#]);
+        with_test_env(dir.path(), Some(&first_server), || async {
+            run(
+                Some("e2e"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        std::fs::write(&input, "new content").unwrap();
+
+        let second_server = sequential_json_server(vec![r#"{"embeddings":[[0.3,0.4]]}"#]);
+        with_test_env(dir.path(), Some(&second_server), || async {
+            run(
+                Some("e2e"),
+                input.clone(),
+                Some(200),
+                Some(0),
+                None,
+                None,
+                Vec::new(),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("e2e")).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            let table = db.open_table(DEFAULT_TABLE_NAME).execute().await.unwrap();
+            let batches = table
+                .query()
+                .execute()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let contexts = extract_contexts(&batches).unwrap();
+
+            assert_eq!(contexts.len(), 1);
+            assert!(contexts[0].contains("new content"));
+            assert!(!contexts[0].contains("old content"));
         })
         .await;
     }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -904,6 +904,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                false,
             )
             .await
             .unwrap();
@@ -966,6 +967,7 @@ mod tests {
                 None,
                 None,
                 Vec::new(),
+                false,
                 false,
             )
             .await
@@ -1030,6 +1032,7 @@ mod tests {
                 None,
                 None,
                 Vec::new(),
+                false,
                 false,
             )
             .await
@@ -1212,6 +1215,7 @@ mod tests {
                 None,
                 None,
                 Vec::new(),
+                false,
                 false,
             )
             .await

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2,7 +2,7 @@
 
 use crate::models::{Embedder, VisionCaptioner};
 use crate::source_kind::SourceKind;
-use crate::store::ChunkRow;
+use crate::store::{ChunkRow, SourceFingerprint};
 use anyhow::{Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -14,6 +14,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::UNIX_EPOCH;
 use walkdir::{DirEntry, WalkDir};
 
 /// Aggregated indexing counters for a single ingest run.
@@ -74,7 +75,7 @@ pub async fn ingest_path(
     pdf_parser: PdfParser,
     exclude_patterns: &[String],
     include_hidden: bool,
-    existing_fingerprints: &BTreeMap<String, String>,
+    existing_fingerprints: &BTreeMap<String, SourceFingerprint>,
     force: bool,
 ) -> Result<IngestResult> {
     let options = build_ingest_options(exclude_patterns, include_hidden)?;
@@ -99,7 +100,31 @@ pub async fn ingest_path(
         }
 
         let source_path = file.display().to_string();
-        let source_fingerprint = match fingerprint_path(&file) {
+        let source_state = match source_file_state(&file) {
+            Ok(state) => state,
+            Err(err) => {
+                stats.skipped_files += 1;
+                stats.errors.push(format!("{}: {}", file.display(), err));
+                progress.inc(1);
+                continue;
+            }
+        };
+
+        if !force
+            && existing_fingerprints
+                .get(&source_path)
+                .is_some_and(|existing| {
+                    existing.size_bytes == source_state.size_bytes
+                        && existing.modified_unix_ms == source_state.modified_unix_ms
+                })
+        {
+            stats.skipped_files += 1;
+            progress.set_message(format!("Skipping unchanged {}", display_name(&file)));
+            progress.inc(1);
+            continue;
+        }
+
+        let source_fingerprint = match fingerprint_path(&file, source_state) {
             Ok(fingerprint) => fingerprint,
             Err(err) => {
                 stats.skipped_files += 1;
@@ -112,7 +137,7 @@ pub async fn ingest_path(
         if !force
             && existing_fingerprints
                 .get(&source_path)
-                .is_some_and(|fingerprint| fingerprint == &source_fingerprint)
+                .is_some_and(|existing| existing == &source_fingerprint)
         {
             stats.skipped_files += 1;
             progress.set_message(format!("Skipping unchanged {}", display_name(&file)));
@@ -267,7 +292,7 @@ async fn extract_units(
 
 async fn embed_units(
     path: &Path,
-    source_fingerprint: &str,
+    source_fingerprint: &SourceFingerprint,
     units: Vec<ExtractedUnit>,
     embedder: &Embedder,
     dim: &mut Option<usize>,
@@ -300,7 +325,7 @@ async fn embed_units(
 
 async fn embed_chunks(
     path: &Path,
-    source_fingerprint: &str,
+    source_fingerprint: &SourceFingerprint,
     page_num: i32,
     chunks: Vec<ChunkContent>,
     embedder: &Embedder,
@@ -317,7 +342,18 @@ async fn embed_chunks(
         if let Some(obj) = metadata.as_object_mut() {
             obj.insert("source".to_string(), json!(path.display().to_string()));
             obj.insert("page".to_string(), json!(page_num));
-            obj.insert("source_fingerprint".to_string(), json!(source_fingerprint));
+            obj.insert(
+                "source_fingerprint".to_string(),
+                json!(source_fingerprint.fingerprint),
+            );
+            obj.insert(
+                "source_size_bytes".to_string(),
+                json!(source_fingerprint.size_bytes),
+            );
+            obj.insert(
+                "source_modified_unix_ms".to_string(),
+                json!(source_fingerprint.modified_unix_ms),
+            );
         }
         let format = metadata
             .get("format")
@@ -396,7 +432,24 @@ fn is_hidden_path(path: &Path) -> bool {
         .map(|name| name.to_string_lossy().starts_with('.'))
         .unwrap_or(false)
 }
-fn fingerprint_path(path: &Path) -> Result<String> {
+fn source_file_state(path: &Path) -> Result<SourceFingerprint> {
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("read file metadata for fingerprinting: {}", path.display()))?;
+    let modified_unix_ms = metadata
+        .modified()
+        .with_context(|| format!("read file mtime for fingerprinting: {}", path.display()))?
+        .duration_since(UNIX_EPOCH)
+        .with_context(|| format!("file mtime predates unix epoch: {}", path.display()))?
+        .as_millis() as u64;
+
+    Ok(SourceFingerprint {
+        fingerprint: String::new(),
+        size_bytes: metadata.len(),
+        modified_unix_ms,
+    })
+}
+
+fn fingerprint_path(path: &Path, source_state: SourceFingerprint) -> Result<SourceFingerprint> {
     let mut file = fs::File::open(path)
         .with_context(|| format!("open file for fingerprinting: {}", path.display()))?;
     let mut hasher = Sha256::new();
@@ -412,7 +465,10 @@ fn fingerprint_path(path: &Path) -> Result<String> {
         hasher.update(&buffer[..read]);
     }
 
-    Ok(to_hex(&hasher.finalize()))
+    Ok(SourceFingerprint {
+        fingerprint: to_hex(&hasher.finalize()),
+        ..source_state
+    })
 }
 
 fn load_text_file(path: &Path) -> Result<String> {
@@ -1239,10 +1295,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("note.txt");
         fs::write(&path, "hello").unwrap();
-        let first = fingerprint_path(&path).unwrap();
+        let first = fingerprint_path(&path, source_file_state(&path).unwrap()).unwrap();
 
         fs::write(&path, "jello").unwrap();
-        let second = fingerprint_path(&path).unwrap();
+        let second = fingerprint_path(&path, source_file_state(&path).unwrap()).unwrap();
 
         assert_ne!(first, second);
     }
@@ -1347,7 +1403,11 @@ mod tests {
         fs::write(&text, "hello world").unwrap();
 
         let mut existing_fingerprints = BTreeMap::new();
-        existing_fingerprints.insert(text.display().to_string(), fingerprint_path(&text).unwrap());
+        let source_state = source_file_state(&text).unwrap();
+        existing_fingerprints.insert(
+            text.display().to_string(),
+            fingerprint_path(&text, source_state).unwrap(),
+        );
 
         let embedder = Embedder::new("http://127.0.0.1:9".to_string(), "embed".to_string());
         let result = ingest_path(
@@ -1367,6 +1427,44 @@ mod tests {
 
         assert!(result.rows.is_empty());
         assert!(result.source_paths.is_empty());
+        assert_eq!(result.stats.indexed_files, 0);
+        assert_eq!(result.stats.skipped_files, 1);
+        assert!(result.stats.errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_ingest_path_skips_by_size_and_mtime_before_hashing() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = dir.path().join("note.txt");
+        fs::write(&text, "hello world").unwrap();
+
+        let source_state = source_file_state(&text).unwrap();
+        let mut existing_fingerprints = BTreeMap::new();
+        existing_fingerprints.insert(
+            text.display().to_string(),
+            SourceFingerprint {
+                fingerprint: "stale-fingerprint".to_string(),
+                ..source_state
+            },
+        );
+
+        let embedder = Embedder::new("http://127.0.0.1:9".to_string(), "embed".to_string());
+        let result = ingest_path(
+            &text,
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+            &existing_fingerprints,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.rows.is_empty());
         assert_eq!(result.stats.indexed_files, 0);
         assert_eq!(result.stats.skipped_files, 1);
         assert!(result.stats.errors.is_empty());

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -11,6 +11,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use walkdir::{DirEntry, WalkDir};
@@ -396,16 +397,22 @@ fn is_hidden_path(path: &Path) -> bool {
         .unwrap_or(false)
 }
 fn fingerprint_path(path: &Path) -> Result<String> {
-    let metadata =
-        fs::metadata(path).with_context(|| format!("read file metadata: {}", path.display()))?;
-    let modified = metadata
-        .modified()
-        .with_context(|| format!("read file modified time: {}", path.display()))?;
-    let modified = modified
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    Ok(format!("{}-{modified}", metadata.len()))
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("open file for fingerprinting: {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("read file for fingerprinting: {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(to_hex(&hasher.finalize()))
 }
 
 fn load_text_file(path: &Path) -> Result<String> {
@@ -1228,14 +1235,13 @@ mod tests {
     }
 
     #[test]
-    fn test_fingerprint_path_changes_when_file_changes() {
+    fn test_fingerprint_path_changes_when_file_content_changes() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("note.txt");
         fs::write(&path, "hello").unwrap();
         let first = fingerprint_path(&path).unwrap();
 
-        std::thread::sleep(std::time::Duration::from_millis(2));
-        fs::write(&path, "hello world").unwrap();
+        fs::write(&path, "jello").unwrap();
         let second = fingerprint_path(&path).unwrap();
 
         assert_ne!(first, second);

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,7 +9,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use pdf_extract::extract_text_by_pages;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -73,6 +73,8 @@ pub async fn ingest_path(
     pdf_parser: PdfParser,
     exclude_patterns: &[String],
     include_hidden: bool,
+    existing_fingerprints: &BTreeMap<String, String>,
+    force: bool,
 ) -> Result<IngestResult> {
     let options = build_ingest_options(exclude_patterns, include_hidden)?;
     let files = collect_files(path, &options)?;
@@ -95,14 +97,45 @@ pub async fn ingest_path(
             continue;
         }
 
-        source_paths.insert(file.display().to_string());
+        let source_path = file.display().to_string();
+        let source_fingerprint = match fingerprint_path(&file) {
+            Ok(fingerprint) => fingerprint,
+            Err(err) => {
+                stats.skipped_files += 1;
+                stats.errors.push(format!("{}: {}", file.display(), err));
+                progress.inc(1);
+                continue;
+            }
+        };
+
+        if !force
+            && existing_fingerprints
+                .get(&source_path)
+                .is_some_and(|fingerprint| fingerprint == &source_fingerprint)
+        {
+            stats.skipped_files += 1;
+            progress.set_message(format!("Skipping unchanged {}", display_name(&file)));
+            progress.inc(1);
+            continue;
+        }
+
+        source_paths.insert(source_path);
 
         match extract_units(
             &file, kind, chunk_size, overlap, vision, pdf_parser, &progress,
         )
         .await
         {
-            Ok(units) => match embed_units(&file, units, embedder, &mut dim, &progress).await {
+            Ok(units) => match embed_units(
+                &file,
+                &source_fingerprint,
+                units,
+                embedder,
+                &mut dim,
+                &progress,
+            )
+            .await
+            {
                 Ok(mut file_rows) => {
                     stats.indexed_files += 1;
                     stats.total_chunks += file_rows.len();
@@ -233,6 +266,7 @@ async fn extract_units(
 
 async fn embed_units(
     path: &Path,
+    source_fingerprint: &str,
     units: Vec<ExtractedUnit>,
     embedder: &Embedder,
     dim: &mut Option<usize>,
@@ -249,7 +283,15 @@ async fn embed_units(
         } else {
             progress.set_message(format!("Embedding {}", display_name(path)));
         }
-        let mut unit_rows = embed_chunks(path, unit.page_num, unit.chunks, embedder, dim).await?;
+        let mut unit_rows = embed_chunks(
+            path,
+            source_fingerprint,
+            unit.page_num,
+            unit.chunks,
+            embedder,
+            dim,
+        )
+        .await?;
         rows.append(&mut unit_rows);
     }
     Ok(rows)
@@ -257,6 +299,7 @@ async fn embed_units(
 
 async fn embed_chunks(
     path: &Path,
+    source_fingerprint: &str,
     page_num: i32,
     chunks: Vec<ChunkContent>,
     embedder: &Embedder,
@@ -273,6 +316,7 @@ async fn embed_chunks(
         if let Some(obj) = metadata.as_object_mut() {
             obj.insert("source".to_string(), json!(path.display().to_string()));
             obj.insert("page".to_string(), json!(page_num));
+            obj.insert("source_fingerprint".to_string(), json!(source_fingerprint));
         }
         let format = metadata
             .get("format")
@@ -351,6 +395,19 @@ fn is_hidden_path(path: &Path) -> bool {
         .map(|name| name.to_string_lossy().starts_with('.'))
         .unwrap_or(false)
 }
+fn fingerprint_path(path: &Path) -> Result<String> {
+    let metadata =
+        fs::metadata(path).with_context(|| format!("read file metadata: {}", path.display()))?;
+    let modified = metadata
+        .modified()
+        .with_context(|| format!("read file modified time: {}", path.display()))?;
+    let modified = modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    Ok(format!("{}-{modified}", metadata.len()))
+}
+
 fn load_text_file(path: &Path) -> Result<String> {
     let bytes = fs::read(path)?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
@@ -1170,6 +1227,20 @@ mod tests {
         assert_eq!(to_hex(&[0x0f, 0xa0]), "0fa0");
     }
 
+    #[test]
+    fn test_fingerprint_path_changes_when_file_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.txt");
+        fs::write(&path, "hello").unwrap();
+        let first = fingerprint_path(&path).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        fs::write(&path, "hello world").unwrap();
+        let second = fingerprint_path(&path).unwrap();
+
+        assert_ne!(first, second);
+    }
+
     #[tokio::test]
     async fn test_ingest_path_skips_image_without_vision_model() {
         let dir = tempfile::tempdir().unwrap();
@@ -1185,6 +1256,8 @@ mod tests {
             None,
             PdfParser::Native,
             &[],
+            false,
+            &BTreeMap::new(),
             false,
         )
         .await
@@ -1204,9 +1277,20 @@ mod tests {
         fs::write(&pdf, b"not a real pdf").unwrap();
 
         let embedder = Embedder::new("http://unused".to_string(), "embed".to_string());
-        let result = ingest_path(&pdf, 100, 0, &embedder, None, PdfParser::Native, &[], false)
-            .await
-            .unwrap();
+        let result = ingest_path(
+            &pdf,
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+            &BTreeMap::new(),
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(result.rows.is_empty());
         assert_eq!(result.stats.indexed_files, 0);
@@ -1235,6 +1319,8 @@ mod tests {
             PdfParser::Native,
             &[],
             false,
+            &BTreeMap::new(),
+            false,
         )
         .await
         .unwrap();
@@ -1246,6 +1332,38 @@ mod tests {
         assert!(result.rows[0].chunk_text.contains("Guide"));
         assert!(result.rows[0].chunk_text.contains("Hello world."));
         assert!(result.rows[0].metadata.contains("\"format\":\"html\""));
+    }
+
+    #[tokio::test]
+    async fn test_ingest_path_skips_unchanged_files_without_embedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = dir.path().join("note.txt");
+        fs::write(&text, "hello world").unwrap();
+
+        let mut existing_fingerprints = BTreeMap::new();
+        existing_fingerprints.insert(text.display().to_string(), fingerprint_path(&text).unwrap());
+
+        let embedder = Embedder::new("http://127.0.0.1:9".to_string(), "embed".to_string());
+        let result = ingest_path(
+            &text,
+            100,
+            0,
+            &embedder,
+            None,
+            PdfParser::Native,
+            &[],
+            false,
+            &existing_fingerprints,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.rows.is_empty());
+        assert!(result.source_paths.is_empty());
+        assert_eq!(result.stats.indexed_files, 0);
+        assert_eq!(result.stats.skipped_files, 1);
+        assert!(result.stats.errors.is_empty());
     }
 
     #[tokio::test]
@@ -1264,6 +1382,8 @@ mod tests {
             None,
             PdfParser::Native,
             &[],
+            false,
+            &BTreeMap::new(),
             false,
         )
         .await

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,7 +12,7 @@ use lancedb::index::scalar::FtsIndexBuilder;
 use lancedb::index::Index;
 use lancedb::index::IndexType;
 use lancedb::query::{ExecutableQuery, QueryBase, Select};
-use lancedb::{connect, Connection, Table};
+use lancedb::{connect, Connection, Error as LanceDbError, Table};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -191,7 +191,8 @@ pub fn ensure_metadata(
 pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String, String>> {
     let table = match db.open_table(DEFAULT_TABLE_NAME).execute().await {
         Ok(table) => table,
-        Err(_) => return Ok(BTreeMap::new()),
+        Err(LanceDbError::TableNotFound { .. }) => return Ok(BTreeMap::new()),
+        Err(err) => return Err(err.into()),
     };
     let batches: Vec<RecordBatch> = table
         .query()

--- a/src/store.rs
+++ b/src/store.rs
@@ -194,16 +194,14 @@ pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String
         Err(LanceDbError::TableNotFound { .. }) => return Ok(BTreeMap::new()),
         Err(err) => return Err(err.into()),
     };
-    let batches: Vec<RecordBatch> = table
+    let mut stream = table
         .query()
         .select(Select::columns(&["source_path", "metadata"]))
         .execute()
-        .await?
-        .try_collect::<Vec<_>>()
         .await?;
 
     let mut fingerprints = BTreeMap::new();
-    for batch in &batches {
+    while let Some(batch) = stream.try_next().await? {
         let source_col = batch
             .column_by_name("source_path")
             .context("source_path column missing")?
@@ -219,6 +217,10 @@ pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String
 
         for row_idx in 0..batch.num_rows() {
             let source = source_col.value(row_idx);
+            if fingerprints.contains_key(source) {
+                continue;
+            }
+
             let Ok(metadata): Result<serde_json::Value, _> =
                 serde_json::from_str(metadata_col.value(row_idx))
             else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,10 +6,12 @@ use anyhow::{bail, Context, Result};
 use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema};
+use futures::TryStreamExt;
 use lancedb::database::CreateTableMode;
 use lancedb::index::scalar::FtsIndexBuilder;
 use lancedb::index::Index;
 use lancedb::index::IndexType;
+use lancedb::query::{ExecutableQuery, QueryBase, Select};
 use lancedb::{connect, Connection, Table};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -186,6 +188,56 @@ pub fn ensure_metadata(
 }
 
 /// Replaces all rows for the provided source paths and inserts fresh rows.
+pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String, String>> {
+    let table = match db.open_table(DEFAULT_TABLE_NAME).execute().await {
+        Ok(table) => table,
+        Err(_) => return Ok(BTreeMap::new()),
+    };
+    let batches: Vec<RecordBatch> = table
+        .query()
+        .select(Select::columns(&["source_path", "metadata"]))
+        .execute()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let mut fingerprints = BTreeMap::new();
+    for batch in &batches {
+        let source_col = batch
+            .column_by_name("source_path")
+            .context("source_path column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("source_path column type")?;
+        let metadata_col = batch
+            .column_by_name("metadata")
+            .context("metadata column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("metadata column type")?;
+
+        for row_idx in 0..batch.num_rows() {
+            let source = source_col.value(row_idx);
+            let Ok(metadata): Result<serde_json::Value, _> =
+                serde_json::from_str(metadata_col.value(row_idx))
+            else {
+                continue;
+            };
+            let Some(fingerprint) = metadata
+                .get("source_fingerprint")
+                .and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            fingerprints
+                .entry(source.to_string())
+                .or_insert_with(|| fingerprint.to_string());
+        }
+    }
+
+    Ok(fingerprints)
+}
+
 pub async fn replace_source_rows(
     db: &Connection,
     rows: &[ChunkRow],
@@ -510,6 +562,33 @@ mod tests {
             metadata: "{}".to_string(),
             embedding: vec![value, value],
         }
+    }
+
+    #[tokio::test]
+    async fn test_load_source_fingerprints_reads_metadata_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = connect_db(dir.path()).await.unwrap();
+
+        replace_source_rows(
+            &db,
+            &[
+                ChunkRow {
+                    metadata: r#"{"source_fingerprint":"fp-a"}"#.to_string(),
+                    ..sample_row("a.txt", "alpha", 1.0)
+                },
+                ChunkRow {
+                    metadata: r#"{"source_fingerprint":"fp-b"}"#.to_string(),
+                    ..sample_row("b.txt", "beta", 2.0)
+                },
+            ],
+            &["a.txt".to_string(), "b.txt".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let fingerprints = load_source_fingerprints(&db).await.unwrap();
+        assert_eq!(fingerprints.get("a.txt"), Some(&"fp-a".to_string()));
+        assert_eq!(fingerprints.get("b.txt"), Some(&"fp-b".to_string()));
     }
 
     #[tokio::test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,6 +63,17 @@ pub struct StoreMetadata {
     pub chunk_overlap: usize,
 }
 
+/// Per-source change detection data loaded from stored chunk metadata.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SourceFingerprint {
+    /// Stable content fingerprint for the source file.
+    pub fingerprint: String,
+    /// Source file size in bytes at indexing time.
+    pub size_bytes: u64,
+    /// Source file modification time in Unix milliseconds at indexing time.
+    pub modified_unix_ms: u64,
+}
+
 /// Counts of source files by content kind.
 #[derive(Debug, Default, Serialize)]
 pub struct ContentKindCounts {
@@ -187,8 +198,10 @@ pub fn ensure_metadata(
     Ok(())
 }
 
-/// Replaces all rows for the provided source paths and inserts fresh rows.
-pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String, String>> {
+/// Loads stored per-source fingerprint data from chunk metadata.
+pub async fn load_source_fingerprints(
+    db: &Connection,
+) -> Result<BTreeMap<String, SourceFingerprint>> {
     let table = match db.open_table(DEFAULT_TABLE_NAME).execute().await {
         Ok(table) => table,
         Err(LanceDbError::TableNotFound { .. }) => return Ok(BTreeMap::new()),
@@ -232,9 +245,19 @@ pub async fn load_source_fingerprints(db: &Connection) -> Result<BTreeMap<String
             else {
                 continue;
             };
-            fingerprints
-                .entry(source.to_string())
-                .or_insert_with(|| fingerprint.to_string());
+            let size_bytes = metadata
+                .get("source_size_bytes")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default();
+            let modified_unix_ms = metadata
+                .get("source_modified_unix_ms")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default();
+            fingerprints.entry(source.to_string()).or_insert_with(|| SourceFingerprint {
+                fingerprint: fingerprint.to_string(),
+                size_bytes,
+                modified_unix_ms,
+            });
         }
     }
 
@@ -590,8 +613,22 @@ mod tests {
         .unwrap();
 
         let fingerprints = load_source_fingerprints(&db).await.unwrap();
-        assert_eq!(fingerprints.get("a.txt"), Some(&"fp-a".to_string()));
-        assert_eq!(fingerprints.get("b.txt"), Some(&"fp-b".to_string()));
+        assert_eq!(
+            fingerprints.get("a.txt"),
+            Some(&SourceFingerprint {
+                fingerprint: "fp-a".to_string(),
+                size_bytes: 0,
+                modified_unix_ms: 0,
+            })
+        );
+        assert_eq!(
+            fingerprints.get("b.txt"),
+            Some(&SourceFingerprint {
+                fingerprint: "fp-b".to_string(),
+                size_bytes: 0,
+                modified_unix_ms: 0,
+            })
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- skip unchanged files during indexing by comparing stored source fingerprints
- add `--force` to bypass the optimization and re-embed all files
- cover unchanged, changed, and fingerprint-loading paths with tests

Closes #14