### PR TITLE
fix(rust): remove compiler warnings

### DIFF
--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -1,4 +1,4 @@
-use crate::config::{ensure_store_layout, load_or_create_config, store_dir, STORE_SUBDIRECTORIES};
+use crate::config::{ensure_store_layout, load_or_create_config, store_dir};
 use crate::store::{
     collect_store_stats, connect_db, load_metadata, StoreMetadata, StoreStats, DEFAULT_TABLE_NAME,
 };
@@ -143,6 +143,7 @@ fn print_human(report: &StatReport) {
     }
 }
 
+#[cfg(test)]
 pub fn dir_size_bytes(path: &Path) -> Result<u64> {
     if !path.exists() {
         return Ok(0);
@@ -255,6 +256,7 @@ pub fn fmt_count(value: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::STORE_SUBDIRECTORIES;
     use crate::test_support::with_test_env;
 
     #[test]

--- a/src/jsonutil.rs
+++ b/src/jsonutil.rs
@@ -84,12 +84,7 @@ mod tests {
 
     #[test]
     fn test_parse_json_includes_raw_snippet_in_error() {
-        #[derive(Debug, serde::Deserialize)]
-        struct Foo {
-            a: i32,
-        }
-
-        let err = parse_json::<Foo>("not json at all", "parse foo").unwrap_err();
+        let err = parse_json::<serde_json::Value>("not json at all", "parse foo").unwrap_err();
         let err_msg = err.to_string();
         assert!(err_msg.contains("parse foo"));
         assert!(err_msg.contains("not json"));

--- a/src/store.rs
+++ b/src/store.rs
@@ -560,6 +560,7 @@ pub fn build_retrieval_filter(
 }
 
 /// Extracts retrieval contexts from query result batches.
+#[cfg(test)]
 pub fn extract_contexts(batches: &[RecordBatch]) -> Result<Vec<String>> {
     let mut out = Vec::new();
     for batch in batches {


### PR DESCRIPTION
## Summary
- gate test-only helpers in `stat` and `store` behind `#[cfg(test)]`
- move the `STORE_SUBDIRECTORIES` import into the `stat` test module
- simplify the `jsonutil` error-path test to avoid a dead-code warning

## Testing
- cargo check
- cargo test --all-targets