### PR TITLE
feat(telemetry): add OTLP trace export bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4134,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4648,9 @@ dependencies = [
  "html2text",
  "indicatif",
  "lancedb",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pdf-extract",
  "reqwest",
  "reqwest-middleware",
@@ -4572,6 +4663,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "walkdir",
  "xdg",
@@ -4794,6 +4886,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4997,6 +5090,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5993,6 +6087,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,11 +6133,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6084,6 +6221,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ html2text = "0.13"
 indicatif = "0.17"
 lancedb = "0.26"
 pdf-extract = "0.10"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -42,7 +42,11 @@ xdg = "2"
 arrow-array = "57"
 arrow-schema = "57"
 tracing = "0.1.44"
+tracing-opentelemetry = { version = "0.32.1", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+opentelemetry = { version = "0.31", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "http-proto", "grpc-tonic", "reqwest-blocking-client", "tls-roots"] }
 
 [dev-dependencies]
 reqwest-middleware = "0.4"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,48 @@ Supported indexable formats currently include:
 - PDF: `.pdf`
 - images: `.png`, `.jpg`, `.jpeg`, `.webp`
 
+## Telemetry
+
+`ragcli` can optionally export tracing spans over OTLP while keeping the normal stderr log output.
+
+OTLP export is disabled unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+Currently supported protocols:
+
+- `http/protobuf` (default when `OTEL_EXPORTER_OTLP_PROTOCOL` is unset)
+- `grpc`
+
+Common environment variables:
+
+```bash
+export OTEL_SERVICE_NAME=ragcli
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_TIMEOUT=10000
+# optional
+export OTEL_EXPORTER_OTLP_HEADERS="api_key=..."
+```
+
+Collector example:
+
+```bash
+export OTEL_SERVICE_NAME=ragcli
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+ragcli doctor
+```
+
+Phoenix local example:
+
+```bash
+export OTEL_SERVICE_NAME=ragcli
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006
+ragcli query "What is this project about?"
+```
+
+For `http/protobuf`, `ragcli` sends traces to the OTLP traces endpoint by appending `/v1/traces` when needed.
+
 ## Storage
 
 Each store lives under:

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006
 ragcli query "What is this project about?"
 ```
 
-For `http/protobuf`, `ragcli` sends traces to the OTLP traces endpoint by appending `/v1/traces` when needed.
+For `http/protobuf`, `ragcli` appends `/v1/traces` only when the configured endpoint has no path (for example `http://localhost:4318`). If you provide a custom path such as `http://localhost:6006/ingest`, that path is used as-is.
 
 ## Storage
 

--- a/docs/otel-implementation-checklist.md
+++ b/docs/otel-implementation-checklist.md
@@ -1,0 +1,75 @@
+# OpenTelemetry / OTLP implementation checklist
+
+This checklist tracks the planned work to add optional OpenTelemetry trace export to `ragcli`, including support for Phoenix and other OTLP-compatible backends.
+
+## Related GitHub issues
+
+- [ ] #46 — `epic(telemetry): track OTLP export integration`
+  - https://github.com/mfmezger/ragcli/issues/46
+- [ ] #43 — `feat(telemetry): add OTLP bootstrap and exporter config`
+  - https://github.com/mfmezger/ragcli/issues/43
+- [ ] #44 — `feat(tracing): instrument query, index, and Ollama spans`
+  - https://github.com/mfmezger/ragcli/issues/44
+- [ ] #45 — `docs(telemetry): add doctor output, docs, and validation`
+  - https://github.com/mfmezger/ragcli/issues/45
+
+## Milestone 1: OTLP bootstrap and exporter configuration
+
+- [x] Add `src/telemetry.rs`
+- [x] Replace `init_tracing()` in `src/main.rs` with telemetry bootstrap logic
+- [x] Keep existing stderr `tracing_subscriber::fmt` output by default
+- [x] Add optional OTLP trace export via OpenTelemetry
+- [x] Support standard env vars:
+  - [x] `OTEL_SERVICE_NAME`
+  - [x] `OTEL_EXPORTER_OTLP_ENDPOINT`
+  - [x] `OTEL_EXPORTER_OTLP_HEADERS`
+  - [x] `OTEL_EXPORTER_OTLP_PROTOCOL`
+  - [x] `OTEL_EXPORTER_OTLP_TIMEOUT`
+- [x] Decide and document enablement behavior when OTLP env vars are absent
+- [x] Configure resource attributes:
+  - [x] `service.name`
+  - [x] `service.version`
+  - [ ] optional deployment/resource attributes
+- [x] Use batch exporting, not per-span simple export
+- [x] Add graceful tracer shutdown / flush on process exit
+- [x] Confirm both `http/protobuf` and `grpc` behavior or explicitly document supported protocol(s)
+
+## Milestone 2: Instrumentation
+
+- [ ] Keep or improve root command span in `src/app.rs`
+- [ ] Add attributes for command/store/query mode at the command level
+- [ ] Expand indexing spans in `src/commands/index.rs`
+- [ ] Add query lifecycle spans in `src/query/execute.rs`
+- [ ] Add retrieval/rerank spans in `src/query/retrieve.rs` and `src/query/rerank.rs`
+- [ ] Add Ollama spans in `src/models.rs` for:
+  - [ ] tags/model discovery
+  - [ ] embeddings
+  - [ ] chat/generation
+  - [ ] vision captioning
+- [ ] Record safe metadata only by default:
+  - [ ] model name
+  - [ ] endpoint/host
+  - [ ] duration
+  - [ ] counts and sizes
+  - [ ] success/failure
+- [ ] Avoid exporting full prompts, contexts, image bytes, or source content by default
+
+## Milestone 3: Doctor, docs, and validation
+
+- [ ] Extend `doctor` to report telemetry configuration
+- [ ] Redact secrets when reporting OTLP headers/auth presence
+- [ ] Add README documentation for OTLP export
+- [ ] Add a Phoenix example
+- [ ] Add a generic Collector example
+- [ ] Document privacy considerations and what is/is not exported by default
+- [ ] Add unit tests for telemetry config parsing and disabled/enabled paths
+- [ ] Add smoke/integration coverage for OTLP-enabled startup
+- [ ] Optionally add a collector-backed integration test later
+
+## Open questions
+
+- [ ] Should OTEL be enabled automatically when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, or require an explicit `RAGCLI_OTEL_ENABLED` flag?
+- [ ] Should exporter init failure warn-and-continue by default, or fail fast?
+- [ ] Should `doctor` attempt any connectivity validation for OTLP endpoints, or only print resolved config?
+- [ ] Should we add `RAGCLI_OTEL_STRICT` and/or `RAGCLI_OTEL_CONSOLE` toggles?
+- [ ] Do we want any LLM semantic-convention attributes now, or keep v1 generic?

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,17 +23,25 @@ use clap::Parser;
 use cli::Cli;
 
 fn main() -> Result<()> {
-    let mut telemetry = telemetry::init()?;
     let cli = Cli::parse();
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    let result = runtime.block_on(app::run(cli));
-    drop(runtime);
 
-    if let Err(err) = telemetry.shutdown() {
+    let mut telemetry = {
+        let _guard = runtime.enter();
+        telemetry::init()?
+    };
+
+    let result = runtime.block_on(app::run(cli));
+
+    if let Err(err) = {
+        let _guard = runtime.enter();
+        telemetry.shutdown()
+    } {
         eprintln!("telemetry shutdown error: {err}");
     }
 
+    drop(runtime);
     result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,41 +14,26 @@ mod retrieval;
 mod rewrite;
 mod source_kind;
 mod store;
+mod telemetry;
 #[cfg(test)]
 mod test_support;
 
 use anyhow::Result;
 use clap::Parser;
 use cli::Cli;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-
-fn init_tracing() {
-    INIT.get_or_init(|| {
-        let filter = match std::env::var("RUST_LOG") {
-            Ok(value) => EnvFilter::try_new(&value).unwrap_or_else(|err| {
-                eprintln!("failed to parse RUST_LOG, using default 'info' filter: {err}");
-                EnvFilter::new("info")
-            }),
-            Err(std::env::VarError::NotPresent) => EnvFilter::new("info"),
-            Err(std::env::VarError::NotUnicode(_)) => {
-                eprintln!(
-                    "failed to parse RUST_LOG, using default 'info' filter: not valid unicode"
-                );
-                EnvFilter::new("info")
-            }
-        };
-        tracing_subscriber::registry()
-            .with(fmt::layer().with_writer(std::io::stderr))
-            .with(filter)
-            .init();
-    });
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    init_tracing();
+fn main() -> Result<()> {
+    let mut telemetry = telemetry::init()?;
     let cli = Cli::parse();
-    app::run(cli).await
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let result = runtime.block_on(app::run(cli));
+    drop(runtime);
+
+    if let Err(err) = telemetry.shutdown() {
+        eprintln!("telemetry shutdown error: {err}");
+    }
+
+    result
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,318 @@
+use anyhow::{anyhow, Context, Result};
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
+use reqwest::blocking::Client;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+const DEFAULT_FILTER: &str = "info";
+const DEFAULT_SERVICE_NAME: &str = env!("CARGO_PKG_NAME");
+const SERVICE_VERSION_KEY: &str = "service.version";
+const HTTP_TRACES_PATH: &str = "/v1/traces";
+
+pub const ENV_OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+pub const ENV_OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+pub const ENV_OTEL_EXPORTER_OTLP_HEADERS: &str = "OTEL_EXPORTER_OTLP_HEADERS";
+pub const ENV_OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
+pub const ENV_OTEL_EXPORTER_OTLP_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_TIMEOUT";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OtlpProtocol {
+    HttpProtobuf,
+    Grpc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TelemetryConfig {
+    pub enabled: bool,
+    pub service_name: String,
+    pub endpoint: Option<String>,
+    pub protocol: OtlpProtocol,
+    pub timeout_ms: Option<u64>,
+    pub headers_configured: bool,
+}
+
+impl TelemetryConfig {
+    pub fn from_env() -> Result<Self> {
+        let endpoint = read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+        let protocol = match read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_PROTOCOL).as_deref() {
+            None => OtlpProtocol::HttpProtobuf,
+            Some("http/protobuf") => OtlpProtocol::HttpProtobuf,
+            Some("grpc") => OtlpProtocol::Grpc,
+            Some(value) => {
+                anyhow::bail!(
+                    "unsupported {} value: {} (expected 'http/protobuf' or 'grpc')",
+                    ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
+                    value
+                )
+            }
+        };
+        let timeout_ms = match read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_TIMEOUT) {
+            Some(value) => Some(value.parse().with_context(|| {
+                format!("parse {} as milliseconds", ENV_OTEL_EXPORTER_OTLP_TIMEOUT)
+            })?),
+            None => None,
+        };
+
+        Ok(Self {
+            enabled: endpoint.is_some(),
+            service_name: read_non_empty_env(ENV_OTEL_SERVICE_NAME)
+                .unwrap_or_else(|| DEFAULT_SERVICE_NAME.to_string()),
+            endpoint,
+            protocol,
+            timeout_ms,
+            headers_configured: read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_HEADERS).is_some(),
+        })
+    }
+
+    pub fn resolved_export_endpoint(&self) -> Option<String> {
+        let endpoint = self.endpoint.as_deref()?;
+        Some(match self.protocol {
+            OtlpProtocol::HttpProtobuf => normalize_http_traces_endpoint(endpoint),
+            OtlpProtocol::Grpc => endpoint.to_string(),
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct TelemetryGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+}
+
+impl TelemetryGuard {
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    pub fn shutdown(&mut self) -> Result<()> {
+        if let Some(provider) = self.tracer_provider.take() {
+            provider
+                .shutdown()
+                .map_err(|err| anyhow!(err.to_string()))
+                .context("shutdown OTLP tracer provider")?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.shutdown() {
+            eprintln!("failed to shutdown telemetry: {err}");
+        }
+    }
+}
+
+pub fn init() -> Result<TelemetryGuard> {
+    let filter = build_env_filter();
+    let config = TelemetryConfig::from_env()?;
+    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
+
+    if !config.enabled {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .init();
+        return Ok(TelemetryGuard::disabled());
+    }
+
+    let tracer_provider = build_tracer_provider(&config)?;
+    let tracer = tracer_provider.tracer(DEFAULT_SERVICE_NAME.to_string());
+    global::set_tracer_provider(tracer_provider.clone());
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(OpenTelemetryLayer::new(tracer))
+        .init();
+
+    Ok(TelemetryGuard {
+        tracer_provider: Some(tracer_provider),
+    })
+}
+
+fn build_tracer_provider(config: &TelemetryConfig) -> Result<SdkTracerProvider> {
+    let resource = Resource::builder()
+        .with_service_name(config.service_name.clone())
+        .with_attributes([KeyValue::new(
+            SERVICE_VERSION_KEY,
+            env!("CARGO_PKG_VERSION"),
+        )])
+        .build();
+
+    let endpoint = config
+        .resolved_export_endpoint()
+        .context("telemetry endpoint missing while OTLP export is enabled")?;
+
+    let exporter = match config.protocol {
+        OtlpProtocol::HttpProtobuf => SpanExporter::builder()
+            .with_http()
+            .with_http_client(Client::new())
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(endpoint)
+            .with_timeout(timeout_or_default(config.timeout_ms))
+            .build()
+            .context("build OTLP HTTP trace exporter")?,
+        OtlpProtocol::Grpc => SpanExporter::builder()
+            .with_tonic()
+            .with_protocol(Protocol::Grpc)
+            .with_endpoint(endpoint)
+            .with_timeout(timeout_or_default(config.timeout_ms))
+            .build()
+            .context("build OTLP gRPC trace exporter")?,
+    };
+
+    Ok(SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build())
+}
+
+fn timeout_or_default(timeout_ms: Option<u64>) -> std::time::Duration {
+    std::time::Duration::from_millis(timeout_ms.unwrap_or(10_000))
+}
+
+fn build_env_filter() -> EnvFilter {
+    match std::env::var("RUST_LOG") {
+        Ok(value) => EnvFilter::try_new(&value).unwrap_or_else(|err| {
+            eprintln!("failed to parse RUST_LOG, using default '{DEFAULT_FILTER}' filter: {err}");
+            EnvFilter::new(DEFAULT_FILTER)
+        }),
+        Err(std::env::VarError::NotPresent) => EnvFilter::new(DEFAULT_FILTER),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eprintln!(
+                "failed to parse RUST_LOG, using default '{DEFAULT_FILTER}' filter: not valid unicode"
+            );
+            EnvFilter::new(DEFAULT_FILTER)
+        }
+    }
+}
+
+fn read_non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_http_traces_endpoint(endpoint: &str) -> String {
+    if endpoint.ends_with(HTTP_TRACES_PATH) {
+        endpoint.to_string()
+    } else {
+        format!("{}{HTTP_TRACES_PATH}", endpoint.trim_end_matches('/'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_env_lock;
+    use std::env;
+
+    #[test]
+    fn test_telemetry_config_disabled_without_endpoint() {
+        let _guard = test_env_lock().lock().unwrap();
+        let previous_endpoint = env::var_os(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+        let previous_service_name = env::var_os(ENV_OTEL_SERVICE_NAME);
+        let previous_protocol = env::var_os(ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
+
+        unsafe {
+            env::remove_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+            env::remove_var(ENV_OTEL_SERVICE_NAME);
+            env::remove_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
+        }
+
+        let config = TelemetryConfig::from_env().unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.service_name, DEFAULT_SERVICE_NAME);
+        assert_eq!(config.protocol, OtlpProtocol::HttpProtobuf);
+
+        unsafe {
+            restore_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT, previous_endpoint);
+            restore_var(ENV_OTEL_SERVICE_NAME, previous_service_name);
+            restore_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL, previous_protocol);
+        }
+    }
+
+    #[test]
+    fn test_telemetry_config_reads_protocol_and_timeout() {
+        let _guard = test_env_lock().lock().unwrap();
+        let previous_endpoint = env::var_os(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+        let previous_protocol = env::var_os(ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
+        let previous_timeout = env::var_os(ENV_OTEL_EXPORTER_OTLP_TIMEOUT);
+        let previous_headers = env::var_os(ENV_OTEL_EXPORTER_OTLP_HEADERS);
+
+        unsafe {
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT, "http://collector:4317");
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL, "grpc");
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_TIMEOUT, "2500");
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_HEADERS, "api_key=test");
+        }
+
+        let config = TelemetryConfig::from_env().unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.protocol, OtlpProtocol::Grpc);
+        assert_eq!(config.timeout_ms, Some(2500));
+        assert!(config.headers_configured);
+        assert_eq!(
+            config.resolved_export_endpoint().as_deref(),
+            Some("http://collector:4317")
+        );
+
+        unsafe {
+            restore_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT, previous_endpoint);
+            restore_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL, previous_protocol);
+            restore_var(ENV_OTEL_EXPORTER_OTLP_TIMEOUT, previous_timeout);
+            restore_var(ENV_OTEL_EXPORTER_OTLP_HEADERS, previous_headers);
+        }
+    }
+
+    #[test]
+    fn test_http_endpoint_appends_traces_path() {
+        let config = TelemetryConfig {
+            enabled: true,
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
+            endpoint: Some("http://localhost:6006".to_string()),
+            protocol: OtlpProtocol::HttpProtobuf,
+            timeout_ms: None,
+            headers_configured: false,
+        };
+
+        assert_eq!(
+            config.resolved_export_endpoint().as_deref(),
+            Some("http://localhost:6006/v1/traces")
+        );
+    }
+
+    #[test]
+    fn test_invalid_protocol_is_rejected() {
+        let _guard = test_env_lock().lock().unwrap();
+        let previous_endpoint = env::var_os(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+        let previous_protocol = env::var_os(ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
+
+        unsafe {
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT, "http://collector:4318");
+            env::set_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL, "http/json");
+        }
+
+        let err = TelemetryConfig::from_env().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unsupported OTEL_EXPORTER_OTLP_PROTOCOL value"));
+
+        unsafe {
+            restore_var(ENV_OTEL_EXPORTER_OTLP_ENDPOINT, previous_endpoint);
+            restore_var(ENV_OTEL_EXPORTER_OTLP_PROTOCOL, previous_protocol);
+        }
+    }
+
+    unsafe fn restore_var(name: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => env::set_var(name, value),
+            None => env::remove_var(name),
+        }
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -94,7 +94,7 @@ impl TelemetryGuard {
         if let Some(provider) = self.tracer_provider.take() {
             provider
                 .shutdown()
-                .map_err(|err| anyhow!(err.to_string()))
+                .map_err(|err| anyhow!(err))
                 .context("shutdown OTLP tracer provider")?;
         }
         Ok(())
@@ -153,7 +153,11 @@ fn build_tracer_provider(config: &TelemetryConfig) -> Result<SdkTracerProvider> 
     let exporter = match config.protocol {
         OtlpProtocol::HttpProtobuf => SpanExporter::builder()
             .with_http()
-            .with_http_client(Client::new())
+            .with_http_client(
+                Client::builder()
+                    .build()
+                    .context("create OTLP HTTP client")?,
+            )
             .with_protocol(Protocol::HttpBinary)
             .with_endpoint(endpoint)
             .with_timeout(timeout_or_default(config.timeout_ms))

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -64,6 +64,9 @@ impl TelemetryConfig {
             endpoint,
             protocol,
             timeout_ms,
+            // Header values are consumed directly by opentelemetry-otlp from the
+            // standard OTEL env vars. We only retain a redaction-safe boolean here
+            // for future diagnostics output.
             headers_configured: read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_HEADERS).is_some(),
         })
     }
@@ -199,11 +202,14 @@ fn read_non_empty_env(name: &str) -> Option<String> {
 }
 
 fn normalize_http_traces_endpoint(endpoint: &str) -> String {
-    if endpoint.ends_with(HTTP_TRACES_PATH) {
-        endpoint.to_string()
-    } else {
-        format!("{}{HTTP_TRACES_PATH}", endpoint.trim_end_matches('/'))
+    if let Ok(url) = reqwest::Url::parse(endpoint) {
+        let path = url.path();
+        if path.is_empty() || path == "/" {
+            return format!("{}{HTTP_TRACES_PATH}", endpoint.trim_end_matches('/'));
+        }
     }
+
+    endpoint.to_string()
 }
 
 #[cfg(test)]
@@ -284,6 +290,23 @@ mod tests {
         assert_eq!(
             config.resolved_export_endpoint().as_deref(),
             Some("http://localhost:6006/v1/traces")
+        );
+    }
+
+    #[test]
+    fn test_http_endpoint_keeps_custom_path() {
+        let config = TelemetryConfig {
+            enabled: true,
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
+            endpoint: Some("http://localhost:6006/ingest".to_string()),
+            protocol: OtlpProtocol::HttpProtobuf,
+            timeout_ms: None,
+            headers_configured: false,
+        };
+
+        assert_eq!(
+            config.resolved_export_endpoint().as_deref(),
+            Some("http://localhost:6006/ingest")
         );
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -118,19 +118,22 @@ pub fn init() -> Result<TelemetryGuard> {
         tracing_subscriber::registry()
             .with(filter)
             .with(fmt_layer)
-            .init();
+            .try_init()
+            .context("initialize tracing subscriber")?;
         return Ok(TelemetryGuard::disabled());
     }
 
     let tracer_provider = build_tracer_provider(&config)?;
     let tracer = tracer_provider.tracer(DEFAULT_SERVICE_NAME.to_string());
-    global::set_tracer_provider(tracer_provider.clone());
 
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
         .with(OpenTelemetryLayer::new(tracer))
-        .init();
+        .try_init()
+        .context("initialize tracing subscriber")?;
+
+    global::set_tracer_provider(tracer_provider.clone());
 
     Ok(TelemetryGuard {
         tracer_provider: Some(tracer_provider),


### PR DESCRIPTION
## Summary
- add optional OTLP trace export bootstrap with env-based configuration
- keep existing stderr tracing output while enabling OpenTelemetry export
- document OTLP usage and update the local implementation checklist

## Changes
- add `src/telemetry.rs` to initialize OTLP exporters and tracer shutdown
- replace the old tracing init in `src/main.rs` with telemetry bootstrap + manual Tokio runtime shutdown
- add OpenTelemetry dependencies in `Cargo.toml`
- document supported OTLP env vars and collector/Phoenix examples in `README.md`
- mark Milestone 1 progress in `docs/otel-implementation-checklist.md`

## Validation
- `cargo check`
- `cargo test --all-targets`
- `cargo fmt -- --check`
- local smoke test verifying HTTP OTLP export posts to `/v1/traces`

Closes #43
Refs #46
