### PR TITLE
test(e2e): add command smoke coverage

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,3 +110,8 @@ tasks:
     desc: Set a config key and value
     cmds:
       - cargo run -- config set {{.CLI_ARGS}}
+
+  live-smoke:
+    desc: Run the ignored live Ollama smoke test (requires RAGCLI_LIVE_E2E=1 and a running Ollama)
+    cmds:
+      - RAGCLI_LIVE_E2E=1 cargo test --test live_ollama_smoke -- --ignored {{.CLI_ARGS}}

--- a/tests/e2e_doctor.rs
+++ b/tests/e2e_doctor.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::collections::BTreeSet;
 use support::{run_ragcli, MockOllamaConfig, MockOllamaServer};
 
 #[test]
@@ -23,5 +24,15 @@ fn test_doctor_json_reports_store_layout_and_installed_models() {
     assert_eq!(report["store"]["status"], "exists");
     assert_eq!(report["config"]["status"], "exists");
     assert_eq!(report["metadata"]["status"], "missing");
-    assert_eq!(report["subdirectories"].as_array().unwrap().len(), 4);
+
+    let subdirectory_names = report["subdirectories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        subdirectory_names,
+        BTreeSet::from(["cache", "lancedb", "meta", "models"])
+    );
 }

--- a/tests/e2e_doctor.rs
+++ b/tests/e2e_doctor.rs
@@ -1,0 +1,27 @@
+mod support;
+
+use support::{run_ragcli, MockOllamaConfig, MockOllamaServer};
+
+#[test]
+fn test_doctor_json_reports_store_layout_and_installed_models() {
+    let dir = tempfile::tempdir().unwrap();
+    let server = MockOllamaServer::start(MockOllamaConfig::default());
+    let env = [("RAGCLI_OLLAMA_URL", server.url())];
+
+    let doctor = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "doctor-e2e", "doctor", "--json"],
+    );
+    doctor.assert_success();
+    let report = doctor.json();
+
+    assert_eq!(report["ollama_reachable"], true);
+    assert_eq!(report["installed_models"]["embed_model_installed"], true);
+    assert_eq!(report["installed_models"]["chat_model_installed"], true);
+    assert_eq!(report["installed_models"]["vision_model_installed"], true);
+    assert_eq!(report["store"]["status"], "exists");
+    assert_eq!(report["config"]["status"], "exists");
+    assert_eq!(report["metadata"]["status"], "missing");
+    assert_eq!(report["subdirectories"].as_array().unwrap().len(), 4);
+}

--- a/tests/e2e_query.rs
+++ b/tests/e2e_query.rs
@@ -1,0 +1,68 @@
+mod support;
+
+use support::{run_ragcli, MockOllamaConfig, MockOllamaServer};
+
+#[test]
+fn test_query_returns_answer_with_citations_and_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    let nebula = docs.join("nebula.md");
+    let orchard = docs.join("orchard.md");
+    std::fs::write(
+        &nebula,
+        "Project Nebula maps star catalogs for observatory search.",
+    )
+    .unwrap();
+    std::fs::write(
+        &orchard,
+        "Orchard operations track apple harvest schedules and storage.",
+    )
+    .unwrap();
+
+    let server = MockOllamaServer::start(MockOllamaConfig {
+        chat_response: "Project Nebula maps star catalogs for observatory search [1]."
+            .to_string(),
+        ..Default::default()
+    });
+    let env = [("RAGCLI_OLLAMA_URL", server.url())];
+
+    let index = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "query-e2e", "index", docs.to_str().unwrap()],
+    );
+    index.assert_success();
+
+    let query = run_ragcli(
+        dir.path(),
+        &env,
+        [
+            "--name",
+            "query-e2e",
+            "query",
+            "What does Project Nebula map?",
+            "--mode",
+            "hybrid",
+            "--top-k",
+            "1",
+            "--source",
+            nebula.to_str().unwrap(),
+            "--show-citations",
+            "--show-context",
+        ],
+    );
+    query.assert_success();
+
+    assert!(query.stdout.contains("Citations:"), "{}", query.stdout);
+    assert!(query.stdout.contains("Retrieved context:"), "{}", query.stdout);
+    assert!(query.stdout.contains("nebula.md"), "{}", query.stdout);
+    assert!(
+        query
+            .stdout
+            .contains("Project Nebula maps star catalogs for observatory search."),
+        "{}",
+        query.stdout
+    );
+    assert!(query.stdout.contains("[1]"), "{}", query.stdout);
+}

--- a/tests/e2e_store_lifecycle.rs
+++ b/tests/e2e_store_lifecycle.rs
@@ -1,0 +1,118 @@
+mod support;
+
+use support::{run_ragcli, MockOllamaConfig, MockOllamaServer};
+
+#[test]
+fn test_index_sources_and_stat_cover_store_lifecycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    let nebula = docs.join("nebula.md");
+    let orchard = docs.join("orchard.md");
+    std::fs::write(
+        &nebula,
+        "Project Nebula maps star catalogs for observatory search.",
+    )
+    .unwrap();
+    std::fs::write(
+        &orchard,
+        "Orchard operations track apple harvest schedules and storage.",
+    )
+    .unwrap();
+
+    let server = MockOllamaServer::start(MockOllamaConfig::default());
+    let env = [("RAGCLI_OLLAMA_URL", server.url())];
+
+    let index = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "lifecycle", "index", docs.to_str().unwrap()],
+    );
+    index.assert_success();
+    assert!(index.stdout.contains("Index complete: 2 files, 2 chunks"));
+
+    let sources = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "lifecycle", "sources", "--json"],
+    );
+    sources.assert_success();
+    let sources_json = sources.json();
+    assert_eq!(sources_json["total_sources"], 2);
+    assert_eq!(sources_json["sources"].as_array().unwrap().len(), 2);
+    let source_paths = sources_json["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|source| source["source_path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(source_paths.iter().any(|path| path.ends_with("nebula.md")));
+    assert!(source_paths.iter().any(|path| path.ends_with("orchard.md")));
+
+    let stat = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "lifecycle", "stat", "--json"],
+    );
+    stat.assert_success();
+    let stat_json = stat.json();
+    assert_eq!(stat_json["stats"]["total_chunks"], 2);
+    assert_eq!(stat_json["stats"]["unique_sources"], 2);
+    assert_eq!(stat_json["stats"]["content_kinds"]["text_files"], 2);
+    assert_eq!(stat_json["metadata"]["embedding_dim"], 4);
+}
+
+#[test]
+fn test_prune_apply_removes_missing_sources_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    let stale = docs.join("stale.md");
+    std::fs::write(&stale, "Project Quartz records calibration baselines.").unwrap();
+
+    let server = MockOllamaServer::start(MockOllamaConfig::default());
+    let env = [("RAGCLI_OLLAMA_URL", server.url())];
+
+    let index = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "maintenance", "index", stale.to_str().unwrap()],
+    );
+    index.assert_success();
+
+    std::fs::remove_file(&stale).unwrap();
+
+    let dry_run = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "maintenance", "prune", "--json"],
+    );
+    dry_run.assert_success();
+    let dry_run_json = dry_run.json();
+    assert_eq!(dry_run_json["dry_run"], true);
+    assert_eq!(dry_run_json["deleted_sources"], 0);
+    assert_eq!(dry_run_json["stale_sources"].as_array().unwrap().len(), 1);
+    assert!(dry_run_json["stale_sources"][0]["source_path"]
+        .as_str()
+        .unwrap()
+        .ends_with("stale.md"));
+
+    let applied = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "maintenance", "prune", "--apply", "--json"],
+    );
+    applied.assert_success();
+    let applied_json = applied.json();
+    assert_eq!(applied_json["dry_run"], false);
+    assert_eq!(applied_json["deleted_sources"], 1);
+    assert_eq!(applied_json["deleted_chunks"], 1);
+
+    let sources = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "maintenance", "sources", "--json"],
+    );
+    sources.assert_success();
+    assert_eq!(sources.json()["total_sources"], 0);
+}

--- a/tests/live_ollama_smoke.rs
+++ b/tests/live_ollama_smoke.rs
@@ -1,0 +1,51 @@
+mod support;
+
+use support::run_ragcli;
+
+#[test]
+#[ignore = "requires a running Ollama with the configured models installed"]
+fn test_live_ollama_index_and_query_smoke() {
+    if std::env::var_os("RAGCLI_LIVE_E2E").is_none() {
+        eprintln!("skipping live smoke test; set RAGCLI_LIVE_E2E=1 to enable");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    let note = docs.join("nebula.txt");
+    std::fs::write(
+        &note,
+        "Project Nebula maps star catalogs for observatory search.",
+    )
+    .unwrap();
+
+    let ollama_url = std::env::var("RAGCLI_OLLAMA_URL")
+        .unwrap_or_else(|_| "http://localhost:11434".to_string());
+    let env = [("RAGCLI_OLLAMA_URL", ollama_url.as_str())];
+
+    let index = run_ragcli(
+        dir.path(),
+        &env,
+        ["--name", "live-smoke", "index", note.to_str().unwrap()],
+    );
+    index.assert_success();
+    assert!(index.stdout.contains("Index complete:"));
+
+    let query = run_ragcli(
+        dir.path(),
+        &env,
+        [
+            "--name",
+            "live-smoke",
+            "query",
+            "What does Project Nebula map?",
+            "--mode",
+            "hybrid",
+            "--top-k",
+            "1",
+        ],
+    );
+    query.assert_success();
+    assert!(!query.stdout.trim().is_empty());
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -191,7 +191,8 @@ fn read_request(stream: &mut TcpStream) -> Option<HttpRequest> {
         buffer.extend_from_slice(&chunk[..read]);
     }
 
-    let body = String::from_utf8_lossy(&buffer[headers_end..headers_end + content_length]).into();
+    let body_end = headers_end.saturating_add(content_length).min(buffer.len());
+    let body = String::from_utf8_lossy(&buffer[headers_end..body_end]).into();
     Some(HttpRequest { method, path, body })
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -11,6 +11,7 @@ use std::sync::{
     Arc,
 };
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 const TELEMETRY_ENVS: [&str; 5] = [
     "OTEL_SERVICE_NAME",
@@ -64,8 +65,8 @@ where
 
     let output = command.output().unwrap();
     CliOutput {
-        stdout: String::from_utf8(output.stdout).unwrap(),
-        stderr: String::from_utf8(output.stderr).unwrap(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         success: output.status.success(),
     }
 }
@@ -136,6 +137,7 @@ struct HttpRequest {
 fn serve(listener: TcpListener, stop: Arc<AtomicBool>, config: MockOllamaConfig) {
     loop {
         let (mut stream, _) = listener.accept().expect("accept mock ollama request");
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
         if stop.load(Ordering::SeqCst) {
             break;
         }
@@ -175,7 +177,7 @@ fn read_request(stream: &mut TcpStream) -> Option<HttpRequest> {
     let content_length = lines
         .find_map(|line| {
             let (name, value) = line.split_once(':')?;
-            if name.eq_ignore_ascii_case("content-length") {
+            if name.trim().eq_ignore_ascii_case("content-length") {
                 value.trim().parse::<usize>().ok()
             } else {
                 None

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,266 @@
+#![allow(dead_code)]
+
+use serde_json::Value;
+use std::ffi::OsStr;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::Path;
+use std::process::Command;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread::{self, JoinHandle};
+
+const TELEMETRY_ENVS: [&str; 5] = [
+    "OTEL_SERVICE_NAME",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_TIMEOUT",
+];
+
+pub struct CliOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub success: bool,
+}
+
+impl CliOutput {
+    pub fn assert_success(&self) {
+        assert!(
+            self.success,
+            "command failed\nstdout:\n{}\nstderr:\n{}",
+            self.stdout,
+            self.stderr
+        );
+    }
+
+    #[allow(dead_code)]
+    pub fn json(&self) -> Value {
+        serde_json::from_str(&self.stdout).unwrap_or_else(|err| {
+            panic!(
+                "stdout was not valid json: {err}\nstdout:\n{}\nstderr:\n{}",
+                self.stdout, self.stderr
+            )
+        })
+    }
+}
+
+pub fn run_ragcli<I, S>(config_home: &Path, extra_env: &[(&str, &str)], args: I) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ragcli"));
+    command.args(args);
+    command.env("XDG_CONFIG_HOME", config_home);
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    for key in TELEMETRY_ENVS {
+        command.env_remove(key);
+    }
+
+    let output = command.output().unwrap();
+    CliOutput {
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8(output.stderr).unwrap(),
+        success: output.status.success(),
+    }
+}
+
+pub struct MockOllamaConfig {
+    pub chat_response: String,
+    pub tags_models: Vec<String>,
+}
+
+impl Default for MockOllamaConfig {
+    fn default() -> Self {
+        Self {
+            chat_response: "Project Nebula maps star catalogs for observatory search [1]."
+                .to_string(),
+            tags_models: vec![
+                "nomic-embed-text-v2-moe:latest".to_string(),
+                "qwen3.5:4b".to_string(),
+            ],
+        }
+    }
+}
+
+pub struct MockOllamaServer {
+    base_url: String,
+    socket_addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockOllamaServer {
+    pub fn start(config: MockOllamaConfig) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock ollama");
+        let socket_addr = listener.local_addr().expect("mock ollama addr");
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let handle = thread::spawn(move || serve(listener, stop_thread, config));
+
+        Self {
+            base_url: format!("http://{socket_addr}"),
+            socket_addr,
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for MockOllamaServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.socket_addr);
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("join mock ollama thread");
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HttpRequest {
+    method: String,
+    path: String,
+    body: String,
+}
+
+fn serve(listener: TcpListener, stop: Arc<AtomicBool>, config: MockOllamaConfig) {
+    loop {
+        let (mut stream, _) = listener.accept().expect("accept mock ollama request");
+        if stop.load(Ordering::SeqCst) {
+            break;
+        }
+
+        let request = match read_request(&mut stream) {
+            Some(request) => request,
+            None => continue,
+        };
+        let (status, body) = route_request(&config, &request);
+        write_response(&mut stream, status, &body);
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<HttpRequest> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let headers_end;
+
+    loop {
+        let read = stream.read(&mut chunk).ok()?;
+        if read == 0 {
+            return None;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(position) = find_bytes(&buffer, b"\r\n\r\n") {
+            headers_end = position + 4;
+            break;
+        }
+    }
+
+    let header_text = String::from_utf8_lossy(&buffer[..headers_end]);
+    let mut lines = header_text.lines();
+    let request_line = lines.next()?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next()?.to_string();
+    let path = parts.next()?.to_string();
+    let content_length = lines
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+
+    while buffer.len() < headers_end + content_length {
+        let read = stream.read(&mut chunk).ok()?;
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+
+    let body = String::from_utf8_lossy(&buffer[headers_end..headers_end + content_length]).into();
+    Some(HttpRequest { method, path, body })
+}
+
+fn route_request(config: &MockOllamaConfig, request: &HttpRequest) -> (&'static str, String) {
+    match (request.method.as_str(), request.path.as_str()) {
+        ("GET", "/api/tags") => {
+            let body = serde_json::json!({
+                "models": config
+                    .tags_models
+                    .iter()
+                    .map(|name| serde_json::json!({ "name": name }))
+                    .collect::<Vec<_>>()
+            });
+            ("200 OK", body.to_string())
+        }
+        ("POST", "/api/embed") => {
+            let input = serde_json::from_str::<Value>(&request.body)
+                .ok()
+                .and_then(|value| value.get("input").and_then(Value::as_str).map(str::to_owned))
+                .unwrap_or_default();
+            let body = serde_json::json!({
+                "embeddings": [compute_embedding(&input)],
+            });
+            ("200 OK", body.to_string())
+        }
+        ("POST", "/api/chat") => {
+            let body = serde_json::json!({
+                "message": {
+                    "content": config.chat_response,
+                }
+            });
+            ("200 OK", body.to_string())
+        }
+        _ => (
+            "404 Not Found",
+            serde_json::json!({"error": "not found"}).to_string(),
+        ),
+    }
+}
+
+fn compute_embedding(input: &str) -> Vec<f32> {
+    let normalized = input.to_ascii_lowercase();
+    let mut embedding = vec![0.0, 0.0, 0.0, 0.0];
+    if normalized.contains("nebula") {
+        embedding[0] = 1.0;
+    }
+    if normalized.contains("orchard") {
+        embedding[1] = 1.0;
+    }
+    if normalized.contains("quartz") {
+        embedding[2] = 1.0;
+    }
+    if embedding.iter().all(|value| *value == 0.0) {
+        embedding[3] = 1.0;
+    }
+    embedding
+}
+
+fn write_response(stream: &mut TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write mock ollama response");
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|window| window == needle)
+}


### PR DESCRIPTION
## Summary
- add CI-safe end-to-end tests for store lifecycle, query, and doctor flows
- add shared integration test helpers with a tiny mock Ollama server
- add an ignored live Ollama smoke test and a Taskfile entry to run it

## Validation
- cargo test --test json_output --test e2e_store_lifecycle --test e2e_query --test e2e_doctor
- cargo test --test live_ollama_smoke --no-run