### PR TITLE
feat(tracing): add query and Ollama spans

### DIFF
--- a/docs/otel-implementation-checklist.md
+++ b/docs/otel-implementation-checklist.md
@@ -36,23 +36,23 @@ This checklist tracks the planned work to add optional OpenTelemetry trace expor
 
 ## Milestone 2: Instrumentation
 
-- [ ] Keep or improve root command span in `src/app.rs`
-- [ ] Add attributes for command/store/query mode at the command level
-- [ ] Expand indexing spans in `src/commands/index.rs`
-- [ ] Add query lifecycle spans in `src/query/execute.rs`
-- [ ] Add retrieval/rerank spans in `src/query/retrieve.rs` and `src/query/rerank.rs`
-- [ ] Add Ollama spans in `src/models.rs` for:
-  - [ ] tags/model discovery
-  - [ ] embeddings
-  - [ ] chat/generation
-  - [ ] vision captioning
-- [ ] Record safe metadata only by default:
-  - [ ] model name
-  - [ ] endpoint/host
-  - [ ] duration
-  - [ ] counts and sizes
-  - [ ] success/failure
-- [ ] Avoid exporting full prompts, contexts, image bytes, or source content by default
+- [x] Keep or improve root command span in `src/app.rs`
+- [x] Add attributes for command/store/query mode at the command level
+- [x] Expand indexing spans in `src/commands/index.rs`
+- [x] Add query lifecycle spans in `src/query/execute.rs`
+- [x] Add retrieval/rerank spans in `src/query/retrieve.rs` and `src/query/rerank.rs`
+- [x] Add Ollama spans in `src/models.rs` for:
+  - [x] tags/model discovery
+  - [x] embeddings
+  - [x] chat/generation
+  - [x] vision captioning
+- [x] Record safe metadata only by default:
+  - [x] model name
+  - [x] endpoint/host
+  - [x] duration
+  - [x] counts and sizes
+  - [x] success/failure
+- [x] Avoid exporting full prompts, contexts, image bytes, or source content by default
 
 ## Milestone 3: Doctor, docs, and validation
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,18 @@
 use crate::cli::{Cli, Command, ConfigCommand};
 use crate::commands;
 use anyhow::Result;
-use tracing::Instrument;
+use tracing::{field, Instrument};
 
 pub async fn run(cli: Cli) -> Result<()> {
     let name = cli.name.as_deref();
     let span_name = name.unwrap_or("default");
-    tracing::info!(name = span_name, "starting ragcli");
-    let span = tracing::info_span!("command_dispatch", name = span_name);
+    let command_name = command_name(&cli.command);
+    tracing::info!(name = span_name, command = command_name, "starting ragcli");
+    let span = tracing::info_span!(
+        "command_dispatch",
+        store_name = span_name,
+        command = command_name
+    );
 
     async move {
         match cli.command {
@@ -54,6 +59,20 @@ pub async fn run(cli: Cli) -> Result<()> {
                 gen_model,
                 max_tokens,
             } => {
+                let span = tracing::info_span!(
+                    "query_command",
+                    mode = ?mode,
+                    top_k,
+                    fetch_k,
+                    max_iterations,
+                    rewrite,
+                    rerank,
+                    has_source_filter = source.is_some(),
+                    has_path_prefix_filter = path_prefix.is_some(),
+                    page = field::debug(page),
+                    has_format_filter = format.is_some(),
+                    max_tokens
+                );
                 commands::query::run(
                     name,
                     commands::query::QueryCommand {
@@ -77,6 +96,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                         max_tokens,
                     },
                 )
+                .instrument(span)
                 .await?
             }
             Command::Config { command } => match command {
@@ -99,4 +119,18 @@ pub async fn run(cli: Cli) -> Result<()> {
     }
     .instrument(span)
     .await
+}
+
+fn command_name(command: &Command) -> &'static str {
+    match command {
+        Command::Index { .. } => "index",
+        Command::Query { .. } => "query",
+        Command::Config { .. } => "config",
+        Command::Sources { .. } => "sources",
+        Command::Delete { .. } => "delete",
+        Command::Clear { .. } => "clear",
+        Command::Prune { .. } => "prune",
+        Command::Stat { .. } => "stat",
+        Command::Doctor { .. } => "doctor",
+    }
 }

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -9,7 +9,7 @@ use crate::store::{connect_db, ensure_metadata, load_source_fingerprints, replac
 use anyhow::Result;
 use std::path::PathBuf;
 use std::time::Instant;
-use tracing::Instrument;
+use tracing::{field, Instrument};
 
 pub async fn run(
     name: Option<&str>,
@@ -22,72 +22,112 @@ pub async fn run(
     include_hidden: bool,
     force: bool,
 ) -> Result<()> {
-    let started = Instant::now();
-    let store = store_dir(name)?;
-    ensure_store_layout(&store)?;
-    let cfg = load_or_create_config(&store)?;
-
-    let (size, overlap) = normalize_chunk_settings(
-        chunk_size.unwrap_or(cfg.chunk.size),
-        chunk_overlap.unwrap_or(cfg.chunk.overlap),
+    let command_span = tracing::info_span!(
+        "index_command",
+        store_name = name.unwrap_or("default"),
+        path = %path.display(),
+        requested_chunk_size = field::debug(chunk_size),
+        requested_chunk_overlap = field::debug(chunk_overlap),
+        requested_embed_model = field::debug(embed_model.as_deref()),
+        pdf_parser = field::debug(pdf_parser),
+        exclude_count = exclude.len(),
+        include_hidden,
+        force,
+        indexed_files = field::Empty,
+        total_chunks = field::Empty,
+        skipped_files = field::Empty,
+        error_count = field::Empty,
+        elapsed_ms = field::Empty,
     );
-    let embed_model_name =
-        embed_model.unwrap_or_else(|| resolve_model_name(&store, &cfg.models.embed));
 
-    let embedder = Embedder::new(cfg.ollama.base_url.clone(), embed_model_name.clone());
-    let vision = VisionCaptioner::new(
-        cfg.ollama.base_url.clone(),
-        resolve_model_name(&store, &cfg.models.vision),
-    );
-    let db = connect_db(&store).await?;
-    let existing_fingerprints = if force {
-        Default::default()
-    } else {
-        load_source_fingerprints(&db).await?
-    };
+    let command_span_inner = command_span.clone();
+    async move {
+        let started = Instant::now();
+        let store = store_dir(name)?;
+        ensure_store_layout(&store)?;
+        let cfg = load_or_create_config(&store)?;
 
-    let span = tracing::info_span!("ingest_path", path = %path.display());
-    let result = ingest_path(
-        &path,
-        size,
-        overlap,
-        &embedder,
-        Some(&vision),
-        match pdf_parser.unwrap_or(PdfParserArg::Native) {
+        let (size, overlap) = normalize_chunk_settings(
+            chunk_size.unwrap_or(cfg.chunk.size),
+            chunk_overlap.unwrap_or(cfg.chunk.overlap),
+        );
+        let embed_model_name =
+            embed_model.unwrap_or_else(|| resolve_model_name(&store, &cfg.models.embed));
+        let vision_model_name = resolve_model_name(&store, &cfg.models.vision);
+        command_span_inner.record("requested_chunk_size", size);
+        command_span_inner.record("requested_chunk_overlap", overlap);
+        command_span_inner.record("requested_embed_model", field::debug(&embed_model_name));
+
+        let embedder = Embedder::new(cfg.ollama.base_url.clone(), embed_model_name.clone());
+        let vision = VisionCaptioner::new(cfg.ollama.base_url.clone(), vision_model_name);
+        let db = connect_db(&store).await?;
+        let existing_fingerprints = if force {
+            Default::default()
+        } else {
+            load_source_fingerprints(&db).await?
+        };
+
+        let parser = match pdf_parser.unwrap_or(PdfParserArg::Native) {
             PdfParserArg::Native => PdfParser::Native,
             PdfParserArg::Liteparse => PdfParser::Liteparse,
-        },
-        &exclude,
-        include_hidden,
-        &existing_fingerprints,
-        force,
-    )
-    .instrument(span)
-    .await?;
+        };
+        let ingest_span = tracing::info_span!(
+            "ingest_path",
+            path = %path.display(),
+            chunk_size = size,
+            chunk_overlap = overlap,
+            parser = ?parser,
+            include_hidden,
+            force,
+        );
+        let result = ingest_path(
+            &path,
+            size,
+            overlap,
+            &embedder,
+            Some(&vision),
+            parser,
+            &exclude,
+            include_hidden,
+            &existing_fingerprints,
+            force,
+        )
+        .instrument(ingest_span)
+        .await?;
 
-    if let Some(dim) = result.embedding_dim {
-        ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
-    }
-
-    if !result.source_paths.is_empty() {
-        replace_source_rows(&db, &result.rows, &result.source_paths).await?;
-    }
-
-    println!(
-        "Index complete: {} files, {} chunks, {} skipped, {}ms",
-        result.stats.indexed_files,
-        result.stats.total_chunks,
-        result.stats.skipped_files,
-        started.elapsed().as_millis()
-    );
-
-    if !result.stats.errors.is_empty() {
-        for err in &result.stats.errors {
-            eprintln!("index error: {err}");
+        if let Some(dim) = result.embedding_dim {
+            ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;
         }
-    }
 
-    Ok(())
+        if !result.source_paths.is_empty() {
+            replace_source_rows(&db, &result.rows, &result.source_paths).await?;
+        }
+
+        let elapsed_ms = started.elapsed().as_millis();
+        command_span_inner.record("indexed_files", result.stats.indexed_files);
+        command_span_inner.record("total_chunks", result.stats.total_chunks);
+        command_span_inner.record("skipped_files", result.stats.skipped_files);
+        command_span_inner.record("error_count", result.stats.errors.len());
+        command_span_inner.record("elapsed_ms", elapsed_ms as u64);
+
+        println!(
+            "Index complete: {} files, {} chunks, {} skipped, {}ms",
+            result.stats.indexed_files,
+            result.stats.total_chunks,
+            result.stats.skipped_files,
+            elapsed_ms
+        );
+
+        if !result.stats.errors.is_empty() {
+            for err in &result.stats.errors {
+                eprintln!("index error: {err}");
+            }
+        }
+
+        Ok(())
+    }
+    .instrument(command_span)
+    .await
 }
 
 #[cfg(test)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -296,7 +296,6 @@ impl VisionCaptioner {
             operation = "vision",
             model = %self.model,
             endpoint_host = %endpoint_host(&self.base_url),
-            image_path = %image_path.display(),
             image_bytes = field::Empty,
             success = field::Empty,
             response_bytes = field::Empty,

--- a/src/models.rs
+++ b/src/models.rs
@@ -135,7 +135,7 @@ impl Embedder {
             operation = "embed",
             model = %self.model,
             endpoint_host = %endpoint_host(&self.base_url),
-            input_chars = text.chars().count(),
+            input_bytes = text.len(),
             success = field::Empty,
             embedding_dim = field::Empty,
             duration_ms = field::Empty,
@@ -225,11 +225,11 @@ impl Generator {
             operation = "chat",
             model = %self.model,
             endpoint_host = %endpoint_host(&self.base_url),
-            system_prompt_chars = system_prompt.chars().count(),
-            user_prompt_chars = user_prompt.chars().count(),
+            system_prompt_bytes = system_prompt.len(),
+            user_prompt_bytes = user_prompt.len(),
             max_tokens,
             success = field::Empty,
-            response_chars = field::Empty,
+            response_bytes = field::Empty,
             duration_ms = field::Empty,
         );
         let started = Instant::now();
@@ -272,7 +272,7 @@ impl Generator {
         span.record("success", result.is_ok());
         span.record("duration_ms", started.elapsed().as_millis() as u64);
         if let Ok(content) = &result {
-            span.record("response_chars", content.chars().count());
+            span.record("response_bytes", content.len());
         }
         result
     }
@@ -299,7 +299,7 @@ impl VisionCaptioner {
             image_path = %image_path.display(),
             image_bytes = field::Empty,
             success = field::Empty,
-            response_chars = field::Empty,
+            response_bytes = field::Empty,
             duration_ms = field::Empty,
         );
         let started = Instant::now();
@@ -344,7 +344,7 @@ impl VisionCaptioner {
         span.record("success", result.is_ok());
         span.record("duration_ms", started.elapsed().as_millis() as u64);
         if let Ok(content) = &result {
-            span.record("response_chars", content.chars().count());
+            span.record("response_bytes", content.len());
         }
         result
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,8 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use serde::Deserialize;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tracing::{field, Instrument};
 
 /// Embedding client backed by Ollama's `/api/embed` endpoint.
 pub struct Embedder {
@@ -75,19 +76,44 @@ impl OllamaClient {
 
     /// Returns the installed model names reported by Ollama.
     pub async fn list_models(&self) -> Result<Vec<String>> {
-        let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
-        let (status, body) = self
-            .client
-            .get_text(url)
-            .await
-            .context("call Ollama tags API")?;
-        if !status.is_success() {
-            anyhow::bail!("Ollama tags API error: {} - {}", status, body);
-        }
+        let span = tracing::info_span!(
+            "ollama_request",
+            backend = "ollama",
+            operation = "tags",
+            endpoint_host = %endpoint_host(&self.base_url),
+            success = field::Empty,
+            response_models = field::Empty,
+            duration_ms = field::Empty,
+        );
+        let started = Instant::now();
+        let result = async {
+            let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
+            let (status, body) = self
+                .client
+                .get_text(url)
+                .await
+                .context("call Ollama tags API")?;
+            if !status.is_success() {
+                anyhow::bail!("Ollama tags API error: {} - {}", status, body);
+            }
 
-        let parsed: TagsResponse =
-            serde_json::from_str(&body).context("parse Ollama tags response")?;
-        Ok(parsed.models.into_iter().map(|model| model.name).collect())
+            let parsed: TagsResponse =
+                serde_json::from_str(&body).context("parse Ollama tags response")?;
+            Ok(parsed
+                .models
+                .into_iter()
+                .map(|model| model.name)
+                .collect::<Vec<_>>())
+        }
+        .instrument(span.clone())
+        .await;
+
+        span.record("success", result.is_ok());
+        span.record("duration_ms", started.elapsed().as_millis() as u64);
+        if let Ok(models) = &result {
+            span.record("response_models", models.len());
+        }
+        result
     }
 }
 
@@ -103,28 +129,51 @@ impl Embedder {
 
     /// Embeds a single text input and returns its vector.
     pub async fn embed(&self, text: &str) -> Result<Vec<f32>> {
-        let url = format!("{}/api/embed", self.base_url.trim_end_matches('/'));
-        let request_body = serde_json::json!({
-            "model": self.model,
-            "input": text,
-        });
-        let (status, body) = self
-            .client
-            .post_json(url, request_body)
-            .await
-            .context("call Ollama embed API")?;
-        if !status.is_success() {
-            anyhow::bail!("Ollama embed API error: {} - {}", status, body);
-        }
+        let span = tracing::info_span!(
+            "ollama_request",
+            backend = "ollama",
+            operation = "embed",
+            model = %self.model,
+            endpoint_host = %endpoint_host(&self.base_url),
+            input_chars = text.chars().count(),
+            success = field::Empty,
+            embedding_dim = field::Empty,
+            duration_ms = field::Empty,
+        );
+        let started = Instant::now();
+        let result = async {
+            let url = format!("{}/api/embed", self.base_url.trim_end_matches('/'));
+            let request_body = serde_json::json!({
+                "model": self.model,
+                "input": text,
+            });
+            let (status, body) = self
+                .client
+                .post_json(url, request_body)
+                .await
+                .context("call Ollama embed API")?;
+            if !status.is_success() {
+                anyhow::bail!("Ollama embed API error: {} - {}", status, body);
+            }
 
-        let parsed: EmbedResponse =
-            serde_json::from_str(&body).context("parse Ollama embed response")?;
-        let embedding = parsed
-            .embeddings
-            .into_iter()
-            .next()
-            .context("Ollama embed response did not include an embedding")?;
-        Ok(embedding)
+            let parsed: EmbedResponse =
+                serde_json::from_str(&body).context("parse Ollama embed response")?;
+            let embedding = parsed
+                .embeddings
+                .into_iter()
+                .next()
+                .context("Ollama embed response did not include an embedding")?;
+            Ok(embedding)
+        }
+        .instrument(span.clone())
+        .await;
+
+        span.record("success", result.is_ok());
+        span.record("duration_ms", started.elapsed().as_millis() as u64);
+        if let Ok(embedding) = &result {
+            span.record("embedding_dim", embedding.len());
+        }
+        result
     }
 }
 
@@ -170,37 +219,62 @@ impl Generator {
         user_prompt: &str,
         max_tokens: usize,
     ) -> Result<String> {
-        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
-        let request_body = serde_json::json!({
-            "model": self.model,
-            "stream": false,
-            "think": false,
-            "options": {
-                "num_predict": max_tokens,
-            },
-            "messages": [
-                {
-                    "role": "system",
-                    "content": system_prompt,
+        let span = tracing::info_span!(
+            "ollama_request",
+            backend = "ollama",
+            operation = "chat",
+            model = %self.model,
+            endpoint_host = %endpoint_host(&self.base_url),
+            system_prompt_chars = system_prompt.chars().count(),
+            user_prompt_chars = user_prompt.chars().count(),
+            max_tokens,
+            success = field::Empty,
+            response_chars = field::Empty,
+            duration_ms = field::Empty,
+        );
+        let started = Instant::now();
+        let result = async {
+            let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
+            let request_body = serde_json::json!({
+                "model": self.model,
+                "stream": false,
+                "think": false,
+                "options": {
+                    "num_predict": max_tokens,
                 },
-                {
-                    "role": "user",
-                    "content": user_prompt,
-                }
-            ]
-        });
-        let (status, body) = self
-            .client
-            .post_json(url, request_body)
-            .await
-            .context("call Ollama chat API")?;
-        if !status.is_success() {
-            anyhow::bail!("Ollama chat API error: {} - {}", status, body);
-        }
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": system_prompt,
+                    },
+                    {
+                        "role": "user",
+                        "content": user_prompt,
+                    }
+                ]
+            });
+            let (status, body) = self
+                .client
+                .post_json(url, request_body)
+                .await
+                .context("call Ollama chat API")?;
+            if !status.is_success() {
+                anyhow::bail!("Ollama chat API error: {} - {}", status, body);
+            }
 
-        let parsed: ChatResponse =
-            serde_json::from_str(&body).context("parse Ollama chat response")?;
-        Ok(parsed.message.content)
+            let parsed: ChatResponse =
+                serde_json::from_str(&body).context("parse Ollama chat response")?;
+            Ok(parsed.message.content)
+        }
+        .instrument(span.clone())
+        .await;
+
+        span.record("success", result.is_ok());
+        span.record("duration_ms", started.elapsed().as_millis() as u64);
+        if let Ok(content) = &result {
+            span.record("response_chars", content.chars().count());
+        }
+        result
     }
 }
 
@@ -216,38 +290,63 @@ impl VisionCaptioner {
 
     /// Produces a retrieval-oriented caption for an image file.
     pub async fn caption_image(&self, image_path: &Path) -> Result<String> {
-        let bytes = std::fs::read(image_path)
-            .with_context(|| format!("read image: {}", image_path.display()))?;
-        let image_b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
-        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
+        let span = tracing::info_span!(
+            "ollama_request",
+            backend = "ollama",
+            operation = "vision",
+            model = %self.model,
+            endpoint_host = %endpoint_host(&self.base_url),
+            image_path = %image_path.display(),
+            image_bytes = field::Empty,
+            success = field::Empty,
+            response_chars = field::Empty,
+            duration_ms = field::Empty,
+        );
+        let started = Instant::now();
+        let result = async {
+            let bytes = std::fs::read(image_path)
+                .with_context(|| format!("read image: {}", image_path.display()))?;
+            span.record("image_bytes", bytes.len());
+            let image_b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+            let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
 
-        let request_body = serde_json::json!({
-            "model": self.model,
-            "stream": false,
-            "think": false,
-            "options": {
-                "num_predict": 128,
-            },
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Describe this image for retrieval. Focus on the subjects, setting, and notable visual details.",
-                    "images": [image_b64],
-                }
-            ]
-        });
-        let (status, body) = self
-            .client
-            .post_json(url, request_body)
-            .await
-            .context("call Ollama vision chat API")?;
-        if !status.is_success() {
-            anyhow::bail!("Ollama vision API error: {} - {}", status, body);
+            let request_body = serde_json::json!({
+                "model": self.model,
+                "stream": false,
+                "think": false,
+                "options": {
+                    "num_predict": 128,
+                },
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Describe this image for retrieval. Focus on the subjects, setting, and notable visual details.",
+                        "images": [image_b64],
+                    }
+                ]
+            });
+            let (status, body) = self
+                .client
+                .post_json(url, request_body)
+                .await
+                .context("call Ollama vision chat API")?;
+            if !status.is_success() {
+                anyhow::bail!("Ollama vision API error: {} - {}", status, body);
+            }
+
+            let parsed: ChatResponse =
+                serde_json::from_str(&body).context("parse Ollama vision response")?;
+            Ok(parsed.message.content)
         }
+        .instrument(span.clone())
+        .await;
 
-        let parsed: ChatResponse =
-            serde_json::from_str(&body).context("parse Ollama vision response")?;
-        Ok(parsed.message.content)
+        span.record("success", result.is_ok());
+        span.record("duration_ms", started.elapsed().as_millis() as u64);
+        if let Ok(content) = &result {
+            span.record("response_chars", content.chars().count());
+        }
+        result
     }
 }
 
@@ -295,6 +394,17 @@ impl HttpClient {
         let body = response.text().await.context("read HTTP response body")?;
         Ok((status, body))
     }
+}
+
+fn endpoint_host(base_url: &str) -> String {
+    reqwest::Url::parse(base_url)
+        .ok()
+        .map(|url| match (url.host_str(), url.port()) {
+            (Some(host), Some(port)) => format!("{host}:{port}"),
+            (Some(host), None) => host.to_string(),
+            _ => base_url.to_string(),
+        })
+        .unwrap_or_else(|| base_url.to_string())
 }
 
 fn build_user_prompt(contexts: &[String], question: &str) -> String {

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -13,6 +13,7 @@ use crate::rewrite::{rewrite_query_for_retrieval, QueryRewriteSet};
 use crate::store;
 use anyhow::Result;
 use std::collections::BTreeSet;
+use tracing::{field, Instrument};
 
 use super::render::{
     evidence_verdict_label, print_citations, print_contexts, print_query_plan, print_query_trace,
@@ -24,154 +25,201 @@ use super::types::{QueryExecutionPath, QueryResult, QueryRuntime};
 
 pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
     let runtime = prepare_runtime(name, &command)?;
+    let execution = execution_path(command.mode);
+    let span = tracing::info_span!(
+        "query_pipeline",
+        store_name = name.unwrap_or("default"),
+        mode = ?command.mode,
+        execution_path = execution_path_label(execution),
+        question_chars = command.question.chars().count(),
+        top_k = command.top_k,
+        fetch_k = command.fetch_k,
+        max_iterations = command.max_iterations,
+        rewrite = command.rewrite,
+        rerank = command.rerank,
+        has_source_filter = command.source.is_some(),
+        has_path_prefix_filter = command.path_prefix.is_some(),
+        page = field::debug(command.page),
+        has_format_filter = command.format.is_some(),
+        hit_count = field::Empty,
+        iteration_count = field::Empty,
+    );
 
-    let result = match execution_path(command.mode) {
-        QueryExecutionPath::Simple => run_simple_query(&runtime, &command).await?,
-        QueryExecutionPath::Agentic => run_agentic_query_command(&runtime, &command).await?,
-        QueryExecutionPath::AgenticStub => {
-            run_agentic_stub_query_command(&runtime, &command).await?
+    let span_inner = span.clone();
+    async move {
+        let result = match execution {
+            QueryExecutionPath::Simple => run_simple_query(&runtime, &command).await?,
+            QueryExecutionPath::Agentic => run_agentic_query_command(&runtime, &command).await?,
+            QueryExecutionPath::AgenticStub => {
+                run_agentic_stub_query_command(&runtime, &command).await?
+            }
+        };
+
+        span_inner.record("hit_count", result.hits.len());
+        span_inner.record("iteration_count", result.iterations.len());
+
+        if result.hits.is_empty() {
+            println!("No relevant context found in the local store.");
+            return Ok(());
         }
-    };
 
-    if result.hits.is_empty() {
-        println!("No relevant context found in the local store.");
-        return Ok(());
+        print_query_plan(&command, &result);
+        print_query_trace(&command, &result);
+        print_scores(&command, &result);
+        print_citations(&command, &result);
+        print_contexts(&command, &result);
+
+        let answer = match &result.answer {
+            Some(answer) => answer.clone(),
+            None => generate_answer(&runtime, &command, &result).await?,
+        };
+        println!();
+        println!("{}", store::strip_thinking(&answer).trim());
+        Ok(())
     }
-
-    print_query_plan(&command, &result);
-    print_query_trace(&command, &result);
-    print_scores(&command, &result);
-    print_citations(&command, &result);
-    print_contexts(&command, &result);
-
-    let answer = match &result.answer {
-        Some(answer) => answer.clone(),
-        None => generate_answer(&runtime, &command, &result).await?,
-    };
-    println!();
-    println!("{}", store::strip_thinking(&answer).trim());
-    Ok(())
+    .instrument(span)
+    .await
 }
 
 async fn run_simple_query(runtime: &QueryRuntime, command: &QueryCommand) -> Result<QueryResult> {
-    let mut trace = vec![format!(
-        "mode {} uses the current hybrid retrieval pipeline",
-        mode_label(command.mode)
-    )];
-    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
-    let hits =
-        retrieve_candidates(runtime, command, &rewrite_set.query_variants(), &mut trace).await?;
+    let span = tracing::info_span!("run_simple_query", mode = ?command.mode);
+    async move {
+        let mut trace = vec![format!(
+            "mode {} uses the current hybrid retrieval pipeline",
+            mode_label(command.mode)
+        )];
+        let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+        let hits = retrieve_candidates(runtime, command, &rewrite_set.query_variants(), &mut trace)
+            .await?;
 
-    Ok(QueryResult {
-        requested_mode: command.mode,
-        execution_label: mode_label(command.mode),
-        rewrite_set,
-        plan: None,
-        iterations: Vec::new(),
-        support_check: None,
-        answer: None,
-        hits,
-        trace,
-    })
+        Ok(QueryResult {
+            requested_mode: command.mode,
+            execution_label: mode_label(command.mode),
+            rewrite_set,
+            plan: None,
+            iterations: Vec::new(),
+            support_check: None,
+            answer: None,
+            hits,
+            trace,
+        })
+    }
+    .instrument(span)
+    .await
 }
 
 async fn run_agentic_query_command(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<QueryResult> {
-    let generator = Generator::new(
-        runtime.cfg.ollama.base_url.clone(),
-        runtime.gen_model_name.clone(),
+    let span = tracing::info_span!(
+        "run_agentic_query",
+        mode = ?command.mode,
+        max_iterations = command.max_iterations,
+        rewrite = command.rewrite,
+        rerank = command.rerank,
     );
-    let mut trace = vec![format!(
-        "mode {} uses the agentic retrieval loop",
-        mode_label(command.mode)
-    )];
-    let plan = match build_query_plan(&generator, &command.question).await {
-        Ok(plan) => {
-            trace.push("planner produced a structured query plan".to_string());
-            plan
-        }
-        Err(err) => {
-            trace.push(format!(
-                "planner failed; falling back to heuristic plan ({})",
-                err.root_cause()
-            ));
-            fallback_query_plan(&command.question)
-        }
-    };
-
-    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
-    let mut iterations = Vec::new();
-    let mut previous_keys = Vec::new();
-    let mut active_queries = initial_agent_queries(&command.question, &plan, &rewrite_set);
-    let mut accumulated_hits = Vec::new();
-
-    for iteration in 1..=command.max_iterations.max(1) {
-        trace.push(format!(
-            "iteration {iteration}: querying {} variant(s)",
-            active_queries.len()
-        ));
-        let iteration_hits =
-            retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
-        let retrieved_count = iteration_hits.len();
-        accumulated_hits = merge_candidates([accumulated_hits, iteration_hits]);
-        let kept_hits = prune_candidates(accumulated_hits.clone(), command.top_k);
-        let assessment = match assess_evidence(&generator, &command.question, &kept_hits).await {
-            Ok(assessment) => assessment,
+    async move {
+        let generator = Generator::new(
+            runtime.cfg.ollama.base_url.clone(),
+            runtime.gen_model_name.clone(),
+        );
+        let mut trace = vec![format!(
+            "mode {} uses the agentic retrieval loop",
+            mode_label(command.mode)
+        )];
+        let plan = match build_query_plan(&generator, &command.question).await {
+            Ok(plan) => {
+                trace.push("planner produced a structured query plan".to_string());
+                plan
+            }
             Err(err) => {
                 trace.push(format!(
-                    "evidence assessment failed; using heuristic fallback ({})",
+                    "planner failed; falling back to heuristic plan ({})",
                     err.root_cause()
                 ));
-                fallback_evidence_assessment(&kept_hits)
+                fallback_query_plan(&command.question)
             }
         };
-        let notes = assessment_notes(&assessment);
-        iterations.push(AgentIteration {
-            iteration,
-            query_variants: active_queries.clone(),
-            retrieved_count,
-            kept_count: kept_hits.len(),
-            sufficiency: assessment.verdict.clone(),
-            notes: notes.clone(),
-        });
-        for note in notes {
-            trace.push(format!("iteration {iteration}: {note}"));
+
+        let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+        let mut iterations = Vec::new();
+        let mut previous_keys = Vec::new();
+        let mut active_queries = initial_agent_queries(&command.question, &plan, &rewrite_set);
+        let mut accumulated_hits = Vec::new();
+
+        for iteration in 1..=command.max_iterations.max(1) {
+            trace.push(format!(
+                "iteration {iteration}: querying {} variant(s)",
+                active_queries.len()
+            ));
+            let iteration_hits =
+                retrieve_candidates(runtime, command, &active_queries, &mut trace).await?;
+            let retrieved_count = iteration_hits.len();
+            accumulated_hits = merge_candidates([accumulated_hits, iteration_hits]);
+            let kept_hits = prune_candidates(accumulated_hits.clone(), command.top_k);
+            let assessment = match assess_evidence(&generator, &command.question, &kept_hits).await
+            {
+                Ok(assessment) => assessment,
+                Err(err) => {
+                    trace.push(format!(
+                        "evidence assessment failed; using heuristic fallback ({})",
+                        err.root_cause()
+                    ));
+                    fallback_evidence_assessment(&kept_hits)
+                }
+            };
+            let notes = assessment_notes(&assessment);
+            iterations.push(AgentIteration {
+                iteration,
+                query_variants: active_queries.clone(),
+                retrieved_count,
+                kept_count: kept_hits.len(),
+                sufficiency: assessment.verdict.clone(),
+                notes: notes.clone(),
+            });
+            for note in notes {
+                trace.push(format!("iteration {iteration}: {note}"));
+            }
+
+            if matches!(assessment.verdict, EvidenceVerdict::Sufficient) {
+                trace.push(format!("iteration {iteration}: evidence marked sufficient"));
+                break;
+            }
+            if iteration >= command.max_iterations.max(1) {
+                trace.push("iteration budget exhausted".to_string());
+                break;
+            }
+
+            let current_keys = kept_hits
+                .iter()
+                .map(|hit| hit.dedupe_key())
+                .collect::<Vec<_>>();
+            if !previous_keys.is_empty() && current_keys == previous_keys {
+                trace.push("retrieval produced no material evidence change; halting".to_string());
+                break;
+            }
+            previous_keys = current_keys;
+
+            let next_queries =
+                refine_agent_queries(&command.question, &plan, &rewrite_set, &assessment);
+            if next_queries == active_queries {
+                trace.push("no better follow-up queries available; halting".to_string());
+                break;
+            }
+            active_queries = next_queries;
         }
 
-        if matches!(assessment.verdict, EvidenceVerdict::Sufficient) {
-            trace.push(format!("iteration {iteration}: evidence marked sufficient"));
-            break;
-        }
-        if iteration >= command.max_iterations.max(1) {
-            trace.push("iteration budget exhausted".to_string());
-            break;
-        }
-
-        let current_keys = kept_hits
-            .iter()
-            .map(|hit| hit.dedupe_key())
-            .collect::<Vec<_>>();
-        if !previous_keys.is_empty() && current_keys == previous_keys {
-            trace.push("retrieval produced no material evidence change; halting".to_string());
-            break;
-        }
-        previous_keys = current_keys;
-
-        let next_queries =
-            refine_agent_queries(&command.question, &plan, &rewrite_set, &assessment);
-        if next_queries == active_queries {
-            trace.push("no better follow-up queries available; halting".to_string());
-            break;
-        }
-        active_queries = next_queries;
-    }
-
-    let final_hits = prune_candidates(accumulated_hits, command.top_k);
-    let answer = generate_answer_from_hits(runtime, command, &final_hits).await?;
-    let support_check =
-        match verify_answer_support(&generator, &command.question, &answer, &final_hits).await {
+        let final_hits = prune_candidates(accumulated_hits, command.top_k);
+        let answer = generate_answer_from_hits(runtime, command, &final_hits).await?;
+        let support_check = match verify_answer_support(
+            &generator,
+            &command.question,
+            &answer,
+            &final_hits,
+        )
+        .await
+        {
             Ok(check) => check,
             Err(err) => {
                 trace.push(format!(
@@ -181,52 +229,61 @@ async fn run_agentic_query_command(
                 fallback_support_check(&answer, &final_hits)
             }
         };
-    if support_check.supported {
-        trace.push("answer support verification passed".to_string());
-    } else {
-        trace.push(format!(
-            "answer support verification found {} unsupported claim(s)",
-            support_check.unsupported_claims.len()
-        ));
-    }
+        if support_check.supported {
+            trace.push("answer support verification passed".to_string());
+        } else {
+            trace.push(format!(
+                "answer support verification found {} unsupported claim(s)",
+                support_check.unsupported_claims.len()
+            ));
+        }
 
-    Ok(QueryResult {
-        requested_mode: command.mode,
-        execution_label: "agentic",
-        rewrite_set,
-        plan: Some(plan),
-        iterations,
-        support_check: Some(support_check),
-        answer: Some(answer),
-        hits: final_hits,
-        trace,
-    })
+        Ok(QueryResult {
+            requested_mode: command.mode,
+            execution_label: "agentic",
+            rewrite_set,
+            plan: Some(plan),
+            iterations,
+            support_check: Some(support_check),
+            answer: Some(answer),
+            hits: final_hits,
+            trace,
+        })
+    }
+    .instrument(span)
+    .await
 }
 
 async fn run_agentic_stub_query_command(
     runtime: &QueryRuntime,
     command: &QueryCommand,
 ) -> Result<QueryResult> {
-    let mut trace = vec![format!(
-        "requested {} mode routed through the graph-mode placeholder path",
-        mode_label(command.mode)
-    )];
-    let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
-    let stub_plan = placeholder_plan(command.mode, &rewrite_set);
-    trace.extend(stub_plan.notes.iter().cloned());
-    let hits = retrieve_candidates(runtime, command, &stub_plan.query_variants, &mut trace).await?;
+    let span = tracing::info_span!("run_agentic_stub_query", mode = ?command.mode);
+    async move {
+        let mut trace = vec![format!(
+            "requested {} mode routed through the graph-mode placeholder path",
+            mode_label(command.mode)
+        )];
+        let rewrite_set = build_rewrite_set(runtime, command, &mut trace).await;
+        let stub_plan = placeholder_plan(command.mode, &rewrite_set);
+        trace.extend(stub_plan.notes.iter().cloned());
+        let hits =
+            retrieve_candidates(runtime, command, &stub_plan.query_variants, &mut trace).await?;
 
-    Ok(QueryResult {
-        requested_mode: command.mode,
-        execution_label: stub_plan.execution_label,
-        rewrite_set,
-        plan: None,
-        iterations: Vec::new(),
-        support_check: None,
-        answer: None,
-        hits,
-        trace,
-    })
+        Ok(QueryResult {
+            requested_mode: command.mode,
+            execution_label: stub_plan.execution_label,
+            rewrite_set,
+            plan: None,
+            iterations: Vec::new(),
+            support_check: None,
+            answer: None,
+            hits,
+            trace,
+        })
+    }
+    .instrument(span)
+    .await
 }
 
 async fn build_rewrite_set(
@@ -234,35 +291,44 @@ async fn build_rewrite_set(
     command: &QueryCommand,
     trace: &mut Vec<String>,
 ) -> QueryRewriteSet {
-    if !command.rewrite {
-        trace.push("rewrite disabled; using original query only".to_string());
-        return QueryRewriteSet::fallback(&command.question);
-    }
-
-    let generator = Generator::new(
-        runtime.cfg.ollama.base_url.clone(),
-        runtime.gen_model_name.clone(),
+    let span = tracing::info_span!(
+        "build_rewrite_set",
+        enabled = command.rewrite,
+        question_chars = command.question.chars().count(),
     );
-    match rewrite_query_for_retrieval(&generator, &command.question).await {
-        Ok(rewrite_set) => {
-            let variants = rewrite_set.query_variants();
-            trace.push(format!(
-                "rewrite enabled; {} retrieval query variant(s) prepared",
-                variants.len()
-            ));
-            for variant in variants.iter().skip(1) {
-                trace.push(format!("rewrite variant: {variant}"));
-            }
-            rewrite_set
+    async move {
+        if !command.rewrite {
+            trace.push("rewrite disabled; using original query only".to_string());
+            return QueryRewriteSet::fallback(&command.question);
         }
-        Err(err) => {
-            trace.push(format!(
-                "rewrite failed; falling back to original query ({})",
-                err.root_cause()
-            ));
-            QueryRewriteSet::fallback(&command.question)
+
+        let generator = Generator::new(
+            runtime.cfg.ollama.base_url.clone(),
+            runtime.gen_model_name.clone(),
+        );
+        match rewrite_query_for_retrieval(&generator, &command.question).await {
+            Ok(rewrite_set) => {
+                let variants = rewrite_set.query_variants();
+                trace.push(format!(
+                    "rewrite enabled; {} retrieval query variant(s) prepared",
+                    variants.len()
+                ));
+                for variant in variants.iter().skip(1) {
+                    trace.push(format!("rewrite variant: {variant}"));
+                }
+                rewrite_set
+            }
+            Err(err) => {
+                trace.push(format!(
+                    "rewrite failed; falling back to original query ({})",
+                    err.root_cause()
+                ));
+                QueryRewriteSet::fallback(&command.question)
+            }
         }
     }
+    .instrument(span)
+    .await
 }
 
 async fn generate_answer(
@@ -278,14 +344,24 @@ async fn generate_answer_from_hits(
     command: &QueryCommand,
     hits: &[RetrievalCandidate],
 ) -> Result<String> {
-    let generator = Generator::new(
-        runtime.cfg.ollama.base_url.clone(),
-        runtime.gen_model_name.clone(),
+    let span = tracing::info_span!(
+        "generate_answer_from_hits",
+        hit_count = hits.len(),
+        question_chars = command.question.chars().count(),
+        max_tokens = command.max_tokens,
     );
-    let contexts = labeled_contexts(hits);
-    generator
-        .generate_answer(&contexts, &command.question, command.max_tokens)
-        .await
+    async move {
+        let generator = Generator::new(
+            runtime.cfg.ollama.base_url.clone(),
+            runtime.gen_model_name.clone(),
+        );
+        let contexts = labeled_contexts(hits);
+        generator
+            .generate_answer(&contexts, &command.question, command.max_tokens)
+            .await
+    }
+    .instrument(span)
+    .await
 }
 
 fn initial_agent_queries(
@@ -356,6 +432,14 @@ fn execution_path(mode: QueryModeArg) -> QueryExecutionPath {
         QueryModeArg::Local | QueryModeArg::Global | QueryModeArg::Mix => {
             QueryExecutionPath::AgenticStub
         }
+    }
+}
+
+fn execution_path_label(path: QueryExecutionPath) -> &'static str {
+    match path {
+        QueryExecutionPath::Simple => "simple",
+        QueryExecutionPath::Agentic => "agentic",
+        QueryExecutionPath::AgenticStub => "agentic_stub",
     }
 }
 

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -3,6 +3,7 @@ use crate::models::Generator;
 use crate::retrieval::{apply_rerank_order, RetrievalCandidate};
 use crate::rewrite::trim_json_fences;
 use anyhow::{Context, Result};
+use tracing::{field, Instrument};
 
 use super::types::QueryRuntime;
 
@@ -26,38 +27,54 @@ pub(crate) async fn rerank_candidates(
     candidates: Vec<RetrievalCandidate>,
     trace: &mut Vec<String>,
 ) -> Vec<RetrievalCandidate> {
-    if !command.rerank || candidates.len() <= 1 {
-        trace.push("rerank disabled; using fused retrieval order".to_string());
-        return candidates;
-    }
-
-    let generator = Generator::new(
-        runtime.cfg.ollama.base_url.clone(),
-        runtime.gen_model_name.clone(),
+    let span = tracing::info_span!(
+        "rerank_candidates",
+        enabled = command.rerank,
+        candidate_count = candidates.len(),
+        fetch_k = command.fetch_k,
+        returned_candidates = field::Empty,
     );
-    match rerank_with_model(
-        &generator,
-        &command.question,
-        &candidates,
-        command.fetch_k.min(candidates.len()),
-    )
-    .await
-    {
-        Ok(reranked) => {
-            trace.push(format!(
-                "rerank enabled; reordered {} candidate(s)",
-                reranked.len()
-            ));
-            reranked
+
+    let span_inner = span.clone();
+    async move {
+        if !command.rerank || candidates.len() <= 1 {
+            trace.push("rerank disabled; using fused retrieval order".to_string());
+            span_inner.record("returned_candidates", candidates.len());
+            return candidates;
         }
-        Err(err) => {
-            trace.push(format!(
-                "rerank failed; falling back to fused retrieval order ({})",
-                err.root_cause()
-            ));
-            candidates
+
+        let generator = Generator::new(
+            runtime.cfg.ollama.base_url.clone(),
+            runtime.gen_model_name.clone(),
+        );
+        match rerank_with_model(
+            &generator,
+            &command.question,
+            &candidates,
+            command.fetch_k.min(candidates.len()),
+        )
+        .await
+        {
+            Ok(reranked) => {
+                span_inner.record("returned_candidates", reranked.len());
+                trace.push(format!(
+                    "rerank enabled; reordered {} candidate(s)",
+                    reranked.len()
+                ));
+                reranked
+            }
+            Err(err) => {
+                span_inner.record("returned_candidates", candidates.len());
+                trace.push(format!(
+                    "rerank failed; falling back to fused retrieval order ({})",
+                    err.root_cause()
+                ));
+                candidates
+            }
         }
     }
+    .instrument(span)
+    .await
 }
 
 async fn rerank_with_model(
@@ -66,18 +83,29 @@ async fn rerank_with_model(
     candidates: &[RetrievalCandidate],
     top_n: usize,
 ) -> Result<Vec<RetrievalCandidate>> {
-    let prompt = build_rerank_prompt(question, candidates);
-    let response = generator
-        .generate_json(
-            "You rerank retrieval candidates for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
-            &prompt,
-            RERANK_RESPONSE_TOKENS,
-        )
-        .await
-        .context("generate rerank JSON")?;
-    let ranked_positions = parse_rerank_payload(&response)?;
-    let ranked_ids = resolve_rerank_positions(candidates, &ranked_positions);
-    Ok(apply_rerank_order(candidates, &ranked_ids, top_n))
+    let span = tracing::info_span!(
+        "rerank_with_model",
+        question_chars = question.chars().count(),
+        candidate_count = candidates.len(),
+        top_n,
+    );
+
+    async move {
+        let prompt = build_rerank_prompt(question, candidates);
+        let response = generator
+            .generate_json(
+                "You rerank retrieval candidates for a local RAG CLI. Respond with strict JSON only and no markdown fences.",
+                &prompt,
+                RERANK_RESPONSE_TOKENS,
+            )
+            .await
+            .context("generate rerank JSON")?;
+        let ranked_positions = parse_rerank_payload(&response)?;
+        let ranked_ids = resolve_rerank_positions(candidates, &ranked_positions);
+        Ok(apply_rerank_order(candidates, &ranked_ids, top_n))
+    }
+    .instrument(span)
+    .await
 }
 
 fn build_rerank_prompt(question: &str, candidates: &[RetrievalCandidate]) -> String {

--- a/src/query/retrieve.rs
+++ b/src/query/retrieve.rs
@@ -7,6 +7,7 @@ use arrow_array::{Float32Array, Float64Array, Int32Array, RecordBatch, StringArr
 use futures::TryStreamExt;
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use tracing::{field, Instrument};
 
 use super::rerank::rerank_candidates;
 use super::runtime::retrieval_limit;
@@ -18,22 +19,42 @@ pub(crate) async fn retrieve_candidates(
     queries: &[String],
     trace: &mut Vec<String>,
 ) -> Result<Vec<RetrievalCandidate>> {
-    let mut groups = Vec::new();
-    for query in queries {
-        groups.push(retrieve_candidates_for_query(runtime, query, command).await?);
+    let span = tracing::info_span!(
+        "retrieve_candidates",
+        query_variants = queries.len(),
+        top_k = command.top_k,
+        fetch_k = command.fetch_k,
+        has_source_filter = command.source.is_some(),
+        has_path_prefix_filter = command.path_prefix.is_some(),
+        page = field::debug(command.page),
+        has_format_filter = command.format.is_some(),
+        merged_candidates = field::Empty,
+        pruned_candidates = field::Empty,
+    );
+
+    let span_inner = span.clone();
+    async move {
+        let mut groups = Vec::new();
+        for query in queries {
+            groups.push(retrieve_candidates_for_query(runtime, query, command).await?);
+        }
+
+        let merged = merge_candidates(groups);
+        span_inner.record("merged_candidates", merged.len());
+        trace.push(format!(
+            "merged {} candidate(s) across {} retrieval query variant(s)",
+            merged.len(),
+            queries.len()
+        ));
+
+        let reranked = rerank_candidates(runtime, command, merged, trace).await;
+        let pruned = prune_candidates(reranked, command.top_k);
+        span_inner.record("pruned_candidates", pruned.len());
+        trace.push(format!("kept {} candidate(s) after pruning", pruned.len()));
+        Ok(pruned)
     }
-
-    let merged = merge_candidates(groups);
-    trace.push(format!(
-        "merged {} candidate(s) across {} retrieval query variant(s)",
-        merged.len(),
-        queries.len()
-    ));
-
-    let reranked = rerank_candidates(runtime, command, merged, trace).await;
-    let pruned = prune_candidates(reranked, command.top_k);
-    trace.push(format!("kept {} candidate(s) after pruning", pruned.len()));
-    Ok(pruned)
+    .instrument(span)
+    .await
 }
 
 async fn retrieve_candidates_for_query(
@@ -41,37 +62,57 @@ async fn retrieve_candidates_for_query(
     question: &str,
     command: &QueryCommand,
 ) -> Result<Vec<RetrievalCandidate>> {
-    let db = connect_db(&runtime.store).await?;
-    let table = db
-        .open_table(store::DEFAULT_TABLE_NAME)
-        .execute()
-        .await
-        .context("open table")?;
-    ensure_fts_index(&table, false).await?;
-
-    let embedder = Embedder::new(
-        runtime.cfg.ollama.base_url.clone(),
-        runtime.embed_model_name.clone(),
+    let span = tracing::info_span!(
+        "retrieve_query_variant",
+        query_chars = question.chars().count(),
+        retrieval_limit = retrieval_limit(command),
+        has_source_filter = command.source.is_some(),
+        has_path_prefix_filter = command.path_prefix.is_some(),
+        page = field::debug(command.page),
+        has_format_filter = command.format.is_some(),
+        batch_count = field::Empty,
+        hit_count = field::Empty,
     );
-    let embedding = embedder.embed(question).await?;
 
-    let mut query = table
-        .query()
-        .full_text_search(FullTextSearchQuery::new(question.to_string()))
-        .nearest_to(embedding.as_slice())?
-        .limit(retrieval_limit(command));
+    let span_inner = span.clone();
+    async move {
+        let db = connect_db(&runtime.store).await?;
+        let table = db
+            .open_table(store::DEFAULT_TABLE_NAME)
+            .execute()
+            .await
+            .context("open table")?;
+        ensure_fts_index(&table, false).await?;
 
-    if let Some(filter) = build_retrieval_filter(
-        command.source.as_deref(),
-        command.path_prefix.as_deref(),
-        command.page,
-        command.format.as_deref(),
-    ) {
-        query = query.only_if(filter);
+        let embedder = Embedder::new(
+            runtime.cfg.ollama.base_url.clone(),
+            runtime.embed_model_name.clone(),
+        );
+        let embedding = embedder.embed(question).await?;
+
+        let mut query = table
+            .query()
+            .full_text_search(FullTextSearchQuery::new(question.to_string()))
+            .nearest_to(embedding.as_slice())?
+            .limit(retrieval_limit(command));
+
+        if let Some(filter) = build_retrieval_filter(
+            command.source.as_deref(),
+            command.path_prefix.as_deref(),
+            command.page,
+            command.format.as_deref(),
+        ) {
+            query = query.only_if(filter);
+        }
+
+        let batches: Vec<RecordBatch> = query.execute().await?.try_collect::<Vec<_>>().await?;
+        span_inner.record("batch_count", batches.len());
+        let hits = extract_candidates(&batches)?;
+        span_inner.record("hit_count", hits.len());
+        Ok(hits)
     }
-
-    let batches: Vec<RecordBatch> = query.execute().await?.try_collect::<Vec<_>>().await?;
-    extract_candidates(&batches)
+    .instrument(span)
+    .await
 }
 
 fn extract_candidates(batches: &[RecordBatch]) -> Result<Vec<RetrievalCandidate>> {


### PR DESCRIPTION
## Summary
- add tracing spans across command, indexing, query, retrieval, rerank, and Ollama flows
- record safe operational metadata for OTLP traces without exporting prompts or source contents
- update the local OTEL implementation checklist to mark instrumentation work complete

## Changes
- improve root command instrumentation in `src/app.rs`
- add command and ingest spans with completion stats in `src/commands/index.rs`
- instrument query execution paths, rewrite, and answer generation in `src/query/execute.rs`
- instrument retrieval and rerank phases in `src/query/retrieve.rs` and `src/query/rerank.rs`
- instrument Ollama tags, embed, chat, and vision requests in `src/models.rs`
- update `docs/otel-implementation-checklist.md` to mark Milestone 2 complete

## Validation
- `cargo check`
- `cargo test --all-targets`

Closes #44
Refs #46
