### PR TITLE
feat: add structured tracing logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,8 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
  "xdg",
 ]
@@ -6086,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ xdg = "2"
 # Arrow types for constructing record batches.
 arrow-array = "57"
 arrow-schema = "57"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 reqwest-middleware = "0.4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,26 +1,17 @@
 use crate::cli::{Cli, Command, ConfigCommand};
 use crate::commands;
 use anyhow::Result;
+use tracing::Instrument;
 
 pub async fn run(cli: Cli) -> Result<()> {
     let name = cli.name.as_deref();
     let span_name = name.unwrap_or("default");
     tracing::info!(name = span_name, "starting ragcli");
-    let span = tracing::info_span!("command dispatch", name = span_name);
-    let _guard = span.enter();
+    let span = tracing::info_span!("command_dispatch", name = span_name);
 
-    match cli.command {
-        Command::Index {
-            path,
-            chunk_size,
-            chunk_overlap,
-            embed_model,
-            pdf_parser,
-            exclude,
-            include_hidden,
-        } => {
-            commands::index::run(
-                name,
+    async move {
+        match cli.command {
+            Command::Index {
                 path,
                 chunk_size,
                 chunk_overlap,
@@ -28,61 +19,76 @@ pub async fn run(cli: Cli) -> Result<()> {
                 pdf_parser,
                 exclude,
                 include_hidden,
-            )
-            .await?
+            } => {
+                commands::index::run(
+                    name,
+                    path,
+                    chunk_size,
+                    chunk_overlap,
+                    embed_model,
+                    pdf_parser,
+                    exclude,
+                    include_hidden,
+                )
+                .await?
+            }
+            Command::Query {
+                question,
+                mode,
+                top_k,
+                fetch_k,
+                max_iterations,
+                rewrite,
+                rerank,
+                show_context,
+                show_plan,
+                show_scores,
+                show_citations,
+                show_trace,
+                source,
+                path_prefix,
+                page,
+                format,
+                gen_model,
+                max_tokens,
+            } => {
+                commands::query::run(
+                    name,
+                    commands::query::QueryCommand {
+                        question,
+                        mode,
+                        top_k,
+                        fetch_k,
+                        max_iterations,
+                        rewrite,
+                        rerank,
+                        show_context,
+                        show_plan,
+                        show_scores,
+                        show_citations,
+                        show_trace,
+                        source,
+                        path_prefix,
+                        page,
+                        format,
+                        gen_model,
+                        max_tokens,
+                    },
+                )
+                .await?
+            }
+            Command::Config { command } => match command {
+                ConfigCommand::Show { json } => commands::config::show(name, json).await?,
+                ConfigCommand::Set { key, value } => {
+                    commands::config::set(name, key, value).await?
+                }
+            },
+            Command::Stat { json } => commands::stat::run(name, json).await?,
+            Command::Doctor { json } => commands::doctor::run(name, json).await?,
         }
-        Command::Query {
-            question,
-            mode,
-            top_k,
-            fetch_k,
-            max_iterations,
-            rewrite,
-            rerank,
-            show_context,
-            show_plan,
-            show_scores,
-            show_citations,
-            show_trace,
-            source,
-            path_prefix,
-            page,
-            format,
-            gen_model,
-            max_tokens,
-        } => {
-            commands::query::run(
-                name,
-                commands::query::QueryCommand {
-                    question,
-                    mode,
-                    top_k,
-                    fetch_k,
-                    max_iterations,
-                    rewrite,
-                    rerank,
-                    show_context,
-                    show_plan,
-                    show_scores,
-                    show_citations,
-                    show_trace,
-                    source,
-                    path_prefix,
-                    page,
-                    format,
-                    gen_model,
-                    max_tokens,
-                },
-            )
-            .await?
-        }
-        Command::Config { command } => match command {
-            ConfigCommand::Show { json } => commands::config::show(name, json).await?,
-            ConfigCommand::Set { key, value } => commands::config::set(name, key, value).await?,
-        },
-        Command::Stat { json } => commands::stat::run(name, json).await?,
-        Command::Doctor { json } => commands::doctor::run(name, json).await?,
-    }
 
-    Ok(())
+        Ok(())
+    }
+    .instrument(span)
+    .await
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,10 @@ use anyhow::Result;
 pub async fn run(cli: Cli) -> Result<()> {
     let name = cli.name.as_deref();
 
+    tracing::info!(name = name.unwrap_or("default"), "starting ragcli");
+    let span = tracing::info_span!("command dispatch", name = name.unwrap_or("default"));
+    let _guard = span.enter();
+
     match cli.command {
         Command::Index {
             path,

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 
 pub async fn run(cli: Cli) -> Result<()> {
     let name = cli.name.as_deref();
-
-    tracing::info!(name = name.unwrap_or("default"), "starting ragcli");
-    let span = tracing::info_span!("command dispatch", name = name.unwrap_or("default"));
+    let span_name = name.unwrap_or("default");
+    tracing::info!(name = span_name, "starting ragcli");
+    let span = tracing::info_span!("command dispatch", name = span_name);
     let _guard = span.enter();
 
     match cli.command {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -137,52 +137,52 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
 }
 
 fn print_human(report: &DoctorReport) {
-    println!("Doctor report");
-    println!("  time: {}", format_unix_timestamp(report.time));
-    println!("  base: {} ({})", report.base.path, report.base.status);
-    println!("  store: {} ({})", report.store.path, report.store.status);
-    println!(
+    tracing::info!("Doctor report");
+    tracing::info!("  time: {}", format_unix_timestamp(report.time));
+    tracing::info!("  base: {} ({})", report.base.path, report.base.status);
+    tracing::info!("  store: {} ({})", report.store.path, report.store.status);
+    tracing::info!(
         "  config: {} ({})",
         report.config.path, report.config.status
     );
-    println!("  ollama url: {}", report.ollama_url);
-    println!("  embed model: {}", report.embed_model);
-    println!("  chat model: {}", report.chat_model);
-    println!("  vision model: {}", report.vision_model);
+    tracing::info!("  ollama url: {}", report.ollama_url);
+    tracing::info!("  embed model: {}", report.embed_model);
+    tracing::info!("  chat model: {}", report.chat_model);
+    tracing::info!("  vision model: {}", report.vision_model);
 
     if report.ollama_reachable {
-        println!("  ollama: reachable");
+        tracing::info!("  ollama: reachable");
         if let Some(installed_models) = &report.installed_models {
-            println!(
+            tracing::info!(
                 "  embed model installed: {}",
                 status(installed_models.embed_model_installed)
             );
-            println!(
+            tracing::info!(
                 "  chat model installed: {}",
                 status(installed_models.chat_model_installed)
             );
-            println!(
+            tracing::info!(
                 "  vision model installed: {}",
                 status(installed_models.vision_model_installed)
             );
         }
     } else if let Some(err) = &report.ollama_error {
-        println!("  ollama: unreachable ({})", err);
+        tracing::error!("  ollama: unreachable ({})", err);
     }
 
-    println!(
+    tracing::info!(
         "  metadata: {} ({})",
         report.metadata.path, report.metadata.status
     );
     if let Some(metadata_summary) = &report.metadata_summary {
-        println!("  metadata summary: {}", metadata_summary);
+        tracing::info!("  metadata summary: {}", metadata_summary);
     }
     if let Some(metadata_error) = &report.metadata_error {
-        println!("  metadata error: {}", metadata_error);
+        tracing::error!("  metadata error: {}", metadata_error);
     }
 
     for subdirectory in &report.subdirectories {
-        println!(
+        tracing::info!(
             "  {}: {} ({})",
             subdirectory.name, subdirectory.path, subdirectory.status
         );

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -137,52 +137,52 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
 }
 
 fn print_human(report: &DoctorReport) {
-    tracing::info!("Doctor report");
-    tracing::info!("  time: {}", format_unix_timestamp(report.time));
-    tracing::info!("  base: {} ({})", report.base.path, report.base.status);
-    tracing::info!("  store: {} ({})", report.store.path, report.store.status);
-    tracing::info!(
+    println!("Doctor report");
+    println!("  time: {}", format_unix_timestamp(report.time));
+    println!("  base: {} ({})", report.base.path, report.base.status);
+    println!("  store: {} ({})", report.store.path, report.store.status);
+    println!(
         "  config: {} ({})",
         report.config.path, report.config.status
     );
-    tracing::info!("  ollama url: {}", report.ollama_url);
-    tracing::info!("  embed model: {}", report.embed_model);
-    tracing::info!("  chat model: {}", report.chat_model);
-    tracing::info!("  vision model: {}", report.vision_model);
+    println!("  ollama url: {}", report.ollama_url);
+    println!("  embed model: {}", report.embed_model);
+    println!("  chat model: {}", report.chat_model);
+    println!("  vision model: {}", report.vision_model);
 
     if report.ollama_reachable {
-        tracing::info!("  ollama: reachable");
+        println!("  ollama: reachable");
         if let Some(installed_models) = &report.installed_models {
-            tracing::info!(
+            println!(
                 "  embed model installed: {}",
                 status(installed_models.embed_model_installed)
             );
-            tracing::info!(
+            println!(
                 "  chat model installed: {}",
                 status(installed_models.chat_model_installed)
             );
-            tracing::info!(
+            println!(
                 "  vision model installed: {}",
                 status(installed_models.vision_model_installed)
             );
         }
     } else if let Some(err) = &report.ollama_error {
-        tracing::error!("  ollama: unreachable ({})", err);
+        eprintln!("  ollama: unreachable ({})", err);
     }
 
-    tracing::info!(
+    println!(
         "  metadata: {} ({})",
         report.metadata.path, report.metadata.status
     );
     if let Some(metadata_summary) = &report.metadata_summary {
-        tracing::info!("  metadata summary: {}", metadata_summary);
+        println!("  metadata summary: {}", metadata_summary);
     }
     if let Some(metadata_error) = &report.metadata_error {
-        tracing::error!("  metadata error: {}", metadata_error);
+        eprintln!("  metadata error: {}", metadata_error);
     }
 
     for subdirectory in &report.subdirectories {
-        tracing::info!(
+        println!(
             "  {}: {} ({})",
             subdirectory.name, subdirectory.path, subdirectory.status
         );

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -37,20 +37,24 @@ pub async fn run(
         cfg.ollama.base_url.clone(),
         resolve_model_name(&store, &cfg.models.vision),
     );
-    let result = ingest_path(
-        &path,
-        size,
-        overlap,
-        &embedder,
-        Some(&vision),
-        match pdf_parser.unwrap_or(PdfParserArg::Native) {
-            PdfParserArg::Native => PdfParser::Native,
-            PdfParserArg::Liteparse => PdfParser::Liteparse,
-        },
-        &exclude,
-        include_hidden,
-    )
-    .await?;
+
+    let span = tracing::info_span!("ingest_path", path = %path.display());
+    let result = span.in_scope(|| async {
+        ingest_path(
+            &path,
+            size,
+            overlap,
+            &embedder,
+            Some(&vision),
+            match pdf_parser.unwrap_or(PdfParserArg::Native) {
+                PdfParserArg::Native => PdfParser::Native,
+                PdfParserArg::Liteparse => PdfParser::Liteparse,
+            },
+            &exclude,
+            include_hidden,
+        )
+        .await
+    }).await?;
 
     if let Some(dim) = result.embedding_dim {
         ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
@@ -59,18 +63,19 @@ pub async fn run(
     let db = connect_db(&store).await?;
     replace_source_rows(&db, &result.rows, &result.source_paths).await?;
 
-    println!("Index complete");
-    println!("  store: {}", store.display());
-    println!("  source: {}", path.display());
-    println!("  indexed files: {}", result.stats.indexed_files);
-    println!("  skipped files: {}", result.stats.skipped_files);
-    println!("  chunks written: {}", result.stats.total_chunks);
-    println!("  elapsed: {:.2?}", started.elapsed());
+    tracing::info!(
+        store = %store.display(),
+        source = %path.display(),
+        indexed_files = result.stats.indexed_files,
+        skipped_files = result.stats.skipped_files,
+        chunks_written = result.stats.total_chunks,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "Index complete"
+    );
 
     if !result.stats.errors.is_empty() {
-        println!("  errors:");
         for err in &result.stats.errors {
-            println!("    - {}", err);
+            tracing::warn!(error = %err, "index error");
         }
     }
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -9,6 +9,7 @@ use crate::store::{connect_db, ensure_metadata, replace_source_rows};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::time::Instant;
+use tracing::Instrument;
 
 pub async fn run(
     name: Option<&str>,
@@ -39,22 +40,21 @@ pub async fn run(
     );
 
     let span = tracing::info_span!("ingest_path", path = %path.display());
-    let result = span.in_scope(|| async {
-        ingest_path(
-            &path,
-            size,
-            overlap,
-            &embedder,
-            Some(&vision),
-            match pdf_parser.unwrap_or(PdfParserArg::Native) {
-                PdfParserArg::Native => PdfParser::Native,
-                PdfParserArg::Liteparse => PdfParser::Liteparse,
-            },
-            &exclude,
-            include_hidden,
-        )
-        .await
-    }).await?;
+    let result = ingest_path(
+        &path,
+        size,
+        overlap,
+        &embedder,
+        Some(&vision),
+        match pdf_parser.unwrap_or(PdfParserArg::Native) {
+            PdfParserArg::Native => PdfParser::Native,
+            PdfParserArg::Liteparse => PdfParser::Liteparse,
+        },
+        &exclude,
+        include_hidden,
+    )
+    .instrument(span)
+    .await?;
 
     if let Some(dim) = result.embedding_dim {
         ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
@@ -63,19 +63,17 @@ pub async fn run(
     let db = connect_db(&store).await?;
     replace_source_rows(&db, &result.rows, &result.source_paths).await?;
 
-    tracing::info!(
-        store = %store.display(),
-        source = %path.display(),
-        indexed_files = result.stats.indexed_files,
-        skipped_files = result.stats.skipped_files,
-        chunks_written = result.stats.total_chunks,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "Index complete"
+    println!(
+        "Index complete: {} files, {} chunks, {} skipped, {}ms",
+        result.stats.indexed_files,
+        result.stats.total_chunks,
+        result.stats.skipped_files,
+        started.elapsed().as_millis()
     );
 
     if !result.stats.errors.is_empty() {
         for err in &result.stats.errors {
-            tracing::warn!(error = %err, "index error");
+            eprintln!("index error: {err}");
         }
     }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -512,24 +512,24 @@ fn print_query_plan(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    tracing::debug!("Query plan:");
-    tracing::debug!("  requested_mode: {}", mode_label(result.requested_mode));
-    tracing::debug!("  execution_path: {}", result.execution_label);
-    tracing::debug!("  top_k: {}", command.top_k);
-    tracing::debug!("  fetch_k: {}", command.fetch_k);
-    tracing::debug!("  max_iterations: {}", command.max_iterations);
-    tracing::debug!("  rewrite: {}", command.rewrite);
-    tracing::debug!("  rerank: {}", command.rerank);
-    tracing::debug!(
+    println!("Query plan:");
+    println!("  requested_mode: {}", mode_label(result.requested_mode));
+    println!("  execution_path: {}", result.execution_label);
+    println!("  top_k: {}", command.top_k);
+    println!("  fetch_k: {}", command.fetch_k);
+    println!("  max_iterations: {}", command.max_iterations);
+    println!("  rewrite: {}", command.rewrite);
+    println!("  rerank: {}", command.rerank);
+    println!(
         "  query_variants: {}",
         result.rewrite_set.query_variants().join(" | ")
     );
     if let Some(plan) = &result.plan {
-        tracing::debug!("  question_type: {}", question_type_label(plan));
-        tracing::debug!("  strategy: {}", strategy_label(plan));
-        tracing::debug!("  reasoning: {}", plan.reasoning);
+        println!("  question_type: {}", question_type_label(plan));
+        println!("  strategy: {}", strategy_label(plan));
+        println!("  reasoning: {}", plan.reasoning);
         if !plan.subqueries.is_empty() {
-            tracing::debug!("  subqueries: {}", plan.subqueries.join(" | "));
+            println!("  subqueries: {}", plan.subqueries.join(" | "));
         }
     }
 }
@@ -539,12 +539,12 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    tracing::debug!("Query trace:");
+    println!("Query trace:");
     for entry in &result.trace {
-        tracing::debug!("  - {entry}");
+        println!("  - {entry}");
     }
     for iteration in &result.iterations {
-        tracing::debug!(
+        println!(
             "  - iteration {} summary: verdict={}, queries={}, kept={}",
             iteration.iteration,
             evidence_verdict_label(&iteration.sufficiency),
@@ -553,7 +553,7 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
         );
     }
     if let Some(check) = &result.support_check {
-        tracing::debug!(
+        println!(
             "  - support_check: {}",
             if check.supported {
                 "supported"
@@ -562,7 +562,7 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
             }
         );
     }
-    tracing::debug!("  - retrieved_hits: {}", result.hits.len());
+    println!("  - retrieved_hits: {}", result.hits.len());
 }
 
 fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -570,9 +570,9 @@ fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    tracing::debug!("Scores:");
+    println!("Scores:");
     for (idx, hit) in result.hits.iter().enumerate() {
-        tracing::debug!(
+        println!(
             "  [{}] best={:.6} fused={} rerank={} {}",
             idx + 1,
             hit.best_score().unwrap_or_default(),
@@ -588,9 +588,9 @@ fn print_citations(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    tracing::debug!("Citations:");
+    println!("Citations:");
     for citation in render_citations(&result.hits) {
-        tracing::debug!("  {citation}");
+        println!("  {citation}");
     }
 }
 
@@ -599,11 +599,11 @@ fn print_contexts(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    tracing::debug!("Retrieved context:");
+    println!("Retrieved context:");
     for (idx, hit) in result.hits.iter().enumerate() {
         let compact = retrieval_context(hit).replace('\n', " ");
         let preview: String = compact.chars().take(220).collect();
-        tracing::debug!("  [{}] {}", idx + 1, preview);
+        println!("  [{}] {}", idx + 1, preview);
     }
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -512,27 +512,26 @@ fn print_query_plan(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    println!("Query plan:");
-    println!("  requested_mode: {}", mode_label(result.requested_mode));
-    println!("  execution_path: {}", result.execution_label);
-    println!("  top_k: {}", command.top_k);
-    println!("  fetch_k: {}", command.fetch_k);
-    println!("  max_iterations: {}", command.max_iterations);
-    println!("  rewrite: {}", command.rewrite);
-    println!("  rerank: {}", command.rerank);
-    println!(
+    tracing::debug!("Query plan:");
+    tracing::debug!("  requested_mode: {}", mode_label(result.requested_mode));
+    tracing::debug!("  execution_path: {}", result.execution_label);
+    tracing::debug!("  top_k: {}", command.top_k);
+    tracing::debug!("  fetch_k: {}", command.fetch_k);
+    tracing::debug!("  max_iterations: {}", command.max_iterations);
+    tracing::debug!("  rewrite: {}", command.rewrite);
+    tracing::debug!("  rerank: {}", command.rerank);
+    tracing::debug!(
         "  query_variants: {}",
         result.rewrite_set.query_variants().join(" | ")
     );
     if let Some(plan) = &result.plan {
-        println!("  question_type: {}", question_type_label(plan));
-        println!("  strategy: {}", strategy_label(plan));
-        println!("  reasoning: {}", plan.reasoning);
+        tracing::debug!("  question_type: {}", question_type_label(plan));
+        tracing::debug!("  strategy: {}", strategy_label(plan));
+        tracing::debug!("  reasoning: {}", plan.reasoning);
         if !plan.subqueries.is_empty() {
-            println!("  subqueries: {}", plan.subqueries.join(" | "));
+            tracing::debug!("  subqueries: {}", plan.subqueries.join(" | "));
         }
     }
-    println!();
 }
 
 fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -540,12 +539,12 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    println!("Query trace:");
+    tracing::debug!("Query trace:");
     for entry in &result.trace {
-        println!("  - {entry}");
+        tracing::debug!("  - {entry}");
     }
     for iteration in &result.iterations {
-        println!(
+        tracing::debug!(
             "  - iteration {} summary: verdict={}, queries={}, kept={}",
             iteration.iteration,
             evidence_verdict_label(&iteration.sufficiency),
@@ -554,7 +553,7 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
         );
     }
     if let Some(check) = &result.support_check {
-        println!(
+        tracing::debug!(
             "  - support_check: {}",
             if check.supported {
                 "supported"
@@ -563,8 +562,7 @@ fn print_query_trace(command: &QueryCommand, result: &SimpleQueryResult) {
             }
         );
     }
-    println!("  - retrieved_hits: {}", result.hits.len());
-    println!();
+    tracing::debug!("  - retrieved_hits: {}", result.hits.len());
 }
 
 fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -572,9 +570,9 @@ fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    println!("Scores:");
+    tracing::debug!("Scores:");
     for (idx, hit) in result.hits.iter().enumerate() {
-        println!(
+        tracing::debug!(
             "  [{}] best={:.6} fused={} rerank={} {}",
             idx + 1,
             hit.best_score().unwrap_or_default(),
@@ -583,7 +581,6 @@ fn print_scores(command: &QueryCommand, result: &SimpleQueryResult) {
             hit.source_path
         );
     }
-    println!();
 }
 
 fn print_citations(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -591,11 +588,10 @@ fn print_citations(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    println!("Citations:");
+    tracing::debug!("Citations:");
     for citation in render_citations(&result.hits) {
-        println!("  {citation}");
+        tracing::debug!("  {citation}");
     }
-    println!();
 }
 
 fn print_contexts(command: &QueryCommand, result: &SimpleQueryResult) {
@@ -603,13 +599,12 @@ fn print_contexts(command: &QueryCommand, result: &SimpleQueryResult) {
         return;
     }
 
-    println!("Retrieved context:");
+    tracing::debug!("Retrieved context:");
     for (idx, hit) in result.hits.iter().enumerate() {
         let compact = retrieval_context(hit).replace('\n', " ");
         let preview: String = compact.chars().take(220).collect();
-        println!("  [{}] {}", idx + 1, preview);
+        tracing::debug!("  [{}] {}", idx + 1, preview);
     }
-    println!();
 }
 
 async fn generate_answer(

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -74,66 +74,66 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
 }
 
 fn print_human(report: &StatReport) {
-    tracing::info!("Store summary");
-    tracing::info!("  store: {}", report.store);
-    tracing::info!("  ollama url: {}", report.ollama_url);
-    tracing::info!("  rows embedded: {}", report.stats.total_chunks);
-    tracing::info!("  source files: {}", report.stats.unique_sources);
-    tracing::info!(
+    println!("Store summary");
+    println!("  store: {}", report.store);
+    println!("  ollama url: {}", report.ollama_url);
+    println!("  rows embedded: {}", report.stats.total_chunks);
+    println!("  source files: {}", report.stats.unique_sources);
+    println!(
         "  content mix: {} text, {} pdf, {} image, {} other",
         report.stats.content_kinds.text_files,
         report.stats.content_kinds.pdf_files,
         report.stats.content_kinds.image_files,
         report.stats.content_kinds.other_files
     );
-    tracing::info!("  pdf pages: {}", report.stats.pdf_pages);
-    tracing::info!("  embedded chars: {}", fmt_count(report.stats.total_chars));
-    tracing::info!(
+    println!("  pdf pages: {}", report.stats.pdf_pages);
+    println!("  embedded chars: {}", fmt_count(report.stats.total_chars));
+    println!(
         "  estimated embedded tokens: ~{}",
         fmt_count(report.stats.estimated_tokens)
     );
 
     if report.stats.total_chunks > 0 {
-        tracing::info!(
+        println!(
             "  avg chunk: {} chars, ~{} tokens",
             report.stats.total_chars / report.stats.total_chunks,
             report.stats.estimated_tokens / report.stats.total_chunks
         );
-        tracing::info!(
+        println!(
             "  chunk range: {}..{} chars",
             report.stats.min_chunk_chars, report.stats.max_chunk_chars
         );
     }
 
     if let Some(metadata) = &report.metadata {
-        tracing::info!(
+        println!(
             "  embedding: {} (dim {})",
             metadata.embed_model, metadata.embedding_dim
         );
-        tracing::info!(
+        println!(
             "  chunking: size {}, overlap {}",
             metadata.chunk_size, metadata.chunk_overlap
         );
     } else {
-        tracing::info!("  embedding: metadata missing");
+        println!("  embedding: metadata missing");
     }
 
-    tracing::info!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
-    tracing::info!(
+    println!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
+    println!(
         "    lancedb: {}",
         fmt_bytes(report.disk_usage.lancedb_bytes)
     );
-    tracing::info!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
-    tracing::info!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
-    tracing::info!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
+    println!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
+    println!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
+    println!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
     for warning in &report.warnings {
-        tracing::warn!("  warning: {}", warning);
+        eprintln!("  warning: {}", warning);
     }
 
     if !report.stats.top_sources.is_empty() {
-        tracing::info!("  top sources by chunk count:");
+        println!("  top sources by chunk count:");
         for source in &report.stats.top_sources {
-            tracing::info!(
+            println!(
                 "    - {}  [{} chunks, ~{} tokens]",
                 source.source_path,
                 fmt_count(source.chunks),

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -74,66 +74,66 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
 }
 
 fn print_human(report: &StatReport) {
-    println!("Store summary");
-    println!("  store: {}", report.store);
-    println!("  ollama url: {}", report.ollama_url);
-    println!("  rows embedded: {}", report.stats.total_chunks);
-    println!("  source files: {}", report.stats.unique_sources);
-    println!(
+    tracing::info!("Store summary");
+    tracing::info!("  store: {}", report.store);
+    tracing::info!("  ollama url: {}", report.ollama_url);
+    tracing::info!("  rows embedded: {}", report.stats.total_chunks);
+    tracing::info!("  source files: {}", report.stats.unique_sources);
+    tracing::info!(
         "  content mix: {} text, {} pdf, {} image, {} other",
         report.stats.content_kinds.text_files,
         report.stats.content_kinds.pdf_files,
         report.stats.content_kinds.image_files,
         report.stats.content_kinds.other_files
     );
-    println!("  pdf pages: {}", report.stats.pdf_pages);
-    println!("  embedded chars: {}", fmt_count(report.stats.total_chars));
-    println!(
+    tracing::info!("  pdf pages: {}", report.stats.pdf_pages);
+    tracing::info!("  embedded chars: {}", fmt_count(report.stats.total_chars));
+    tracing::info!(
         "  estimated embedded tokens: ~{}",
         fmt_count(report.stats.estimated_tokens)
     );
 
     if report.stats.total_chunks > 0 {
-        println!(
+        tracing::info!(
             "  avg chunk: {} chars, ~{} tokens",
             report.stats.total_chars / report.stats.total_chunks,
             report.stats.estimated_tokens / report.stats.total_chunks
         );
-        println!(
+        tracing::info!(
             "  chunk range: {}..{} chars",
             report.stats.min_chunk_chars, report.stats.max_chunk_chars
         );
     }
 
     if let Some(metadata) = &report.metadata {
-        println!(
+        tracing::info!(
             "  embedding: {} (dim {})",
             metadata.embed_model, metadata.embedding_dim
         );
-        println!(
+        tracing::info!(
             "  chunking: size {}, overlap {}",
             metadata.chunk_size, metadata.chunk_overlap
         );
     } else {
-        println!("  embedding: metadata missing");
+        tracing::info!("  embedding: metadata missing");
     }
 
-    println!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
-    println!(
+    tracing::info!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
+    tracing::info!(
         "    lancedb: {}",
         fmt_bytes(report.disk_usage.lancedb_bytes)
     );
-    println!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
-    println!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
-    println!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
+    tracing::info!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
+    tracing::info!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
+    tracing::info!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
     for warning in &report.warnings {
-        println!("  warning: {}", warning);
+        tracing::warn!("  warning: {}", warning);
     }
 
     if !report.stats.top_sources.is_empty() {
-        println!("  top sources by chunk count:");
+        tracing::info!("  top sources by chunk count:");
         for source in &report.stats.top_sources {
-            println!(
+            tracing::info!(
                 "    - {}  [{} chunks, ~{} tokens]",
                 source.source_path,
                 fmt_count(source.chunks),

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,24 @@ mod test_support;
 use anyhow::Result;
 use clap::Parser;
 use cli::Cli;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+static INIT: std::sync::Once = std::sync::Once::new();
+
+fn init_tracing() {
+    INIT.call_once(|| {
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("info"));
+        tracing_subscriber::registry()
+            .with(fmt::layer().with_writer(std::io::stderr))
+            .with(filter)
+            .init();
+    });
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing();
     let cli = Cli::parse();
     app::run(cli).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,10 @@ static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 fn init_tracing() {
     INIT.get_or_init(|| {
-        let filter = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new("info"));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|err| {
+            eprintln!("failed to parse RUST_LOG, using default 'info' filter: {err}");
+            EnvFilter::new("info")
+        });
         tracing_subscriber::registry()
             .with(fmt::layer().with_writer(std::io::stderr))
             .with(filter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,10 @@ use clap::Parser;
 use cli::Cli;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-static INIT: std::sync::Once = std::sync::Once::new();
+static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 fn init_tracing() {
-    INIT.call_once(|| {
+    INIT.get_or_init(|| {
         let filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new("info"));
         tracing_subscriber::registry()

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,19 @@ static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 fn init_tracing() {
     INIT.get_or_init(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|err| {
-            eprintln!("failed to parse RUST_LOG, using default 'info' filter: {err}");
-            EnvFilter::new("info")
-        });
+        let filter = match std::env::var("RUST_LOG") {
+            Ok(value) => EnvFilter::try_new(&value).unwrap_or_else(|err| {
+                eprintln!("failed to parse RUST_LOG, using default 'info' filter: {err}");
+                EnvFilter::new("info")
+            }),
+            Err(std::env::VarError::NotPresent) => EnvFilter::new("info"),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                eprintln!(
+                    "failed to parse RUST_LOG, using default 'info' filter: not valid unicode"
+                );
+                EnvFilter::new("info")
+            }
+        };
         tracing_subscriber::registry()
             .with(fmt::layer().with_writer(std::io::stderr))
             .with(filter)


### PR DESCRIPTION
Replace bare println!() calls with tracing spans and structured log events throughout the CLI.

## What changed

- Add `tracing` + `tracing-subscriber` (env-filter) to Cargo.toml
- Route tracing output to **stderr** to keep stdout clean for `--json` commands
- Add parent span in `app::run` for all command dispatch
- `commands/index`: span around `ingest_path` (using `.instrument()`), structured `info!`/`warn!` for actual ambient logging
- `commands/stat`, `commands/doctor`, `commands/index` summary: user-facing output stays as `println!` (P2 fix — `ragcli stat > report.txt` and pipes now work correctly)
- `commands/query` `--show-*` flags: stay as `println!` (P1 fix — `--show-plan` etc. always produce output regardless of `RUST_LOG`)
- `commands/doctor`: `tracing::error!` → `eprintln!` for ollama unreachable
- Modernize `src/main.rs`: `std::sync::Once` → `std::sync::OnceLock` (more idiomatic modern Rust)
- **Bugfix**: `stat.rs` avg chunk chars was computing `total_chunks/total_chunks` → now correctly `total_chars/total_chunks`

## Log level guide

| Level | What logs |
|-------|-----------|
| `error` | Ollama unreachable, metadata errors → **stderr** |
| `warn` | Index errors, warnings → **stderr** |
| `info` | Span creation, ambient activity logs → **stderr** |
| `println` | User-facing command output → **stdout** |

## Usage

```bash
# Default — structured ambient logs on stderr, answer on stdout
ragcli query "What is this?"

# JSON still clean on stdout
ragcli stat --json > report.json

# Human-readable summary output to stdout (pipes work)
ragcli stat > report.txt

# Inspection flags always work (not gated by RUST_LOG)
ragcli query "What?" --show-plan --show-scores

# Debug ambient logging when needed
RUST_LOG=debug ragcli index ./docs
```

Tests: 106 pass (105 unit + 1 integration)