### PR TITLE
feat(store): add source management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It indexes local files into a persistent LanceDB store, uses Ollama for embeddin
 - compatibility checks for embedding model + chunk settings
 - `doctor` checks for store state, Ollama reachability, and installed models
 - `stat` summarizes indexed content, approximate embedded token volume, and store disk usage
+- `sources`/`ls`, `delete`, `clear`, and `prune` help inspect and maintain indexed content
 - query modes with inspectable retrieval output via `--mode`, `--show-plan`, `--show-scores`, `--show-citations`, and `--show-trace`
 
 ## Quick Start
@@ -78,6 +79,17 @@ Inspect what is already embedded:
 
 ```bash
 cargo run -- stat
+cargo run -- sources
+cargo run -- ls
+```
+
+Remove or clean indexed content:
+
+```bash
+cargo run -- delete ./notes/today.md
+cargo run -- prune
+cargo run -- prune --apply
+cargo run -- clear --yes
 ```
 
 ## Configuration
@@ -151,6 +163,10 @@ When upgrading across store schema changes, reindex into a fresh store or remove
 ## Behavior Notes
 
 - Re-indexing replaces existing rows for the same `source_path`.
+- `sources`/`ls` lists indexed paths with per-source format, chunk count, character count, token estimate, and page count when applicable.
+- `delete <path>` removes one indexed source path.
+- `prune` previews rows whose stored `source_path` no longer exists on disk; add `--apply` to remove them.
+- `clear` removes all indexed rows for the selected store and requires `--yes`.
 - Text and source files are decoded lossily, so non-UTF-8 files do not abort indexing.
 - Hidden files and directories are skipped during directory traversal unless `--include-hidden` is set.
 - `index --exclude <glob>` can be repeated to skip unwanted files or directories.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,6 +71,26 @@ tasks:
     cmds:
       - cargo run -- stat {{.CLI_ARGS}}
 
+  sources:
+    desc: List indexed source paths
+    cmds:
+      - cargo run -- sources {{.CLI_ARGS}}
+
+  delete:
+    desc: Delete one indexed source path
+    cmds:
+      - cargo run -- delete {{.CLI_ARGS}}
+
+  clear:
+    desc: Clear all indexed content from the selected store
+    cmds:
+      - cargo run -- clear {{.CLI_ARGS}}
+
+  prune:
+    desc: Preview or remove stale indexed source paths
+    cmds:
+      - cargo run -- prune {{.CLI_ARGS}}
+
   index:
     desc: Index a file or directory
     cmds:

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,6 +85,12 @@ pub async fn run(cli: Cli) -> Result<()> {
                     commands::config::set(name, key, value).await?
                 }
             },
+            Command::Sources { json } => commands::sources::run(name, json).await?,
+            Command::Delete { path } => commands::maintenance::delete(name, path).await?,
+            Command::Clear { yes } => commands::maintenance::clear(name, yes).await?,
+            Command::Prune { apply, json } => {
+                commands::maintenance::prune(name, apply, json).await?
+            }
             Command::Stat { json } => commands::stat::run(name, json).await?,
             Command::Doctor { json } => commands::doctor::run(name, json).await?,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,33 @@ pub enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
+    /// Lists indexed source paths together with per-source metadata.
+    #[command(visible_alias = "ls")]
+    Sources {
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Removes a single indexed source path from the store.
+    Delete {
+        /// Indexed source path to remove.
+        path: String,
+    },
+    /// Removes all indexed content from the selected store.
+    Clear {
+        /// Confirms the destructive clear operation.
+        #[arg(long, default_value_t = false)]
+        yes: bool,
+    },
+    /// Removes indexed sources whose files no longer exist on disk.
+    Prune {
+        /// Applies the prune instead of printing a preview.
+        #[arg(long, default_value_t = false)]
+        apply: bool,
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Shows a summary of indexed content and store usage.
     Stat {
         /// Prints machine-readable JSON instead of the default text report.
@@ -239,6 +266,36 @@ mod tests {
                 assert!(force);
             }
             command => panic!("expected index command, got {command:?}"),
+        }
+    }
+
+    #[test]
+    fn test_store_management_commands_parse() {
+        let sources = Cli::try_parse_from(["ragcli", "ls", "--json"]).unwrap();
+        match sources.command {
+            Command::Sources { json } => assert!(json),
+            command => panic!("expected sources command, got {command:?}"),
+        }
+
+        let delete = Cli::try_parse_from(["ragcli", "delete", "docs/a.md"]).unwrap();
+        match delete.command {
+            Command::Delete { path } => assert_eq!(path, "docs/a.md"),
+            command => panic!("expected delete command, got {command:?}"),
+        }
+
+        let clear = Cli::try_parse_from(["ragcli", "clear", "--yes"]).unwrap();
+        match clear.command {
+            Command::Clear { yes } => assert!(yes),
+            command => panic!("expected clear command, got {command:?}"),
+        }
+
+        let prune = Cli::try_parse_from(["ragcli", "prune", "--apply", "--json"]).unwrap();
+        match prune.command {
+            Command::Prune { apply, json } => {
+                assert!(apply);
+                assert!(json);
+            }
+            command => panic!("expected prune command, got {command:?}"),
         }
     }
 

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -1,0 +1,284 @@
+use crate::commands::stat::fmt_count;
+use crate::config::{ensure_store_layout, store_dir};
+use crate::store::{connect_db, delete_source_rows, list_indexed_sources, IndexedSource};
+use anyhow::{bail, Result};
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub struct PruneReport {
+    pub store: String,
+    pub dry_run: bool,
+    pub stale_sources: Vec<IndexedSource>,
+    pub deleted_sources: usize,
+    pub deleted_chunks: usize,
+}
+
+pub async fn delete(name: Option<&str>, path: String) -> Result<()> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let db = connect_db(&store).await?;
+    let sources = list_indexed_sources(&db).await?;
+    let Some(source) = sources
+        .into_iter()
+        .find(|source| source.source_path == path)
+    else {
+        println!("No indexed source matched {}", path);
+        return Ok(());
+    };
+
+    delete_source_rows(&db, std::slice::from_ref(&source.source_path)).await?;
+    println!(
+        "Deleted {} [{} chunks, ~{} tokens]",
+        source.source_path,
+        fmt_count(source.chunks),
+        fmt_count(source.estimated_tokens)
+    );
+    Ok(())
+}
+
+pub async fn clear(name: Option<&str>, yes: bool) -> Result<()> {
+    if !yes {
+        bail!("clear is destructive; rerun with --yes to remove all indexed sources from the selected store");
+    }
+
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let db = connect_db(&store).await?;
+    let sources = list_indexed_sources(&db).await?;
+    if sources.is_empty() {
+        println!("Store already empty: {}", store.display());
+        return Ok(());
+    }
+
+    let deleted_sources = sources.len();
+    let deleted_chunks = sources.iter().map(|source| source.chunks).sum::<usize>();
+    let paths = sources
+        .into_iter()
+        .map(|source| source.source_path)
+        .collect::<Vec<_>>();
+    delete_source_rows(&db, &paths).await?;
+
+    println!(
+        "Cleared store {}: removed {} sources and {} chunks",
+        store.display(),
+        fmt_count(deleted_sources),
+        fmt_count(deleted_chunks)
+    );
+    Ok(())
+}
+
+pub async fn prune(name: Option<&str>, apply: bool, json: bool) -> Result<()> {
+    let report = build_prune_report(name, apply).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_prune_human(&report);
+    }
+    Ok(())
+}
+
+async fn build_prune_report(name: Option<&str>, apply: bool) -> Result<PruneReport> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let db = connect_db(&store).await?;
+    let stale_sources = list_indexed_sources(&db)
+        .await?
+        .into_iter()
+        .filter(|source| !Path::new(&source.source_path).exists())
+        .collect::<Vec<_>>();
+    let deleted_sources = stale_sources.len();
+    let deleted_chunks = stale_sources
+        .iter()
+        .map(|source| source.chunks)
+        .sum::<usize>();
+
+    if apply && !stale_sources.is_empty() {
+        let paths = stale_sources
+            .iter()
+            .map(|source| source.source_path.clone())
+            .collect::<Vec<_>>();
+        delete_source_rows(&db, &paths).await?;
+    }
+
+    Ok(PruneReport {
+        store: store.display().to_string(),
+        dry_run: !apply,
+        stale_sources,
+        deleted_sources: if apply { deleted_sources } else { 0 },
+        deleted_chunks: if apply { deleted_chunks } else { 0 },
+    })
+}
+
+fn print_prune_human(report: &PruneReport) {
+    if report.dry_run {
+        println!("Prune preview");
+    } else {
+        println!("Prune complete");
+    }
+    println!("  store: {}", report.store);
+    println!("  stale sources: {}", report.stale_sources.len());
+
+    if report.stale_sources.is_empty() {
+        println!("  nothing to prune");
+        return;
+    }
+
+    for source in &report.stale_sources {
+        println!(
+            "    - {}  [{}, {} chunks, ~{} tokens]",
+            source.source_path,
+            source.format,
+            fmt_count(source.chunks),
+            fmt_count(source.estimated_tokens)
+        );
+    }
+
+    if report.dry_run {
+        println!("  rerun with --apply to remove these rows");
+    } else {
+        println!(
+            "  removed {} sources and {} chunks",
+            fmt_count(report.deleted_sources),
+            fmt_count(report.deleted_chunks)
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_kind::SourceKind;
+    use crate::store::{connect_db, list_indexed_sources, replace_source_rows, ChunkRow};
+    use crate::test_support::with_test_env;
+    use std::path::Path;
+
+    fn sample_row(source_path: &str, text: &str) -> ChunkRow {
+        ChunkRow {
+            id: format!("{}-{}", source_path, text),
+            source_path: source_path.to_string(),
+            chunk_text: text.to_string(),
+            chunk_hash: text.to_string(),
+            format: SourceKind::from_path(Path::new(source_path))
+                .format_label()
+                .unwrap_or("text")
+                .to_string(),
+            page: 0,
+            chunk_index: 0,
+            metadata: "{}".to_string(),
+            embedding: vec![0.1, 0.2],
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_clear_requires_explicit_confirmation() {
+        let err = clear(Some("danger"), false).await.unwrap_err().to_string();
+        assert!(err.contains("--yes"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_delete_removes_matching_source() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("delete-one")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[
+                    sample_row("docs/a.md", "alpha"),
+                    sample_row("docs/b.md", "beta"),
+                ],
+                &["docs/a.md".to_string(), "docs/b.md".to_string()],
+            )
+            .await
+            .unwrap();
+
+            delete(Some("delete-one"), "docs/a.md".to_string())
+                .await
+                .unwrap();
+
+            let remaining = list_indexed_sources(&db).await.unwrap();
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].source_path, "docs/b.md");
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_prune_report_marks_missing_sources_without_deleting_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let live_path = dir.path().join("live.txt");
+            std::fs::write(&live_path, "live").unwrap();
+            let missing_path = dir.path().join("missing.txt");
+            let store = store_dir(Some("prune-preview")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[
+                    sample_row(&live_path.display().to_string(), "alpha"),
+                    sample_row(&missing_path.display().to_string(), "beta"),
+                ],
+                &[
+                    live_path.display().to_string(),
+                    missing_path.display().to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+
+            let report = build_prune_report(Some("prune-preview"), false)
+                .await
+                .unwrap();
+            assert!(report.dry_run);
+            assert_eq!(report.stale_sources.len(), 1);
+            assert_eq!(
+                report.stale_sources[0].source_path,
+                missing_path.display().to_string()
+            );
+            assert_eq!(report.deleted_sources, 0);
+
+            let remaining = list_indexed_sources(&db).await.unwrap();
+            assert_eq!(remaining.len(), 2);
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_prune_report_deletes_missing_sources_when_applied() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let live_path = dir.path().join("live.txt");
+            std::fs::write(&live_path, "live").unwrap();
+            let missing_path = dir.path().join("missing.txt");
+            let store = store_dir(Some("prune-apply")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[
+                    sample_row(&live_path.display().to_string(), "alpha"),
+                    sample_row(&missing_path.display().to_string(), "beta"),
+                ],
+                &[
+                    live_path.display().to_string(),
+                    missing_path.display().to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+
+            let report = build_prune_report(Some("prune-apply"), true).await.unwrap();
+            assert!(!report.dry_run);
+            assert_eq!(report.deleted_sources, 1);
+            assert_eq!(report.deleted_chunks, 1);
+
+            let remaining = list_indexed_sources(&db).await.unwrap();
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].source_path, live_path.display().to_string());
+        })
+        .await;
+    }
+}

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -1,6 +1,9 @@
 use crate::commands::stat::fmt_count;
 use crate::config::{ensure_store_layout, store_dir};
-use crate::store::{connect_db, delete_source_rows, list_indexed_sources, IndexedSource};
+use crate::store::{
+    clear_store_rows, connect_db, delete_source_rows, list_indexed_source_summaries,
+    load_indexed_source_summary, IndexedSourceSummary,
+};
 use anyhow::{bail, Result};
 use serde::Serialize;
 use std::path::Path;
@@ -9,7 +12,7 @@ use std::path::Path;
 pub struct PruneReport {
     pub store: String,
     pub dry_run: bool,
-    pub stale_sources: Vec<IndexedSource>,
+    pub stale_sources: Vec<IndexedSourceSummary>,
     pub deleted_sources: usize,
     pub deleted_chunks: usize,
 }
@@ -18,21 +21,17 @@ pub async fn delete(name: Option<&str>, path: String) -> Result<()> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let db = connect_db(&store).await?;
-    let sources = list_indexed_sources(&db).await?;
-    let Some(source) = sources
-        .into_iter()
-        .find(|source| source.source_path == path)
-    else {
+    let Some(source) = load_indexed_source_summary(&db, &path).await? else {
         println!("No indexed source matched {}", path);
         return Ok(());
     };
 
     delete_source_rows(&db, std::slice::from_ref(&source.source_path)).await?;
     println!(
-        "Deleted {} [{} chunks, ~{} tokens]",
+        "Deleted {} [{}, {} chunks]",
         source.source_path,
-        fmt_count(source.chunks),
-        fmt_count(source.estimated_tokens)
+        source.format,
+        fmt_count(source.chunks)
     );
     Ok(())
 }
@@ -45,7 +44,7 @@ pub async fn clear(name: Option<&str>, yes: bool) -> Result<()> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let db = connect_db(&store).await?;
-    let sources = list_indexed_sources(&db).await?;
+    let sources = list_indexed_source_summaries(&db).await?;
     if sources.is_empty() {
         println!("Store already empty: {}", store.display());
         return Ok(());
@@ -53,11 +52,7 @@ pub async fn clear(name: Option<&str>, yes: bool) -> Result<()> {
 
     let deleted_sources = sources.len();
     let deleted_chunks = sources.iter().map(|source| source.chunks).sum::<usize>();
-    let paths = sources
-        .into_iter()
-        .map(|source| source.source_path)
-        .collect::<Vec<_>>();
-    delete_source_rows(&db, &paths).await?;
+    clear_store_rows(&db).await?;
 
     println!(
         "Cleared store {}: removed {} sources and {} chunks",
@@ -82,7 +77,7 @@ async fn build_prune_report(name: Option<&str>, apply: bool) -> Result<PruneRepo
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let db = connect_db(&store).await?;
-    let stale_sources = list_indexed_sources(&db)
+    let stale_sources = list_indexed_source_summaries(&db)
         .await?
         .into_iter()
         .filter(|source| !Path::new(&source.source_path).exists())
@@ -125,13 +120,14 @@ fn print_prune_human(report: &PruneReport) {
     }
 
     for source in &report.stale_sources {
-        println!(
-            "    - {}  [{}, {} chunks, ~{} tokens]",
-            source.source_path,
-            source.format,
-            fmt_count(source.chunks),
-            fmt_count(source.estimated_tokens)
-        );
+        let mut details = vec![
+            source.format.clone(),
+            format!("{} chunks", fmt_count(source.chunks)),
+        ];
+        if source.page_count > 0 {
+            details.push(format!("{} pages", fmt_count(source.page_count)));
+        }
+        println!("    - {}  [{}]", source.source_path, details.join(", "));
     }
 
     if report.dry_run {
@@ -149,7 +145,10 @@ fn print_prune_human(report: &PruneReport) {
 mod tests {
     use super::*;
     use crate::source_kind::SourceKind;
-    use crate::store::{connect_db, list_indexed_sources, replace_source_rows, ChunkRow};
+    use crate::store::{
+        connect_db, list_indexed_source_summaries, list_indexed_sources, replace_source_rows,
+        ChunkRow,
+    };
     use crate::test_support::with_test_env;
     use std::path::Path;
 
@@ -201,6 +200,31 @@ mod tests {
             let remaining = list_indexed_sources(&db).await.unwrap();
             assert_eq!(remaining.len(), 1);
             assert_eq!(remaining[0].source_path, "docs/b.md");
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_clear_removes_all_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("clear-store")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[
+                    sample_row("docs/a.md", "alpha"),
+                    sample_row("docs/b.md", "beta"),
+                ],
+                &["docs/a.md".to_string(), "docs/b.md".to_string()],
+            )
+            .await
+            .unwrap();
+
+            clear(Some("clear-store"), true).await.unwrap();
+
+            assert!(list_indexed_source_summaries(&db).await.unwrap().is_empty());
         })
         .await;
     }

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -4,9 +4,9 @@ use crate::store::{
     clear_store_rows, connect_db, delete_source_rows, list_indexed_source_summaries,
     load_indexed_source_summary, IndexedSourceSummary,
 };
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use serde::Serialize;
-use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug, Serialize)]
 pub struct PruneReport {
@@ -77,11 +77,12 @@ async fn build_prune_report(name: Option<&str>, apply: bool) -> Result<PruneRepo
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let db = connect_db(&store).await?;
-    let stale_sources = list_indexed_source_summaries(&db)
-        .await?
-        .into_iter()
-        .filter(|source| !Path::new(&source.source_path).exists())
-        .collect::<Vec<_>>();
+    let mut stale_sources = Vec::new();
+    for source in list_indexed_source_summaries(&db).await? {
+        if source_is_missing(&source)? {
+            stale_sources.push(source);
+        }
+    }
     let deleted_sources = stale_sources.len();
     let deleted_chunks = stale_sources
         .iter()
@@ -103,6 +104,29 @@ async fn build_prune_report(name: Option<&str>, apply: bool) -> Result<PruneRepo
         deleted_sources: if apply { deleted_sources } else { 0 },
         deleted_chunks: if apply { deleted_chunks } else { 0 },
     })
+}
+
+fn source_prune_path(source: &IndexedSourceSummary) -> Result<PathBuf> {
+    if let Some(path) = &source.source_absolute_path {
+        return Ok(PathBuf::from(path));
+    }
+
+    let path = PathBuf::from(&source.source_path);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        bail!(
+            "cannot safely prune relative source path {}; reindex it with a newer ragcli before pruning",
+            source.source_path
+        )
+    }
+}
+
+fn source_is_missing(source: &IndexedSourceSummary) -> Result<bool> {
+    let path = source_prune_path(source)?;
+    Ok(!path
+        .try_exists()
+        .with_context(|| format!("check whether source exists: {}", path.display()))?)
 }
 
 fn print_prune_human(report: &PruneReport) {
@@ -153,6 +177,10 @@ mod tests {
     use std::path::Path;
 
     fn sample_row(source_path: &str, text: &str) -> ChunkRow {
+        sample_row_with_metadata(source_path, text, "{}")
+    }
+
+    fn sample_row_with_metadata(source_path: &str, text: &str, metadata: &str) -> ChunkRow {
         ChunkRow {
             id: format!("{}-{}", source_path, text),
             source_path: source_path.to_string(),
@@ -164,7 +192,7 @@ mod tests {
                 .to_string(),
             page: 0,
             chunk_index: 0,
-            metadata: "{}".to_string(),
+            metadata: metadata.to_string(),
             embedding: vec![0.1, 0.2],
         }
     }
@@ -225,6 +253,57 @@ mod tests {
             clear(Some("clear-store"), true).await.unwrap();
 
             assert!(list_indexed_source_summaries(&db).await.unwrap().is_empty());
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_prune_report_rejects_relative_sources_without_absolute_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("prune-relative")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[sample_row("docs/a.md", "alpha")],
+                &["docs/a.md".to_string()],
+            )
+            .await
+            .unwrap();
+
+            let err = build_prune_report(Some("prune-relative"), false)
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("cannot safely prune relative source path docs/a.md"));
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_prune_report_uses_absolute_metadata_for_relative_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let live_path = dir.path().join("docs").join("a.md");
+            std::fs::create_dir_all(live_path.parent().unwrap()).unwrap();
+            std::fs::write(&live_path, "live").unwrap();
+            let store = store_dir(Some("prune-absolute")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            let metadata = format!(r#"{{"source_absolute_path":"{}"}}"#, live_path.display());
+            replace_source_rows(
+                &db,
+                &[sample_row_with_metadata("docs/a.md", "alpha", &metadata)],
+                &["docs/a.md".to_string()],
+            )
+            .await
+            .unwrap();
+
+            let report = build_prune_report(Some("prune-absolute"), false)
+                .await
+                .unwrap();
+            assert!(report.stale_sources.is_empty());
         })
         .await;
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod doctor;
 pub mod index;
+pub mod maintenance;
 pub mod query;
+pub mod sources;
 pub mod stat;

--- a/src/commands/sources.rs
+++ b/src/commands/sources.rs
@@ -1,0 +1,115 @@
+use crate::commands::stat::fmt_count;
+use crate::config::{ensure_store_layout, store_dir};
+use crate::store::{connect_db, list_indexed_sources, IndexedSource};
+use anyhow::Result;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct SourcesReport {
+    pub store: String,
+    pub total_sources: usize,
+    pub sources: Vec<IndexedSource>,
+}
+
+pub async fn run(name: Option<&str>, json: bool) -> Result<()> {
+    let report = build_report(name).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+    Ok(())
+}
+
+async fn build_report(name: Option<&str>) -> Result<SourcesReport> {
+    let store = store_dir(name)?;
+    ensure_store_layout(&store)?;
+    let db = connect_db(&store).await?;
+    let sources = list_indexed_sources(&db).await?;
+
+    Ok(SourcesReport {
+        store: store.display().to_string(),
+        total_sources: sources.len(),
+        sources,
+    })
+}
+
+fn print_human(report: &SourcesReport) {
+    println!("Indexed sources");
+    println!("  store: {}", report.store);
+    println!("  sources: {}", report.total_sources);
+
+    if report.sources.is_empty() {
+        println!("  no indexed sources");
+        return;
+    }
+
+    for source in &report.sources {
+        let mut details = vec![
+            source.format.clone(),
+            format!("{} chunks", fmt_count(source.chunks)),
+            format!("~{} tokens", fmt_count(source.estimated_tokens)),
+            format!("{} chars", fmt_count(source.chars)),
+        ];
+        if source.page_count > 0 {
+            details.push(format!("{} pages", fmt_count(source.page_count)));
+        }
+
+        println!("    - {}  [{}]", source.source_path, details.join(", "));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_kind::SourceKind;
+    use crate::store::{connect_db, replace_source_rows, ChunkRow};
+    use crate::test_support::with_test_env;
+    use std::path::Path;
+
+    fn sample_row(source_path: &str, text: &str) -> ChunkRow {
+        ChunkRow {
+            id: format!("{}-{}", source_path, text),
+            source_path: source_path.to_string(),
+            chunk_text: text.to_string(),
+            chunk_hash: text.to_string(),
+            format: SourceKind::from_path(Path::new(source_path))
+                .format_label()
+                .unwrap_or("text")
+                .to_string(),
+            page: 0,
+            chunk_index: 0,
+            metadata: "{}".to_string(),
+            embedding: vec![0.1, 0.2],
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_report_lists_indexed_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let store = store_dir(Some("inspect")).unwrap();
+            ensure_store_layout(&store).unwrap();
+            let db = connect_db(&store).await.unwrap();
+            replace_source_rows(
+                &db,
+                &[
+                    sample_row("docs/a.md", "alpha"),
+                    sample_row("docs/a.md", "beta"),
+                    sample_row("notes/todo.txt", "gamma"),
+                ],
+                &["docs/a.md".to_string(), "notes/todo.txt".to_string()],
+            )
+            .await
+            .unwrap();
+
+            let report = build_report(Some("inspect")).await.unwrap();
+            assert_eq!(report.total_sources, 2);
+            assert_eq!(report.sources[0].source_path, "docs/a.md");
+            assert_eq!(report.sources[0].chunks, 2);
+            assert_eq!(report.sources[0].format, "markdown");
+            assert_eq!(report.sources[1].source_path, "notes/todo.txt");
+        })
+        .await;
+    }
+}

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -332,6 +332,7 @@ async fn embed_chunks(
     dim: &mut Option<usize>,
 ) -> Result<Vec<ChunkRow>> {
     let mut rows = Vec::new();
+    let source_absolute_path = canonical_source_path(path);
     for (idx, chunk) in chunks.into_iter().enumerate() {
         let embedding = embedder.embed(&chunk.text).await?;
         if dim.is_none() {
@@ -354,6 +355,12 @@ async fn embed_chunks(
                 "source_modified_unix_ms".to_string(),
                 json!(source_fingerprint.modified_unix_ms),
             );
+            if let Some(source_absolute_path) = &source_absolute_path {
+                obj.insert(
+                    "source_absolute_path".to_string(),
+                    json!(source_absolute_path),
+                );
+            }
         }
         let format = metadata
             .get("format")
@@ -373,6 +380,12 @@ async fn embed_chunks(
         });
     }
     Ok(rows)
+}
+
+fn canonical_source_path(path: &Path) -> Option<String> {
+    fs::canonicalize(path)
+        .ok()
+        .map(|path| path.display().to_string())
 }
 
 fn build_ingest_options(

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -15,8 +15,8 @@ use anyhow::Result;
 use std::collections::BTreeSet;
 
 use super::render::{
-    evidence_verdict_label, print_citations, print_contexts, print_query_plan,
-    print_query_trace, print_scores,
+    evidence_verdict_label, print_citations, print_contexts, print_query_plan, print_query_trace,
+    print_scores,
 };
 use super::retrieve::retrieve_candidates;
 use super::runtime::{mode_label, prepare_runtime};

--- a/src/store.rs
+++ b/src/store.rs
@@ -100,7 +100,7 @@ pub struct SourceChunkStat {
     pub estimated_tokens: usize,
 }
 
-/// Per-source metadata used for store inspection and maintenance commands.
+/// Per-source metadata used for store inspection commands.
 #[derive(Debug, Default, Serialize, Clone, PartialEq, Eq)]
 pub struct IndexedSource {
     /// Source file path.
@@ -113,6 +113,19 @@ pub struct IndexedSource {
     pub chars: usize,
     /// Approximate token count for this source.
     pub estimated_tokens: usize,
+    /// Number of unique pages represented for paginated sources.
+    pub page_count: usize,
+}
+
+/// Lightweight per-source metadata used for maintenance commands.
+#[derive(Debug, Default, Serialize, Clone, PartialEq, Eq)]
+pub struct IndexedSourceSummary {
+    /// Source file path.
+    pub source_path: String,
+    /// Indexed format label such as `text`, `markdown`, `pdf`, or `image`.
+    pub format: String,
+    /// Number of chunks stored for this source.
+    pub chunks: usize,
     /// Number of unique pages represented for paginated sources.
     pub page_count: usize,
 }
@@ -294,13 +307,10 @@ pub async fn replace_source_rows(
     rows: &[ChunkRow],
     source_paths: &[String],
 ) -> Result<()> {
-    let source_paths: BTreeSet<String> = source_paths.iter().cloned().collect();
     let table = open_or_create_table(db, rows).await?;
 
-    for source_path in source_paths {
-        table
-            .delete(&format!("source_path = {}", sql_string(&source_path)))
-            .await?;
+    if let Some(filter) = build_source_delete_filter(source_paths) {
+        table.delete(&filter).await?;
     }
 
     if !rows.is_empty() {
@@ -334,25 +344,67 @@ pub async fn list_indexed_sources(db: &Connection) -> Result<Vec<IndexedSource>>
     collect_indexed_sources(&batches)
 }
 
+/// Lists lightweight indexed source metadata without scanning chunk text.
+pub async fn list_indexed_source_summaries(db: &Connection) -> Result<Vec<IndexedSourceSummary>> {
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(Vec::new());
+    };
+
+    let batches = table
+        .query()
+        .select(Select::columns(&["source_path", "page", "format"]))
+        .execute()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+    collect_indexed_source_summaries(&batches)
+}
+
+/// Loads lightweight metadata for a single indexed source path.
+pub async fn load_indexed_source_summary(
+    db: &Connection,
+    source_path: &str,
+) -> Result<Option<IndexedSourceSummary>> {
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(None);
+    };
+
+    let batches = table
+        .query()
+        .only_if(format!("source_path = {}", sql_string(source_path)))
+        .select(Select::columns(&["source_path", "page", "format"]))
+        .execute()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+    Ok(collect_indexed_source_summaries(&batches)?
+        .into_iter()
+        .next())
+}
+
 /// Deletes all stored rows for the given source paths.
 pub async fn delete_source_rows(db: &Connection, source_paths: &[String]) -> Result<()> {
-    if source_paths.is_empty() {
+    let Some(filter) = build_source_delete_filter(source_paths) else {
         return Ok(());
-    }
-
+    };
     let Some(table) = open_table_if_exists(db).await? else {
         return Ok(());
     };
 
-    for source_path in source_paths.iter().cloned().collect::<BTreeSet<_>>() {
-        table
-            .delete(&format!("source_path = {}", sql_string(&source_path)))
-            .await?;
-    }
+    table.delete(&filter).await?;
+    ensure_fts_index(&table, true).await?;
 
-    if table_has_rows(&table).await? {
-        ensure_fts_index(&table, true).await?;
-    }
+    Ok(())
+}
+
+/// Deletes every stored row in the selected table.
+pub async fn clear_store_rows(db: &Connection) -> Result<()> {
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(());
+    };
+
+    table.delete("source_path IS NOT NULL").await?;
+    ensure_fts_index(&table, true).await?;
 
     Ok(())
 }
@@ -396,19 +448,6 @@ async fn open_or_create_table(db: &Connection, rows: &[ChunkRow]) -> Result<Tabl
                 .context("create table")
         }
     }
-}
-
-async fn table_has_rows(table: &Table) -> Result<bool> {
-    let mut stream = table
-        .query()
-        .select(Select::columns(&["id"]))
-        .limit(1)
-        .execute()
-        .await?;
-    Ok(stream
-        .try_next()
-        .await?
-        .is_some_and(|batch| batch.num_rows() > 0))
 }
 
 fn build_schema(dim: usize) -> Arc<Schema> {
@@ -523,6 +562,63 @@ pub fn extract_contexts(batches: &[RecordBatch]) -> Result<Vec<String>> {
         }
     }
     Ok(out)
+}
+
+/// Collects lightweight per-source metadata from stored chunk batches.
+pub fn collect_indexed_source_summaries(
+    batches: &[RecordBatch],
+) -> Result<Vec<IndexedSourceSummary>> {
+    let mut sources: BTreeMap<String, IndexedSourceSummary> = BTreeMap::new();
+    let mut pages_by_source: BTreeMap<String, BTreeSet<i32>> = BTreeMap::new();
+
+    for batch in batches {
+        let source_col = batch
+            .column_by_name("source_path")
+            .context("source_path column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("source_path column type")?;
+        let page_col = batch
+            .column_by_name("page")
+            .context("page column missing")?
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .context("page column type")?;
+        let format_col = batch
+            .column_by_name("format")
+            .context("format column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("format column type")?;
+
+        for i in 0..batch.num_rows() {
+            let source = source_col.value(i);
+            let entry = sources
+                .entry(source.to_string())
+                .or_insert_with(|| IndexedSourceSummary {
+                    source_path: source.to_string(),
+                    format: format_col.value(i).to_string(),
+                    ..Default::default()
+                });
+            entry.chunks += 1;
+
+            let page = page_col.value(i);
+            if page > 0 {
+                pages_by_source
+                    .entry(source.to_string())
+                    .or_default()
+                    .insert(page);
+            }
+        }
+    }
+
+    for (source, pages) in pages_by_source {
+        if let Some(entry) = sources.get_mut(&source) {
+            entry.page_count = pages.len();
+        }
+    }
+
+    Ok(sources.into_values().collect())
 }
 
 /// Collects per-source metadata from stored chunk batches.
@@ -693,6 +789,25 @@ pub fn strip_thinking(text: &str) -> String {
     text.to_string()
 }
 
+fn build_source_delete_filter(source_paths: &[String]) -> Option<String> {
+    let source_paths = source_paths.iter().cloned().collect::<BTreeSet<_>>();
+    match source_paths.len() {
+        0 => None,
+        1 => source_paths
+            .iter()
+            .next()
+            .map(|source_path| format!("source_path = {}", sql_string(source_path))),
+        _ => Some(format!(
+            "source_path IN ({})",
+            source_paths
+                .iter()
+                .map(|source_path| sql_string(source_path))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
 fn sql_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
@@ -816,6 +931,17 @@ mod tests {
         assert!(!contexts.iter().any(|ctx| ctx.contains("old")));
     }
 
+    #[test]
+    fn test_build_source_delete_filter_uses_in_clause_for_multiple_sources() {
+        let filter = build_source_delete_filter(&[
+            "b.txt".to_string(),
+            "a.txt".to_string(),
+            "a.txt".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(filter, "source_path IN ('a.txt', 'b.txt')");
+    }
+
     #[tokio::test]
     async fn test_delete_source_rows_removes_only_requested_source() {
         let dir = tempfile::tempdir().unwrap();
@@ -839,6 +965,27 @@ mod tests {
         let sources = list_indexed_sources(&db).await.unwrap();
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].source_path, "b.txt");
+    }
+
+    #[tokio::test]
+    async fn test_clear_store_rows_removes_every_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = connect_db(dir.path()).await.unwrap();
+
+        replace_source_rows(
+            &db,
+            &[
+                sample_row("a.txt", "alpha", 1.0),
+                sample_row("b.txt", "beta", 2.0),
+            ],
+            &["a.txt".to_string(), "b.txt".to_string()],
+        )
+        .await
+        .unwrap();
+
+        clear_store_rows(&db).await.unwrap();
+
+        assert!(list_indexed_source_summaries(&db).await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1026,7 +1173,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_indexed_sources_aggregates_metadata() {
+    fn test_collect_indexed_source_summaries_aggregates_metadata() {
         let schema = build_schema(2);
         let batch = build_record_batch(
             schema,
@@ -1045,18 +1192,20 @@ mod tests {
         )
         .unwrap();
 
-        let sources = collect_indexed_sources(&[batch]).unwrap();
+        let sources = collect_indexed_source_summaries(&[batch.clone()]).unwrap();
 
         assert_eq!(sources.len(), 3);
         assert_eq!(sources[0].source_path, "image.png");
         assert_eq!(sources[0].format, "image");
         assert_eq!(sources[1].source_path, "notes.md");
         assert_eq!(sources[1].chunks, 1);
-        assert_eq!(sources[1].chars, "hello world".chars().count());
         assert_eq!(sources[2].source_path, "paper.pdf");
         assert_eq!(sources[2].format, "pdf");
         assert_eq!(sources[2].chunks, 2);
         assert_eq!(sources[2].page_count, 2);
+
+        let detailed = collect_indexed_sources(&[batch]).unwrap();
+        assert_eq!(detailed[1].chars, "hello world".chars().count());
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -100,6 +100,23 @@ pub struct SourceChunkStat {
     pub estimated_tokens: usize,
 }
 
+/// Per-source metadata used for store inspection and maintenance commands.
+#[derive(Debug, Default, Serialize, Clone, PartialEq, Eq)]
+pub struct IndexedSource {
+    /// Source file path.
+    pub source_path: String,
+    /// Indexed format label such as `text`, `markdown`, `pdf`, or `image`.
+    pub format: String,
+    /// Number of chunks stored for this source.
+    pub chunks: usize,
+    /// Total characters stored for this source.
+    pub chars: usize,
+    /// Approximate token count for this source.
+    pub estimated_tokens: usize,
+    /// Number of unique pages represented for paginated sources.
+    pub page_count: usize,
+}
+
 /// Aggregate statistics for a store.
 #[derive(Debug, Default, Serialize)]
 pub struct StoreStats {
@@ -198,14 +215,20 @@ pub fn ensure_metadata(
     Ok(())
 }
 
+async fn open_table_if_exists(db: &Connection) -> Result<Option<Table>> {
+    match db.open_table(DEFAULT_TABLE_NAME).execute().await {
+        Ok(table) => Ok(Some(table)),
+        Err(LanceDbError::TableNotFound { .. }) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Loads stored per-source fingerprint data from chunk metadata.
 pub async fn load_source_fingerprints(
     db: &Connection,
 ) -> Result<BTreeMap<String, SourceFingerprint>> {
-    let table = match db.open_table(DEFAULT_TABLE_NAME).execute().await {
-        Ok(table) => table,
-        Err(LanceDbError::TableNotFound { .. }) => return Ok(BTreeMap::new()),
-        Err(err) => return Err(err.into()),
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(BTreeMap::new());
     };
     let mut stream = table
         .query()
@@ -253,11 +276,13 @@ pub async fn load_source_fingerprints(
                 .get("source_modified_unix_ms")
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or_default();
-            fingerprints.entry(source.to_string()).or_insert_with(|| SourceFingerprint {
-                fingerprint: fingerprint.to_string(),
-                size_bytes,
-                modified_unix_ms,
-            });
+            fingerprints
+                .entry(source.to_string())
+                .or_insert_with(|| SourceFingerprint {
+                    fingerprint: fingerprint.to_string(),
+                    size_bytes,
+                    modified_unix_ms,
+                });
         }
     }
 
@@ -285,6 +310,50 @@ pub async fn replace_source_rows(
         table.add(Box::new(batches)).execute().await?;
     }
     ensure_fts_index(&table, true).await?;
+    Ok(())
+}
+
+/// Lists indexed sources together with aggregate per-source metadata.
+pub async fn list_indexed_sources(db: &Connection) -> Result<Vec<IndexedSource>> {
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(Vec::new());
+    };
+
+    let batches = table
+        .query()
+        .select(Select::columns(&[
+            "source_path",
+            "chunk_text",
+            "page",
+            "format",
+        ]))
+        .execute()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+    collect_indexed_sources(&batches)
+}
+
+/// Deletes all stored rows for the given source paths.
+pub async fn delete_source_rows(db: &Connection, source_paths: &[String]) -> Result<()> {
+    if source_paths.is_empty() {
+        return Ok(());
+    }
+
+    let Some(table) = open_table_if_exists(db).await? else {
+        return Ok(());
+    };
+
+    for source_path in source_paths.iter().cloned().collect::<BTreeSet<_>>() {
+        table
+            .delete(&format!("source_path = {}", sql_string(&source_path)))
+            .await?;
+    }
+
+    if table_has_rows(&table).await? {
+        ensure_fts_index(&table, true).await?;
+    }
+
     Ok(())
 }
 
@@ -327,6 +396,19 @@ async fn open_or_create_table(db: &Connection, rows: &[ChunkRow]) -> Result<Tabl
                 .context("create table")
         }
     }
+}
+
+async fn table_has_rows(table: &Table) -> Result<bool> {
+    let mut stream = table
+        .query()
+        .select(Select::columns(&["id"]))
+        .limit(1)
+        .execute()
+        .await?;
+    Ok(stream
+        .try_next()
+        .await?
+        .is_some_and(|batch| batch.num_rows() > 0))
 }
 
 fn build_schema(dim: usize) -> Arc<Schema> {
@@ -441,6 +523,70 @@ pub fn extract_contexts(batches: &[RecordBatch]) -> Result<Vec<String>> {
         }
     }
     Ok(out)
+}
+
+/// Collects per-source metadata from stored chunk batches.
+pub fn collect_indexed_sources(batches: &[RecordBatch]) -> Result<Vec<IndexedSource>> {
+    let mut sources: BTreeMap<String, IndexedSource> = BTreeMap::new();
+    let mut pages_by_source: BTreeMap<String, BTreeSet<i32>> = BTreeMap::new();
+
+    for batch in batches {
+        let text_col = batch
+            .column_by_name("chunk_text")
+            .context("chunk_text column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("chunk_text column type")?;
+        let source_col = batch
+            .column_by_name("source_path")
+            .context("source_path column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("source_path column type")?;
+        let page_col = batch
+            .column_by_name("page")
+            .context("page column missing")?
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .context("page column type")?;
+        let format_col = batch
+            .column_by_name("format")
+            .context("format column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("format column type")?;
+
+        for i in 0..batch.num_rows() {
+            let source = source_col.value(i);
+            let text = text_col.value(i);
+            let entry = sources
+                .entry(source.to_string())
+                .or_insert_with(|| IndexedSource {
+                    source_path: source.to_string(),
+                    format: format_col.value(i).to_string(),
+                    ..Default::default()
+                });
+            entry.chunks += 1;
+            entry.chars += text.chars().count();
+            entry.estimated_tokens += estimate_token_count(text);
+
+            let page = page_col.value(i);
+            if page > 0 {
+                pages_by_source
+                    .entry(source.to_string())
+                    .or_default()
+                    .insert(page);
+            }
+        }
+    }
+
+    for (source, pages) in pages_by_source {
+        if let Some(entry) = sources.get_mut(&source) {
+            entry.page_count = pages.len();
+        }
+    }
+
+    Ok(sources.into_values().collect())
 }
 
 /// Collects summary statistics from stored chunk batches.
@@ -671,6 +817,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_delete_source_rows_removes_only_requested_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = connect_db(dir.path()).await.unwrap();
+
+        replace_source_rows(
+            &db,
+            &[
+                sample_row("a.txt", "alpha", 1.0),
+                sample_row("b.txt", "beta", 2.0),
+            ],
+            &["a.txt".to_string(), "b.txt".to_string()],
+        )
+        .await
+        .unwrap();
+
+        delete_source_rows(&db, &["a.txt".to_string()])
+            .await
+            .unwrap();
+
+        let sources = list_indexed_sources(&db).await.unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_path, "b.txt");
+    }
+
+    #[tokio::test]
     async fn test_hybrid_search_keeps_keyword_match() {
         let dir = tempfile::tempdir().unwrap();
         let db = connect_db(dir.path()).await.unwrap();
@@ -852,6 +1023,40 @@ mod tests {
             filter,
             "source_path = 'docs/it''s.txt' AND source_path LIKE 'docs/\\_v1\\%/%' ESCAPE '\\' AND page = 3 AND format = 'markdown'"
         );
+    }
+
+    #[test]
+    fn test_collect_indexed_sources_aggregates_metadata() {
+        let schema = build_schema(2);
+        let batch = build_record_batch(
+            schema,
+            &[
+                sample_row("notes.md", "hello world", 1.0),
+                ChunkRow {
+                    page: 1,
+                    ..sample_row("paper.pdf", "page one", 2.0)
+                },
+                ChunkRow {
+                    page: 2,
+                    ..sample_row("paper.pdf", "page two", 3.0)
+                },
+                sample_row("image.png", "caption text", 4.0),
+            ],
+        )
+        .unwrap();
+
+        let sources = collect_indexed_sources(&[batch]).unwrap();
+
+        assert_eq!(sources.len(), 3);
+        assert_eq!(sources[0].source_path, "image.png");
+        assert_eq!(sources[0].format, "image");
+        assert_eq!(sources[1].source_path, "notes.md");
+        assert_eq!(sources[1].chunks, 1);
+        assert_eq!(sources[1].chars, "hello world".chars().count());
+        assert_eq!(sources[2].source_path, "paper.pdf");
+        assert_eq!(sources[2].format, "pdf");
+        assert_eq!(sources[2].chunks, 2);
+        assert_eq!(sources[2].page_count, 2);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -122,6 +122,9 @@ pub struct IndexedSource {
 pub struct IndexedSourceSummary {
     /// Source file path.
     pub source_path: String,
+    /// Canonical absolute source file path when recorded at index time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_absolute_path: Option<String>,
     /// Indexed format label such as `text`, `markdown`, `pdf`, or `image`.
     pub format: String,
     /// Number of chunks stored for this source.
@@ -352,7 +355,12 @@ pub async fn list_indexed_source_summaries(db: &Connection) -> Result<Vec<Indexe
 
     let batches = table
         .query()
-        .select(Select::columns(&["source_path", "page", "format"]))
+        .select(Select::columns(&[
+            "source_path",
+            "page",
+            "format",
+            "metadata",
+        ]))
         .execute()
         .await?
         .try_collect::<Vec<_>>()
@@ -372,7 +380,12 @@ pub async fn load_indexed_source_summary(
     let batches = table
         .query()
         .only_if(format!("source_path = {}", sql_string(source_path)))
-        .select(Select::columns(&["source_path", "page", "format"]))
+        .select(Select::columns(&[
+            "source_path",
+            "page",
+            "format",
+            "metadata",
+        ]))
         .execute()
         .await?
         .try_collect::<Vec<_>>()
@@ -590,16 +603,42 @@ pub fn collect_indexed_source_summaries(
             .as_any()
             .downcast_ref::<StringArray>()
             .context("format column type")?;
+        let metadata_col = batch
+            .column_by_name("metadata")
+            .context("metadata column missing")?
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("metadata column type")?;
 
         for i in 0..batch.num_rows() {
             let source = source_col.value(i);
+            let absolute_path = serde_json::from_str::<serde_json::Value>(metadata_col.value(i))
+                .ok()
+                .and_then(|metadata| {
+                    metadata
+                        .get("source_absolute_path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                });
             let entry = sources
                 .entry(source.to_string())
                 .or_insert_with(|| IndexedSourceSummary {
                     source_path: source.to_string(),
+                    source_absolute_path: absolute_path,
                     format: format_col.value(i).to_string(),
                     ..Default::default()
                 });
+            if entry.source_absolute_path.is_none() {
+                entry.source_absolute_path =
+                    serde_json::from_str::<serde_json::Value>(metadata_col.value(i))
+                        .ok()
+                        .and_then(|metadata| {
+                            metadata
+                                .get("source_absolute_path")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        });
+            }
             entry.chunks += 1;
 
             let page = page_col.value(i);
@@ -1178,7 +1217,10 @@ mod tests {
         let batch = build_record_batch(
             schema,
             &[
-                sample_row("notes.md", "hello world", 1.0),
+                ChunkRow {
+                    metadata: r#"{"source_absolute_path":"/tmp/notes.md"}"#.to_string(),
+                    ..sample_row("notes.md", "hello world", 1.0)
+                },
                 ChunkRow {
                     page: 1,
                     ..sample_row("paper.pdf", "page one", 2.0)
@@ -1199,6 +1241,10 @@ mod tests {
         assert_eq!(sources[0].format, "image");
         assert_eq!(sources[1].source_path, "notes.md");
         assert_eq!(sources[1].chunks, 1);
+        assert_eq!(
+            sources[1].source_absolute_path.as_deref(),
+            Some("/tmp/notes.md")
+        );
         assert_eq!(sources[2].source_path, "paper.pdf");
         assert_eq!(sources[2].format, "pdf");
         assert_eq!(sources[2].chunks, 2);

--- a/src/store.rs
+++ b/src/store.rs
@@ -332,7 +332,7 @@ pub async fn list_indexed_sources(db: &Connection) -> Result<Vec<IndexedSource>>
         return Ok(Vec::new());
     };
 
-    let batches = table
+    let mut stream = table
         .query()
         .select(Select::columns(&[
             "source_path",
@@ -341,10 +341,13 @@ pub async fn list_indexed_sources(db: &Connection) -> Result<Vec<IndexedSource>>
             "format",
         ]))
         .execute()
-        .await?
-        .try_collect::<Vec<_>>()
         .await?;
-    collect_indexed_sources(&batches)
+    let mut sources = BTreeMap::new();
+    let mut pages_by_source = BTreeMap::new();
+    while let Some(batch) = stream.try_next().await? {
+        accumulate_indexed_sources(&mut sources, &mut pages_by_source, &batch)?;
+    }
+    Ok(finalize_indexed_sources(sources, pages_by_source))
 }
 
 /// Lists lightweight indexed source metadata without scanning chunk text.
@@ -353,7 +356,7 @@ pub async fn list_indexed_source_summaries(db: &Connection) -> Result<Vec<Indexe
         return Ok(Vec::new());
     };
 
-    let batches = table
+    let mut stream = table
         .query()
         .select(Select::columns(&[
             "source_path",
@@ -362,10 +365,13 @@ pub async fn list_indexed_source_summaries(db: &Connection) -> Result<Vec<Indexe
             "metadata",
         ]))
         .execute()
-        .await?
-        .try_collect::<Vec<_>>()
         .await?;
-    collect_indexed_source_summaries(&batches)
+    let mut sources = BTreeMap::new();
+    let mut pages_by_source = BTreeMap::new();
+    while let Some(batch) = stream.try_next().await? {
+        accumulate_indexed_source_summaries(&mut sources, &mut pages_by_source, &batch)?;
+    }
+    Ok(finalize_indexed_source_summaries(sources, pages_by_source))
 }
 
 /// Loads lightweight metadata for a single indexed source path.
@@ -377,7 +383,7 @@ pub async fn load_indexed_source_summary(
         return Ok(None);
     };
 
-    let batches = table
+    let mut stream = table
         .query()
         .only_if(format!("source_path = {}", sql_string(source_path)))
         .select(Select::columns(&[
@@ -387,10 +393,13 @@ pub async fn load_indexed_source_summary(
             "metadata",
         ]))
         .execute()
-        .await?
-        .try_collect::<Vec<_>>()
         .await?;
-    Ok(collect_indexed_source_summaries(&batches)?
+    let mut sources = BTreeMap::new();
+    let mut pages_by_source = BTreeMap::new();
+    while let Some(batch) = stream.try_next().await? {
+        accumulate_indexed_source_summaries(&mut sources, &mut pages_by_source, &batch)?;
+    }
+    Ok(finalize_indexed_source_summaries(sources, pages_by_source)
         .into_iter()
         .next())
 }
@@ -578,150 +587,164 @@ pub fn extract_contexts(batches: &[RecordBatch]) -> Result<Vec<String>> {
 }
 
 /// Collects lightweight per-source metadata from stored chunk batches.
+#[cfg(test)]
 pub fn collect_indexed_source_summaries(
     batches: &[RecordBatch],
 ) -> Result<Vec<IndexedSourceSummary>> {
-    let mut sources: BTreeMap<String, IndexedSourceSummary> = BTreeMap::new();
-    let mut pages_by_source: BTreeMap<String, BTreeSet<i32>> = BTreeMap::new();
-
+    let mut sources = BTreeMap::new();
+    let mut pages_by_source = BTreeMap::new();
     for batch in batches {
-        let source_col = batch
-            .column_by_name("source_path")
-            .context("source_path column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("source_path column type")?;
-        let page_col = batch
-            .column_by_name("page")
-            .context("page column missing")?
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .context("page column type")?;
-        let format_col = batch
-            .column_by_name("format")
-            .context("format column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("format column type")?;
-        let metadata_col = batch
-            .column_by_name("metadata")
-            .context("metadata column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("metadata column type")?;
+        accumulate_indexed_source_summaries(&mut sources, &mut pages_by_source, batch)?;
+    }
+    Ok(finalize_indexed_source_summaries(sources, pages_by_source))
+}
 
-        for i in 0..batch.num_rows() {
-            let source = source_col.value(i);
-            let absolute_path = serde_json::from_str::<serde_json::Value>(metadata_col.value(i))
-                .ok()
-                .and_then(|metadata| {
-                    metadata
-                        .get("source_absolute_path")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_string)
-                });
-            let entry = sources
+fn accumulate_indexed_source_summaries(
+    sources: &mut BTreeMap<String, IndexedSourceSummary>,
+    pages_by_source: &mut BTreeMap<String, BTreeSet<i32>>,
+    batch: &RecordBatch,
+) -> Result<()> {
+    let source_col = batch
+        .column_by_name("source_path")
+        .context("source_path column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("source_path column type")?;
+    let page_col = batch
+        .column_by_name("page")
+        .context("page column missing")?
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .context("page column type")?;
+    let format_col = batch
+        .column_by_name("format")
+        .context("format column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("format column type")?;
+    let metadata_col = batch
+        .column_by_name("metadata")
+        .context("metadata column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("metadata column type")?;
+
+    for i in 0..batch.num_rows() {
+        let source = source_col.value(i);
+        let entry = sources
+            .entry(source.to_string())
+            .or_insert_with(|| IndexedSourceSummary {
+                source_path: source.to_string(),
+                format: format_col.value(i).to_string(),
+                ..Default::default()
+            });
+        if entry.source_absolute_path.is_none() {
+            entry.source_absolute_path = source_absolute_path_from_metadata(metadata_col.value(i));
+        }
+        entry.chunks += 1;
+
+        let page = page_col.value(i);
+        if page > 0 {
+            pages_by_source
                 .entry(source.to_string())
-                .or_insert_with(|| IndexedSourceSummary {
-                    source_path: source.to_string(),
-                    source_absolute_path: absolute_path,
-                    format: format_col.value(i).to_string(),
-                    ..Default::default()
-                });
-            if entry.source_absolute_path.is_none() {
-                entry.source_absolute_path =
-                    serde_json::from_str::<serde_json::Value>(metadata_col.value(i))
-                        .ok()
-                        .and_then(|metadata| {
-                            metadata
-                                .get("source_absolute_path")
-                                .and_then(serde_json::Value::as_str)
-                                .map(str::to_string)
-                        });
-            }
-            entry.chunks += 1;
-
-            let page = page_col.value(i);
-            if page > 0 {
-                pages_by_source
-                    .entry(source.to_string())
-                    .or_default()
-                    .insert(page);
-            }
+                .or_default()
+                .insert(page);
         }
     }
 
+    Ok(())
+}
+
+fn finalize_indexed_source_summaries(
+    mut sources: BTreeMap<String, IndexedSourceSummary>,
+    pages_by_source: BTreeMap<String, BTreeSet<i32>>,
+) -> Vec<IndexedSourceSummary> {
     for (source, pages) in pages_by_source {
         if let Some(entry) = sources.get_mut(&source) {
             entry.page_count = pages.len();
         }
     }
-
-    Ok(sources.into_values().collect())
+    sources.into_values().collect()
 }
 
 /// Collects per-source metadata from stored chunk batches.
+#[cfg(test)]
 pub fn collect_indexed_sources(batches: &[RecordBatch]) -> Result<Vec<IndexedSource>> {
-    let mut sources: BTreeMap<String, IndexedSource> = BTreeMap::new();
-    let mut pages_by_source: BTreeMap<String, BTreeSet<i32>> = BTreeMap::new();
-
+    let mut sources = BTreeMap::new();
+    let mut pages_by_source = BTreeMap::new();
     for batch in batches {
-        let text_col = batch
-            .column_by_name("chunk_text")
-            .context("chunk_text column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("chunk_text column type")?;
-        let source_col = batch
-            .column_by_name("source_path")
-            .context("source_path column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("source_path column type")?;
-        let page_col = batch
-            .column_by_name("page")
-            .context("page column missing")?
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .context("page column type")?;
-        let format_col = batch
-            .column_by_name("format")
-            .context("format column missing")?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .context("format column type")?;
+        accumulate_indexed_sources(&mut sources, &mut pages_by_source, batch)?;
+    }
+    Ok(finalize_indexed_sources(sources, pages_by_source))
+}
 
-        for i in 0..batch.num_rows() {
-            let source = source_col.value(i);
-            let text = text_col.value(i);
-            let entry = sources
+fn accumulate_indexed_sources(
+    sources: &mut BTreeMap<String, IndexedSource>,
+    pages_by_source: &mut BTreeMap<String, BTreeSet<i32>>,
+    batch: &RecordBatch,
+) -> Result<()> {
+    let text_col = batch
+        .column_by_name("chunk_text")
+        .context("chunk_text column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("chunk_text column type")?;
+    let source_col = batch
+        .column_by_name("source_path")
+        .context("source_path column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("source_path column type")?;
+    let page_col = batch
+        .column_by_name("page")
+        .context("page column missing")?
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .context("page column type")?;
+    let format_col = batch
+        .column_by_name("format")
+        .context("format column missing")?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context("format column type")?;
+
+    for i in 0..batch.num_rows() {
+        let source = source_col.value(i);
+        let text = text_col.value(i);
+        let char_count = text.chars().count();
+        let entry = sources
+            .entry(source.to_string())
+            .or_insert_with(|| IndexedSource {
+                source_path: source.to_string(),
+                format: format_col.value(i).to_string(),
+                ..Default::default()
+            });
+        entry.chunks += 1;
+        entry.chars += char_count;
+        entry.estimated_tokens += estimate_token_count_from_chars(char_count);
+
+        let page = page_col.value(i);
+        if page > 0 {
+            pages_by_source
                 .entry(source.to_string())
-                .or_insert_with(|| IndexedSource {
-                    source_path: source.to_string(),
-                    format: format_col.value(i).to_string(),
-                    ..Default::default()
-                });
-            entry.chunks += 1;
-            entry.chars += text.chars().count();
-            entry.estimated_tokens += estimate_token_count(text);
-
-            let page = page_col.value(i);
-            if page > 0 {
-                pages_by_source
-                    .entry(source.to_string())
-                    .or_default()
-                    .insert(page);
-            }
+                .or_default()
+                .insert(page);
         }
     }
 
+    Ok(())
+}
+
+fn finalize_indexed_sources(
+    mut sources: BTreeMap<String, IndexedSource>,
+    pages_by_source: BTreeMap<String, BTreeSet<i32>>,
+) -> Vec<IndexedSource> {
     for (source, pages) in pages_by_source {
         if let Some(entry) = sources.get_mut(&source) {
             entry.page_count = pages.len();
         }
     }
-
-    Ok(sources.into_values().collect())
+    sources.into_values().collect()
 }
 
 /// Collects summary statistics from stored chunk batches.
@@ -860,8 +883,22 @@ fn sql_like_prefix(value: &str) -> String {
     format!("'{escaped}%'")
 }
 
+fn source_absolute_path_from_metadata(raw: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|metadata| {
+            metadata
+                .get("source_absolute_path")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+}
+
 fn estimate_token_count(text: &str) -> usize {
-    let chars = text.chars().count();
+    estimate_token_count_from_chars(text.chars().count())
+}
+
+fn estimate_token_count_from_chars(chars: usize) -> usize {
     chars.div_ceil(4)
 }
 


### PR DESCRIPTION
## Summary
- add `sources`/`ls` to inspect indexed source paths with per-source metadata
- add `delete`, `clear`, and `prune` commands for intentional store maintenance
- document the new commands and safeguards in the README and Taskfile

## Testing
- cargo fmt -- --check
- cargo test

Closes #11