### PR TITLE
feat(telemetry): add doctor reporting and OTLP smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ ragcli query "What is this project about?"
 
 For `http/protobuf`, `ragcli` appends `/v1/traces` only when the configured endpoint has no path (for example `http://localhost:4318`). If you provide a custom path such as `http://localhost:6006/ingest`, that path is used as-is.
 
+You can inspect the resolved telemetry settings with:
+
+```bash
+ragcli doctor
+ragcli doctor --json
+```
+
+`doctor` reports whether telemetry is enabled, the resolved service name, protocol, endpoint, timeout, and whether OTLP headers are configured. Header values are never printed.
+
+By default, exported spans include operational metadata such as command names, query/index execution details, model names, endpoint hosts, durations, and request/response sizes. They do **not** include prompt bodies, retrieved source content, image bytes, or OTLP header values.
+
 ## Storage
 
 Each store lives under:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ ragcli doctor
 ragcli doctor --json
 ```
 
-`doctor` reports whether telemetry is enabled, the resolved service name, protocol, endpoint, timeout, and whether OTLP headers are configured. Header values are never printed.
+`doctor` reports whether telemetry is enabled, the resolved service name, protocol, endpoint, timeout, whether OTLP headers are configured, and any telemetry configuration parse error. Header values are never printed.
 
 By default, exported spans include operational metadata such as command names, query/index execution details, model names, endpoint hosts, durations, and request/response sizes. They do **not** include prompt bodies, retrieved source content, image bytes, or OTLP header values.
 

--- a/docs/otel-implementation-checklist.md
+++ b/docs/otel-implementation-checklist.md
@@ -56,14 +56,14 @@ This checklist tracks the planned work to add optional OpenTelemetry trace expor
 
 ## Milestone 3: Doctor, docs, and validation
 
-- [ ] Extend `doctor` to report telemetry configuration
-- [ ] Redact secrets when reporting OTLP headers/auth presence
-- [ ] Add README documentation for OTLP export
-- [ ] Add a Phoenix example
-- [ ] Add a generic Collector example
-- [ ] Document privacy considerations and what is/is not exported by default
-- [ ] Add unit tests for telemetry config parsing and disabled/enabled paths
-- [ ] Add smoke/integration coverage for OTLP-enabled startup
+- [x] Extend `doctor` to report telemetry configuration
+- [x] Redact secrets when reporting OTLP headers/auth presence
+- [x] Add README documentation for OTLP export
+- [x] Add a Phoenix example
+- [x] Add a generic Collector example
+- [x] Document privacy considerations and what is/is not exported by default
+- [x] Add unit tests for telemetry config parsing and disabled/enabled paths
+- [x] Add smoke/integration coverage for OTLP-enabled startup
 - [ ] Optionally add a collector-backed integration test later
 
 ## Open questions

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,6 +3,7 @@ use crate::config::{
 };
 use crate::models::OllamaClient;
 use crate::store;
+use crate::telemetry::{TelemetryConfig, TelemetryStatus};
 use anyhow::{Context, Result};
 use serde::Serialize;
 use std::fs;
@@ -43,6 +44,7 @@ pub struct DoctorReport {
     pub ollama_reachable: bool,
     pub ollama_error: Option<String>,
     pub installed_models: Option<ModelInstallReport>,
+    pub telemetry: TelemetryStatus,
     pub metadata: PathStatusReport,
     pub metadata_summary: Option<String>,
     pub metadata_error: Option<String>,
@@ -63,6 +65,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let cfg = load_or_create_config(&store)?;
+    let telemetry = TelemetryConfig::from_env()?.status();
     let base = config::base_dir()?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -126,6 +129,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
         ollama_reachable,
         ollama_error,
         installed_models,
+        telemetry,
         metadata: PathStatusReport {
             path: metadata_path.display().to_string(),
             status: status(metadata_path.exists()),
@@ -170,6 +174,23 @@ fn print_human(report: &DoctorReport) {
         eprintln!("  ollama: unreachable ({})", err);
     }
 
+    println!("  telemetry enabled: {}", status(report.telemetry.enabled));
+    println!(
+        "  telemetry service name: {}",
+        report.telemetry.service_name
+    );
+    println!("  telemetry protocol: {}", report.telemetry.protocol);
+    if let Some(endpoint) = &report.telemetry.endpoint {
+        println!("  telemetry endpoint: {}", endpoint);
+    }
+    if let Some(timeout_ms) = report.telemetry.timeout_ms {
+        println!("  telemetry timeout ms: {}", timeout_ms);
+    }
+    println!(
+        "  telemetry headers configured: {}",
+        status(report.telemetry.headers_configured)
+    );
+
     println!(
         "  metadata: {} ({})",
         report.metadata.path, report.metadata.status
@@ -203,6 +224,7 @@ fn format_unix_timestamp(timestamp: u64) -> String {
 mod tests {
     use super::*;
     use crate::test_support::{sequential_json_server, with_test_env};
+    use std::env;
 
     #[test]
     fn test_format_unix_timestamp_uses_rfc3339_when_possible() {
@@ -218,6 +240,7 @@ mod tests {
             assert!(serde_json::to_string(&report)
                 .unwrap()
                 .contains("\"ollama_reachable\""));
+            assert!(!report.telemetry.enabled);
         })
         .await;
     }
@@ -252,5 +275,78 @@ mod tests {
             assert!(report.metadata_error.is_some());
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_report_includes_telemetry_env_configuration() {
+        use std::env;
+
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let previous_endpoint = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
+            let previous_protocol = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
+            let previous_service_name = env::var_os(crate::telemetry::ENV_OTEL_SERVICE_NAME);
+            let previous_headers = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS);
+            let previous_timeout = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT);
+
+            unsafe {
+                env::set_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
+                    "http://localhost:6006",
+                );
+                env::set_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
+                    "http/protobuf",
+                );
+                env::set_var(crate::telemetry::ENV_OTEL_SERVICE_NAME, "ragcli-test");
+                env::set_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS,
+                    "api_key=secret",
+                );
+                env::set_var(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT, "2500");
+            }
+
+            let report = build_report(Some("telemetry")).await.unwrap();
+            assert!(report.telemetry.enabled);
+            assert_eq!(report.telemetry.service_name, "ragcli-test");
+            assert_eq!(report.telemetry.protocol, "http/protobuf");
+            assert_eq!(
+                report.telemetry.endpoint.as_deref(),
+                Some("http://localhost:6006/v1/traces")
+            );
+            assert_eq!(report.telemetry.timeout_ms, Some(2500));
+            assert!(report.telemetry.headers_configured);
+
+            unsafe {
+                restore_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
+                    previous_endpoint,
+                );
+                restore_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
+                    previous_protocol,
+                );
+                restore_var(
+                    crate::telemetry::ENV_OTEL_SERVICE_NAME,
+                    previous_service_name,
+                );
+                restore_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS,
+                    previous_headers,
+                );
+                restore_var(
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT,
+                    previous_timeout,
+                );
+            }
+        })
+        .await;
+    }
+
+    unsafe fn restore_var(name: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => env::set_var(name, value),
+            None => env::remove_var(name),
+        }
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -45,6 +45,7 @@ pub struct DoctorReport {
     pub ollama_error: Option<String>,
     pub installed_models: Option<ModelInstallReport>,
     pub telemetry: TelemetryStatus,
+    pub telemetry_error: Option<String>,
     pub metadata: PathStatusReport,
     pub metadata_summary: Option<String>,
     pub metadata_error: Option<String>,
@@ -65,7 +66,10 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
     let store = store_dir(name)?;
     ensure_store_layout(&store)?;
     let cfg = load_or_create_config(&store)?;
-    let telemetry = TelemetryConfig::from_env()?.status();
+    let (telemetry, telemetry_error) = match TelemetryConfig::from_env() {
+        Ok(config) => (config.status(), None),
+        Err(err) => (TelemetryStatus::from_env_lossy(), Some(err.to_string())),
+    };
     let base = config::base_dir()?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -130,6 +134,7 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
         ollama_error,
         installed_models,
         telemetry,
+        telemetry_error,
         metadata: PathStatusReport {
             path: metadata_path.display().to_string(),
             status: status(metadata_path.exists()),
@@ -190,6 +195,9 @@ fn print_human(report: &DoctorReport) {
         "  telemetry headers configured: {}",
         status(report.telemetry.headers_configured)
     );
+    if let Some(err) = &report.telemetry_error {
+        eprintln!("  telemetry config error: {}", err);
+    }
 
     println!(
         "  metadata: {} ({})",
@@ -225,6 +233,37 @@ mod tests {
     use super::*;
     use crate::test_support::{sequential_json_server, with_test_env};
     use std::env;
+
+    struct ScopedEnvVars {
+        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl ScopedEnvVars {
+        fn set(vars: &[(&'static str, &str)]) -> Self {
+            let previous = vars
+                .iter()
+                .map(|(name, _)| (*name, env::var_os(name)))
+                .collect();
+
+            unsafe {
+                for (name, value) in vars {
+                    env::set_var(name, value);
+                }
+            }
+
+            Self { previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVars {
+        fn drop(&mut self) {
+            unsafe {
+                for (name, value) in self.previous.drain(..).rev() {
+                    restore_var(name, value);
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_format_unix_timestamp_uses_rfc3339_when_possible() {
@@ -279,32 +318,24 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_build_report_includes_telemetry_env_configuration() {
-        use std::env;
-
         let dir = tempfile::tempdir().unwrap();
         with_test_env(dir.path(), None, || async {
-            let previous_endpoint = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT);
-            let previous_protocol = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL);
-            let previous_service_name = env::var_os(crate::telemetry::ENV_OTEL_SERVICE_NAME);
-            let previous_headers = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS);
-            let previous_timeout = env::var_os(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT);
-
-            unsafe {
-                env::set_var(
+            let _vars = ScopedEnvVars::set(&[
+                (
                     crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
                     "http://localhost:6006",
-                );
-                env::set_var(
+                ),
+                (
                     crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
                     "http/protobuf",
-                );
-                env::set_var(crate::telemetry::ENV_OTEL_SERVICE_NAME, "ragcli-test");
-                env::set_var(
+                ),
+                (crate::telemetry::ENV_OTEL_SERVICE_NAME, "ragcli-test"),
+                (
                     crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS,
                     "api_key=secret",
-                );
-                env::set_var(crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT, "2500");
-            }
+                ),
+                (crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT, "2500"),
+            ]);
 
             let report = build_report(Some("telemetry")).await.unwrap();
             assert!(report.telemetry.enabled);
@@ -316,31 +347,62 @@ mod tests {
             );
             assert_eq!(report.telemetry.timeout_ms, Some(2500));
             assert!(report.telemetry.headers_configured);
-
-            unsafe {
-                restore_var(
-                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
-                    previous_endpoint,
-                );
-                restore_var(
-                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
-                    previous_protocol,
-                );
-                restore_var(
-                    crate::telemetry::ENV_OTEL_SERVICE_NAME,
-                    previous_service_name,
-                );
-                restore_var(
-                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_HEADERS,
-                    previous_headers,
-                );
-                restore_var(
-                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_TIMEOUT,
-                    previous_timeout,
-                );
-            }
+            assert!(report.telemetry_error.is_none());
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_build_report_keeps_running_when_telemetry_env_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        with_test_env(dir.path(), None, || async {
+            let _vars = ScopedEnvVars::set(&[
+                (
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
+                    "http://localhost:6006",
+                ),
+                (
+                    crate::telemetry::ENV_OTEL_EXPORTER_OTLP_PROTOCOL,
+                    "http/json",
+                ),
+                (crate::telemetry::ENV_OTEL_SERVICE_NAME, "ragcli-test"),
+            ]);
+
+            let report = build_report(Some("telemetry-invalid")).await.unwrap();
+            assert!(report.telemetry.enabled);
+            assert_eq!(report.telemetry.service_name, "ragcli-test");
+            assert_eq!(report.telemetry.protocol, "http/protobuf");
+            assert_eq!(
+                report.telemetry.endpoint.as_deref(),
+                Some("http://localhost:6006/v1/traces")
+            );
+            assert!(report
+                .telemetry_error
+                .as_deref()
+                .unwrap()
+                .contains("unsupported OTEL_EXPORTER_OTLP_PROTOCOL value"));
+            assert!(serde_json::to_string(&report)
+                .unwrap()
+                .contains("\"telemetry_error\""));
+        })
+        .await;
+    }
+
+    #[test]
+    fn test_scoped_env_vars_restore_on_panic() {
+        let _guard = crate::config::test_env_lock().lock().unwrap();
+        let previous_service_name = env::var_os(crate::telemetry::ENV_OTEL_SERVICE_NAME);
+
+        let result = std::panic::catch_unwind(|| {
+            let _vars = ScopedEnvVars::set(&[(crate::telemetry::ENV_OTEL_SERVICE_NAME, "boom")]);
+            panic!("force unwind");
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            env::var_os(crate::telemetry::ENV_OTEL_SERVICE_NAME),
+            previous_service_name
+        );
     }
 
     unsafe fn restore_var(name: &str, value: Option<std::ffi::OsString>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod test_support;
 
 use anyhow::Result;
 use clap::Parser;
-use cli::Cli;
+use cli::{Cli, Command};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -30,7 +30,14 @@ fn main() -> Result<()> {
 
     let mut telemetry = {
         let _guard = runtime.enter();
-        telemetry::init()?
+        match telemetry::init() {
+            Ok(telemetry) => telemetry,
+            Err(err) if matches!(cli.command, Command::Doctor { .. }) => {
+                eprintln!("telemetry init error: {err}");
+                telemetry::TelemetryGuard::disabled()
+            }
+            Err(err) => return Err(err),
+        }
     };
 
     let result = runtime.block_on(app::run(cli));

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -54,6 +54,31 @@ pub struct TelemetryStatus {
     pub headers_configured: bool,
 }
 
+impl TelemetryStatus {
+    pub fn from_env_lossy() -> Self {
+        let protocol = match read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_PROTOCOL).as_deref() {
+            Some("grpc") => OtlpProtocol::Grpc,
+            _ => OtlpProtocol::HttpProtobuf,
+        };
+        let endpoint =
+            read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_ENDPOINT).map(|endpoint| match protocol {
+                OtlpProtocol::HttpProtobuf => normalize_http_traces_endpoint(&endpoint),
+                OtlpProtocol::Grpc => endpoint,
+            });
+
+        Self {
+            enabled: endpoint.is_some(),
+            service_name: read_non_empty_env(ENV_OTEL_SERVICE_NAME)
+                .unwrap_or_else(|| DEFAULT_SERVICE_NAME.to_string()),
+            endpoint,
+            protocol: protocol.as_str(),
+            timeout_ms: read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_TIMEOUT)
+                .and_then(|value| value.parse().ok()),
+            headers_configured: read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_HEADERS).is_some(),
+        }
+    }
+}
+
 impl TelemetryConfig {
     pub fn from_env() -> Result<Self> {
         let endpoint = read_non_empty_env(ENV_OTEL_EXPORTER_OTLP_ENDPOINT);

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -19,10 +19,19 @@ pub const ENV_OTEL_EXPORTER_OTLP_HEADERS: &str = "OTEL_EXPORTER_OTLP_HEADERS";
 pub const ENV_OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 pub const ENV_OTEL_EXPORTER_OTLP_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_TIMEOUT";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 pub enum OtlpProtocol {
     HttpProtobuf,
     Grpc,
+}
+
+impl OtlpProtocol {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HttpProtobuf => "http/protobuf",
+            Self::Grpc => "grpc",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -31,6 +40,16 @@ pub struct TelemetryConfig {
     pub service_name: String,
     pub endpoint: Option<String>,
     pub protocol: OtlpProtocol,
+    pub timeout_ms: Option<u64>,
+    pub headers_configured: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct TelemetryStatus {
+    pub enabled: bool,
+    pub service_name: String,
+    pub endpoint: Option<String>,
+    pub protocol: &'static str,
     pub timeout_ms: Option<u64>,
     pub headers_configured: bool,
 }
@@ -77,6 +96,17 @@ impl TelemetryConfig {
             OtlpProtocol::HttpProtobuf => normalize_http_traces_endpoint(endpoint),
             OtlpProtocol::Grpc => endpoint.to_string(),
         })
+    }
+
+    pub fn status(&self) -> TelemetryStatus {
+        TelemetryStatus {
+            enabled: self.enabled,
+            service_name: self.service_name.clone(),
+            endpoint: self.resolved_export_endpoint(),
+            protocol: self.protocol.as_str(),
+            timeout_ms: self.timeout_ms,
+            headers_configured: self.headers_configured,
+        }
     }
 }
 

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -1,5 +1,46 @@
 use serde_json::Value;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::process::Command;
+use std::thread;
+
+fn one_shot_ok_server(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let _ = stream.read(&mut buf);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+
+    format!("http://{}", addr)
+}
+
+fn otlp_stub_server() -> (String, std::sync::mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0_u8; 8192];
+            let size = stream.read(&mut buf).unwrap_or_default();
+            let request = String::from_utf8_lossy(&buf[..size]).to_string();
+            let _ = tx.send(request);
+            let response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(response.as_bytes()).unwrap();
+        }
+    });
+
+    (format!("http://{}", addr), rx)
+}
 
 #[test]
 fn test_config_show_json_outputs_machine_readable_report() {
@@ -26,4 +67,58 @@ fn test_config_show_json_outputs_machine_readable_report() {
         report["active_overrides"][0],
         "models.chat <- RAGCLI_CHAT_MODEL"
     );
+}
+
+#[test]
+fn test_doctor_json_reports_telemetry_configuration() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ragcli"))
+        .args(["doctor", "--json"])
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("OTEL_SERVICE_NAME", "ragcli-test")
+        .env("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        .env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:6006")
+        .env("OTEL_EXPORTER_OTLP_HEADERS", "api_key=secret")
+        .env("OTEL_EXPORTER_OTLP_TIMEOUT", "2500")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let report: Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(report["telemetry"]["enabled"], true);
+    assert_eq!(report["telemetry"]["service_name"], "ragcli-test");
+    assert_eq!(report["telemetry"]["protocol"], "http/protobuf");
+    assert_eq!(
+        report["telemetry"]["endpoint"],
+        "http://localhost:6006/v1/traces"
+    );
+    assert_eq!(report["telemetry"]["timeout_ms"], 2500);
+    assert_eq!(report["telemetry"]["headers_configured"], true);
+}
+
+#[test]
+fn test_cli_starts_with_otlp_enabled_and_emits_trace_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let ollama = one_shot_ok_server(r#"{"models":[]}"#);
+    let (otlp_endpoint, requests) = otlp_stub_server();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ragcli"))
+        .args(["doctor"])
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("RAGCLI_OLLAMA_URL", &ollama)
+        .env("OTEL_SERVICE_NAME", "ragcli-test")
+        .env("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        .env("OTEL_EXPORTER_OTLP_ENDPOINT", &otlp_endpoint)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let request = requests
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("expected OTLP request");
+    assert!(request.starts_with("POST /v1/traces HTTP/1.1"));
 }

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -97,6 +97,37 @@ fn test_doctor_json_reports_telemetry_configuration() {
     );
     assert_eq!(report["telemetry"]["timeout_ms"], 2500);
     assert_eq!(report["telemetry"]["headers_configured"], true);
+    assert_eq!(report["telemetry_error"], Value::Null);
+}
+
+#[test]
+fn test_doctor_json_reports_invalid_telemetry_configuration_without_failing() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ragcli"))
+        .args(["doctor", "--json"])
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("OTEL_SERVICE_NAME", "ragcli-test")
+        .env("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json")
+        .env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:6006")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let report: Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(report["telemetry"]["enabled"], true);
+    assert_eq!(report["telemetry"]["service_name"], "ragcli-test");
+    assert_eq!(report["telemetry"]["protocol"], "http/protobuf");
+    assert_eq!(
+        report["telemetry"]["endpoint"],
+        "http://localhost:6006/v1/traces"
+    );
+    assert!(report["telemetry_error"]
+        .as_str()
+        .unwrap()
+        .contains("unsupported OTEL_EXPORTER_OTLP_PROTOCOL value"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend `doctor` to report resolved telemetry configuration
- document telemetry inspection and privacy behavior in the README
- add JSON/integration coverage for OTLP-enabled startup and doctor output

## Changes
- add `TelemetryStatus` in `src/telemetry.rs` for redaction-safe reporting
- include telemetry details in `src/commands/doctor.rs` for both human and JSON output
- expand README telemetry docs with doctor inspection commands and privacy notes
- add integration tests in `tests/json_output.rs` for telemetry JSON output and OTLP startup smoke coverage
- update `docs/otel-implementation-checklist.md` to mark Milestone 3 complete except the optional collector-backed test

## Validation
- `cargo check`
- `cargo test --all-targets`

Closes #45
Refs #46
