### PR TITLE
feat(ui): add shared TUI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -954,6 +955,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1746,6 +1770,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3616,6 +3649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,6 +4681,7 @@ dependencies = [
  "atomicwrites",
  "base64 0.22.1",
  "clap",
+ "comfy-table",
  "console",
  "csv",
  "futures",
@@ -4660,6 +4700,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "textwrap",
  "time",
  "tokio",
  "toml",
@@ -5425,6 +5466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5819,6 +5866,17 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -6309,6 +6367,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ globset = "0.4"
 html2text = "0.13"
 indicatif = "0.17"
 console = "0.15"
+comfy-table = "7.2"
+textwrap = "0.16"
 lancedb = "0.26"
 pdf-extract = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"] }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,6 +2,7 @@ use crate::config::{
     self, ensure_store_layout, load_or_create_config_with_sources, load_or_create_file_config,
     save_config, store_dir, Config, ConfigSources,
 };
+use crate::ui::{self, Panel};
 use anyhow::Result;
 use serde::Serialize;
 
@@ -40,16 +41,27 @@ fn build_show_report(name: Option<&str>) -> Result<ConfigShowReport> {
 }
 
 fn print_show_human(report: &ConfigShowReport) -> Result<()> {
-    println!("Store: {}", report.store);
-    println!("Config: {}", report.config_path);
+    ui::command_header("ragcli config show", "");
+
+    let mut location = Panel::new("Config Location");
+    location.kv("store", &report.store, 6);
+    location.kv("file", &report.config_path, 6);
+    location.render();
+
     println!();
-    println!("{}", toml::to_string_pretty(&report.config)?);
+    let mut config = Panel::new("Config");
+    for line in toml::to_string_pretty(&report.config)?.lines() {
+        config.push(format!("  {line}"));
+    }
+    config.render();
 
     if !report.active_overrides.is_empty() {
-        println!("Active environment overrides:");
+        println!();
+        let mut overrides = Panel::new("Active Environment Overrides");
         for override_entry in &report.active_overrides {
-            println!("  {}", override_entry);
+            overrides.prose("env", override_entry, 4);
         }
+        overrides.render();
     }
 
     Ok(())
@@ -62,8 +74,12 @@ pub async fn set(name: Option<&str>, key: String, value: String) -> Result<()> {
     cfg.set_path(&key, &value)?;
     save_config(&store, &cfg)?;
 
-    println!("Updated {}", config::config_path(&store).display());
-    println!("  {} = {}", key, value);
+    let mut panel = Panel::new("Config Updated");
+    panel.kv("file", config::config_path(&store).display().to_string(), 6);
+    panel.kv("key", key, 6);
+    panel.kv("value", value, 6);
+    panel.kv("status", ui::ok("saved"), 6);
+    panel.render();
     Ok(())
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -4,17 +4,15 @@ use crate::config::{
 use crate::models::OllamaClient;
 use crate::store;
 use crate::telemetry::{TelemetryConfig, TelemetryStatus};
+use crate::ui::{self, Panel};
 use anyhow::{Context, Result};
-use console::{measure_text_width, style};
+use console::style;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-
-const MIN_BOX_WIDTH: usize = 48;
-const MAX_PROSE_WIDTH: usize = 104;
 
 #[derive(Debug, Serialize)]
 pub struct PathStatusReport {
@@ -151,16 +149,10 @@ async fn build_report(name: Option<&str>) -> Result<DoctorReport> {
 }
 
 fn print_human(report: &DoctorReport) {
-    // ── Header ────────────────────────────────────────────────────────────────
-    println!(
-        "{}  {}",
-        style("ragcli doctor").bold().cyan(),
-        style(format_unix_timestamp(report.time)).dim()
-    );
-    println!();
+    ui::command_header("ragcli doctor", format_unix_timestamp(report.time));
 
     // ── Paths ─────────────────────────────────────────────────────────────────
-    let mut paths_box = SectionBox::new("Paths");
+    let mut paths_box = Panel::new("Paths");
     paths_box.push(path_row_str("base", &report.base, 8));
     paths_box.push(path_row_str("store", &report.store, 8));
     paths_box.push(path_row_str("config", &report.config, 8));
@@ -173,7 +165,7 @@ fn print_human(report: &DoctorReport) {
         ));
     }
     if let Some(summary) = &report.metadata_summary {
-        for row in wrapped_dim_rows("summary", summary, 8, MAX_PROSE_WIDTH) {
+        for row in ui::wrapped_dim_rows("summary", summary, 8, ui::DEFAULT_WRAP_WIDTH) {
             paths_box.push(row);
         }
     }
@@ -181,12 +173,12 @@ fn print_human(report: &DoctorReport) {
     println!();
 
     // ── Ollama ────────────────────────────────────────────────────────────────
-    let mut ollama_box = SectionBox::new("Ollama");
+    let mut ollama_box = Panel::new("Ollama");
     ollama_box.push(kv_str("url", &report.ollama_url, 9));
     if report.ollama_reachable {
-        ollama_box.push(kv_str("reachable", &ok("yes"), 9));
+        ollama_box.push(kv_str("reachable", &ui::ok("yes"), 9));
     } else {
-        ollama_box.push(kv_str("reachable", &err("no"), 9));
+        ollama_box.push(kv_str("reachable", &ui::err("no"), 9));
         if let Some(e) = &report.ollama_error {
             ollama_box.push(format!(
                 "  {:<9}  {}",
@@ -199,7 +191,7 @@ fn print_human(report: &DoctorReport) {
     println!();
 
     // ── Models ────────────────────────────────────────────────────────────────
-    let mut models_box = SectionBox::new("Models");
+    let mut models_box = Panel::new("Models");
     match &report.installed_models {
         Some(inst) => {
             models_box.push(model_row_str(
@@ -231,12 +223,12 @@ fn print_human(report: &DoctorReport) {
     println!();
 
     // ── Telemetry ─────────────────────────────────────────────────────────────
-    let mut tel_box = SectionBox::new("Telemetry");
+    let mut tel_box = Panel::new("Telemetry");
     let tel = &report.telemetry;
     if tel.enabled {
-        tel_box.push(kv_str("enabled", &ok("yes"), 14));
+        tel_box.push(kv_str("enabled", &ui::ok("yes"), 14));
     } else {
-        tel_box.push(kv_str("enabled", &err("no"), 14));
+        tel_box.push(kv_str("enabled", &ui::err("no"), 14));
     }
     tel_box.push(kv_str("service name", &tel.service_name, 14));
     tel_box.push(kv_str("protocol", &tel.protocol, 14));
@@ -247,9 +239,9 @@ fn print_human(report: &DoctorReport) {
         tel_box.push(kv_str("timeout (ms)", &timeout_ms.to_string(), 14));
     }
     if tel.headers_configured {
-        tel_box.push(kv_str("headers", &ok("configured"), 14));
+        tel_box.push(kv_str("headers", &ui::ok("configured"), 14));
     } else {
-        tel_box.push(kv_str("headers", &err("not configured"), 14));
+        tel_box.push(kv_str("headers", &ui::err("not configured"), 14));
     }
     if let Some(e) = &report.telemetry_error {
         tel_box.push(format!(
@@ -262,7 +254,7 @@ fn print_human(report: &DoctorReport) {
     println!();
 
     // ── Store Layout ──────────────────────────────────────────────────────────
-    let mut layout_box = SectionBox::new("Store Layout");
+    let mut layout_box = Panel::new("Store Layout");
     let col = report
         .subdirectories
         .iter()
@@ -271,9 +263,9 @@ fn print_human(report: &DoctorReport) {
         .unwrap_or(0);
     for sub in &report.subdirectories {
         let status_str = if sub.status == "exists" {
-            ok("exists")
+            ui::ok("exists")
         } else {
-            err("missing")
+            ui::err("missing")
         };
         layout_box.push(format!(
             "  {}  {}  {}",
@@ -294,9 +286,9 @@ fn print_hints(report: &DoctorReport) {
     }
 
     println!();
-    let mut hints_box = SectionBox::new("Hints");
+    let mut hints_box = Panel::new("Hints");
     for hint in hints {
-        for row in wrapped_hint_rows(&hint, MAX_PROSE_WIDTH) {
+        for row in ui::wrapped_hint_rows(&hint, ui::DEFAULT_WRAP_WIDTH) {
             hints_box.push(row);
         }
     }
@@ -412,70 +404,6 @@ fn model_install_hints(
         .collect()
 }
 
-/// Renders a labelled section with rounded box-drawing borders.
-///
-/// ```text
-/// ╭─ Title ──────────────────────────────╮
-/// │  key   value                         │
-/// ╰──────────────────────────────────────╯
-/// ```
-struct SectionBox {
-    title: &'static str,
-    rows: Vec<String>,
-}
-
-impl SectionBox {
-    fn new(title: &'static str) -> Self {
-        Self {
-            title,
-            rows: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, row: impl Into<String>) {
-        self.rows.push(row.into());
-    }
-
-    fn render(&self) {
-        let title_visual = measure_text_width(self.title);
-        let max_row_visual = self
-            .rows
-            .iter()
-            .map(|r| measure_text_width(r))
-            .max()
-            .unwrap_or(0);
-
-        // Total box width (including the two │ borders).
-        // – content area: box_width - 4  (│·content·│)
-        // – title must fit in top border: box_width >= title_visual + 5 + 1 filler
-        // Do not cap to terminal width here: rows are already styled strings, and
-        // truncating them risks cutting ANSI escape sequences while still leaving
-        // long paths, metadata summaries, and hints outside the right border.
-        let box_width = (max_row_visual + 4)
-            .max(title_visual + 6)
-            .max(MIN_BOX_WIDTH);
-        let inner_width = box_width - 4;
-
-        // Top border  ╭─ Title ─────────────────────╮
-        let top_fill = box_width.saturating_sub(title_visual + 5);
-        println!(
-            "╭─ {} {}╮",
-            style(self.title).bold().cyan(),
-            "─".repeat(top_fill)
-        );
-
-        // Content rows  │ …content… │
-        for row in &self.rows {
-            let visual = measure_text_width(row);
-            let pad = inner_width.saturating_sub(visual);
-            println!("│ {}{} │", row, " ".repeat(pad));
-        }
-
-        // Bottom border  ╰──────────────────────────╯
-        println!("╰{}╯", "─".repeat(box_width - 2));
-    }
-}
-
 /// Build a plain key/value row string with aligned padding.
 fn kv_str(label: &str, value: &str, width: usize) -> String {
     format!("  {}  {}", style(format!("{label:<width$}")).dim(), value)
@@ -484,9 +412,9 @@ fn kv_str(label: &str, value: &str, width: usize) -> String {
 /// Build a path row string: label  path  ✓/✗ status.
 fn path_row_str(label: &str, report: &PathStatusReport, width: usize) -> String {
     let status_str = if report.status == "exists" {
-        ok("exists")
+        ui::ok("exists")
     } else {
-        err("missing")
+        ui::err("missing")
     };
     format!(
         "  {}  {}  {}",
@@ -499,9 +427,9 @@ fn path_row_str(label: &str, report: &PathStatusReport, width: usize) -> String 
 /// Build a model row string: label  model-name  ✓/✗ installed.
 fn model_row_str(label: &str, model: &str, installed: bool, width: usize) -> String {
     let status_str = if installed {
-        ok("installed")
+        ui::ok("installed")
     } else {
-        err("not installed")
+        ui::err("not installed")
     };
     format!(
         "  {}  {:<30}  {}",
@@ -509,81 +437,6 @@ fn model_row_str(label: &str, model: &str, installed: bool, width: usize) -> Str
         model,
         status_str,
     )
-}
-
-fn wrapped_dim_rows(
-    label: &str,
-    text: &str,
-    label_width: usize,
-    value_width: usize,
-) -> Vec<String> {
-    wrap_words(text, value_width)
-        .into_iter()
-        .enumerate()
-        .map(|(idx, line)| {
-            let label = if idx == 0 { label } else { "" };
-            format!(
-                "  {}  {}",
-                style(format!("{label:<label_width$}")).dim(),
-                style(line).dim()
-            )
-        })
-        .collect()
-}
-
-fn wrapped_hint_rows(hint: &str, width: usize) -> Vec<String> {
-    wrap_words(hint, width)
-        .into_iter()
-        .enumerate()
-        .map(|(idx, line)| {
-            if idx == 0 {
-                format!("  {} {}", style("→").yellow().bold(), style(line).yellow())
-            } else {
-                format!("    {}", style(line).yellow())
-            }
-        })
-        .collect()
-}
-
-fn wrap_words(text: &str, max_width: usize) -> Vec<String> {
-    let mut lines = Vec::new();
-    let mut current = String::new();
-
-    for word in text.split_whitespace() {
-        if current.is_empty() {
-            current.push_str(word);
-            continue;
-        }
-
-        let next_width = measure_text_width(&current) + 1 + measure_text_width(word);
-        if next_width > max_width {
-            lines.push(current);
-            current = word.to_string();
-        } else {
-            current.push(' ');
-            current.push_str(word);
-        }
-    }
-
-    if !current.is_empty() {
-        lines.push(current);
-    }
-
-    if lines.is_empty() {
-        lines.push(String::new());
-    }
-
-    lines
-}
-
-/// Green ✓ prefix with text.
-fn ok(text: &str) -> String {
-    format!("{} {}", style("✓").green().bold(), style(text).green())
-}
-
-/// Red ✗ prefix with text.
-fn err(text: &str) -> String {
-    format!("{} {}", style("✗").red().bold(), style(text).red())
 }
 
 fn format_unix_timestamp(timestamp: u64) -> String {

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -6,6 +6,7 @@ use crate::config::{
 use crate::ingest::{ingest_path, PdfParser};
 use crate::models::{Embedder, VisionCaptioner};
 use crate::store::{connect_db, ensure_metadata, load_source_fingerprints, replace_source_rows};
+use crate::ui::{self, Panel};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -110,18 +111,39 @@ pub async fn run(
         command_span_inner.record("error_count", result.stats.errors.len());
         command_span_inner.record("elapsed_ms", elapsed_ms as u64);
 
-        println!(
-            "Index complete: {} files, {} chunks, {} skipped, {}ms",
-            result.stats.indexed_files,
-            result.stats.total_chunks,
-            result.stats.skipped_files,
-            elapsed_ms
+        ui::command_header("ragcli index", format!("{}ms", elapsed_ms));
+        let mut summary = Panel::new("Index Summary");
+        summary.kv("path", path.display().to_string(), 14);
+        summary.kv("store", store.display().to_string(), 14);
+        summary.kv("embed model", &embed_model_name, 14);
+        summary.kv("pdf parser", format!("{parser:?}"), 14);
+        summary.status(
+            "status",
+            result.stats.errors.is_empty(),
+            "complete",
+            "completed with errors",
+            14,
         );
+        summary.kv(
+            "result",
+            format!(
+                "Index complete: {} files, {} chunks, {} skipped",
+                result.stats.indexed_files, result.stats.total_chunks, result.stats.skipped_files
+            ),
+            14,
+        );
+        summary.kv("indexed files", result.stats.indexed_files.to_string(), 14);
+        summary.kv("chunks", result.stats.total_chunks.to_string(), 14);
+        summary.kv("skipped", result.stats.skipped_files.to_string(), 14);
+        summary.render();
 
         if !result.stats.errors.is_empty() {
+            println!();
+            let mut errors = Panel::new("Index Errors");
             for err in &result.stats.errors {
-                eprintln!("index error: {err}");
+                errors.prose("error", err, 8);
             }
+            errors.render();
         }
 
         Ok(())

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -4,6 +4,7 @@ use crate::store::{
     clear_store_rows, connect_db, delete_source_rows, list_indexed_source_summaries,
     load_indexed_source_summary, IndexedSourceSummary,
 };
+use crate::ui::{self, Panel};
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -22,17 +23,20 @@ pub async fn delete(name: Option<&str>, path: String) -> Result<()> {
     ensure_store_layout(&store)?;
     let db = connect_db(&store).await?;
     let Some(source) = load_indexed_source_summary(&db, &path).await? else {
-        println!("No indexed source matched {}", path);
+        let mut panel = Panel::new("Delete Source");
+        panel.kv("source", path, 8);
+        panel.kv("status", ui::warn("not indexed"), 8);
+        panel.render();
         return Ok(());
     };
 
     delete_source_rows(&db, std::slice::from_ref(&source.source_path)).await?;
-    println!(
-        "Deleted {} [{}, {} chunks]",
-        source.source_path,
-        source.format,
-        fmt_count(source.chunks)
-    );
+    let mut panel = Panel::new("Delete Source");
+    panel.kv("source", &source.source_path, 8);
+    panel.kv("format", &source.format, 8);
+    panel.kv("chunks", fmt_count(source.chunks), 8);
+    panel.kv("status", ui::ok("deleted"), 8);
+    panel.render();
     Ok(())
 }
 
@@ -46,7 +50,10 @@ pub async fn clear(name: Option<&str>, yes: bool) -> Result<()> {
     let db = connect_db(&store).await?;
     let sources = list_indexed_source_summaries(&db).await?;
     if sources.is_empty() {
-        println!("Store already empty: {}", store.display());
+        let mut panel = Panel::new("Clear Store");
+        panel.kv("store", store.display().to_string(), 8);
+        panel.kv("status", ui::warn("already empty"), 8);
+        panel.render();
         return Ok(());
     }
 
@@ -54,12 +61,12 @@ pub async fn clear(name: Option<&str>, yes: bool) -> Result<()> {
     let deleted_chunks = sources.iter().map(|source| source.chunks).sum::<usize>();
     clear_store_rows(&db).await?;
 
-    println!(
-        "Cleared store {}: removed {} sources and {} chunks",
-        store.display(),
-        fmt_count(deleted_sources),
-        fmt_count(deleted_chunks)
-    );
+    let mut panel = Panel::new("Clear Store");
+    panel.kv("store", store.display().to_string(), 8);
+    panel.kv("sources", fmt_count(deleted_sources), 8);
+    panel.kv("chunks", fmt_count(deleted_chunks), 8);
+    panel.kv("status", ui::ok("cleared"), 8);
+    panel.render();
     Ok(())
 }
 
@@ -130,39 +137,60 @@ fn source_is_missing(source: &IndexedSourceSummary) -> Result<bool> {
 }
 
 fn print_prune_human(report: &PruneReport) {
-    if report.dry_run {
-        println!("Prune preview");
+    ui::command_header(
+        if report.dry_run {
+            "ragcli prune"
+        } else {
+            "ragcli prune --apply"
+        },
+        "",
+    );
+
+    let mut summary = Panel::new(if report.dry_run {
+        "Prune Preview"
     } else {
-        println!("Prune complete");
-    }
-    println!("  store: {}", report.store);
-    println!("  stale sources: {}", report.stale_sources.len());
+        "Prune Complete"
+    });
+    summary.kv("store", &report.store, 8);
+    summary.kv("stale", report.stale_sources.len().to_string(), 8);
 
     if report.stale_sources.is_empty() {
-        println!("  nothing to prune");
+        summary.kv("status", ui::ok("nothing to prune"), 8);
+        summary.render();
         return;
     }
 
-    for source in &report.stale_sources {
-        let mut details = vec![
-            source.format.clone(),
-            format!("{} chunks", fmt_count(source.chunks)),
-        ];
-        if source.page_count > 0 {
-            details.push(format!("{} pages", fmt_count(source.page_count)));
-        }
-        println!("    - {}  [{}]", source.source_path, details.join(", "));
-    }
-
     if report.dry_run {
-        println!("  rerun with --apply to remove these rows");
+        summary.kv("status", ui::warn("dry run"), 8);
+        summary.hint("Rerun with `--apply` to remove these rows.");
     } else {
-        println!(
-            "  removed {} sources and {} chunks",
-            fmt_count(report.deleted_sources),
-            fmt_count(report.deleted_chunks)
-        );
+        summary.kv("sources", fmt_count(report.deleted_sources), 8);
+        summary.kv("chunks", fmt_count(report.deleted_chunks), 8);
+        summary.kv("status", ui::ok("removed stale rows"), 8);
     }
+    summary.render();
+
+    println!();
+    ui::render_table(
+        "Stale Sources",
+        &["Source", "Format", "Chunks", "Pages"],
+        report
+            .stale_sources
+            .iter()
+            .map(|source| {
+                vec![
+                    source.source_path.clone(),
+                    source.format.clone(),
+                    fmt_count(source.chunks),
+                    if source.page_count > 0 {
+                        fmt_count(source.page_count)
+                    } else {
+                        "-".to_string()
+                    },
+                ]
+            })
+            .collect(),
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/sources.rs
+++ b/src/commands/sources.rs
@@ -1,6 +1,7 @@
 use crate::commands::stat::fmt_count;
 use crate::config::{ensure_store_layout, store_dir};
 use crate::store::{connect_db, list_indexed_sources, IndexedSource};
+use crate::ui::{self, Panel};
 use anyhow::Result;
 use serde::Serialize;
 
@@ -35,28 +36,41 @@ async fn build_report(name: Option<&str>) -> Result<SourcesReport> {
 }
 
 fn print_human(report: &SourcesReport) {
-    println!("Indexed sources");
-    println!("  store: {}", report.store);
-    println!("  sources: {}", report.total_sources);
+    ui::command_header("ragcli sources", "");
 
+    let mut summary = Panel::new("Indexed Sources");
+    summary.kv("store", &report.store, 8);
+    summary.kv("sources", report.total_sources.to_string(), 8);
     if report.sources.is_empty() {
-        println!("  no indexed sources");
+        summary.kv("status", ui::warn("no indexed sources"), 8);
+        summary.render();
         return;
     }
+    summary.render();
 
-    for source in &report.sources {
-        let mut details = vec![
-            source.format.clone(),
-            format!("{} chunks", fmt_count(source.chunks)),
-            format!("~{} tokens", fmt_count(source.estimated_tokens)),
-            format!("{} chars", fmt_count(source.chars)),
-        ];
-        if source.page_count > 0 {
-            details.push(format!("{} pages", fmt_count(source.page_count)));
-        }
-
-        println!("    - {}  [{}]", source.source_path, details.join(", "));
-    }
+    println!();
+    ui::render_table(
+        "Sources",
+        &["Source", "Format", "Chunks", "Tokens", "Chars", "Pages"],
+        report
+            .sources
+            .iter()
+            .map(|source| {
+                vec![
+                    source.source_path.clone(),
+                    source.format.clone(),
+                    fmt_count(source.chunks),
+                    format!("~{}", fmt_count(source.estimated_tokens)),
+                    fmt_count(source.chars),
+                    if source.page_count > 0 {
+                        fmt_count(source.page_count)
+                    } else {
+                        "-".to_string()
+                    },
+                ]
+            })
+            .collect(),
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -2,6 +2,7 @@ use crate::config::{ensure_store_layout, load_or_create_config, store_dir};
 use crate::store::{
     collect_store_stats, connect_db, load_metadata, StoreMetadata, StoreStats, DEFAULT_TABLE_NAME,
 };
+use crate::ui::{self, Panel};
 use anyhow::Result;
 use futures::TryStreamExt;
 use lancedb::query::ExecutableQuery;
@@ -74,72 +75,110 @@ async fn build_report(name: Option<&str>) -> Result<StatReport> {
 }
 
 fn print_human(report: &StatReport) {
-    println!("Store summary");
-    println!("  store: {}", report.store);
-    println!("  ollama url: {}", report.ollama_url);
-    println!("  rows embedded: {}", report.stats.total_chunks);
-    println!("  source files: {}", report.stats.unique_sources);
-    println!(
-        "  content mix: {} text, {} pdf, {} image, {} other",
-        report.stats.content_kinds.text_files,
-        report.stats.content_kinds.pdf_files,
-        report.stats.content_kinds.image_files,
-        report.stats.content_kinds.other_files
-    );
-    println!("  pdf pages: {}", report.stats.pdf_pages);
-    println!("  embedded chars: {}", fmt_count(report.stats.total_chars));
-    println!(
-        "  estimated embedded tokens: ~{}",
-        fmt_count(report.stats.estimated_tokens)
-    );
+    ui::command_header("ragcli stat", "");
 
+    let mut summary = Panel::new("Store Summary");
+    summary.kv("store", &report.store, 13);
+    summary.kv("ollama url", &report.ollama_url, 13);
+    summary.kv("rows", report.stats.total_chunks.to_string(), 13);
+    summary.kv("sources", report.stats.unique_sources.to_string(), 13);
+    summary.kv("pdf pages", report.stats.pdf_pages.to_string(), 13);
+    summary.kv("chars", fmt_count(report.stats.total_chars), 13);
+    summary.kv(
+        "tokens",
+        format!("~{}", fmt_count(report.stats.estimated_tokens)),
+        13,
+    );
+    summary.render();
+
+    println!();
+    let mut content = Panel::new("Content Mix");
+    content.kv("text", report.stats.content_kinds.text_files.to_string(), 8);
+    content.kv("pdf", report.stats.content_kinds.pdf_files.to_string(), 8);
+    content.kv(
+        "image",
+        report.stats.content_kinds.image_files.to_string(),
+        8,
+    );
+    content.kv(
+        "other",
+        report.stats.content_kinds.other_files.to_string(),
+        8,
+    );
     if report.stats.total_chunks > 0 {
-        println!(
-            "  avg chunk: {} chars, ~{} tokens",
-            report.stats.total_chars / report.stats.total_chunks,
-            report.stats.estimated_tokens / report.stats.total_chunks
+        content.kv(
+            "avg",
+            format!(
+                "{} chars, ~{} tokens",
+                report.stats.total_chars / report.stats.total_chunks,
+                report.stats.estimated_tokens / report.stats.total_chunks
+            ),
+            8,
         );
-        println!(
-            "  chunk range: {}..{} chars",
-            report.stats.min_chunk_chars, report.stats.max_chunk_chars
+        content.kv(
+            "range",
+            format!(
+                "{}..{} chars",
+                report.stats.min_chunk_chars, report.stats.max_chunk_chars
+            ),
+            8,
         );
     }
+    content.render();
 
+    println!();
+    let mut storage = Panel::new("Storage");
+    storage.kv("total", fmt_bytes(report.disk_usage.total_bytes), 8);
+    storage.kv("lancedb", fmt_bytes(report.disk_usage.lancedb_bytes), 8);
+    storage.kv("meta", fmt_bytes(report.disk_usage.meta_bytes), 8);
+    storage.kv("cache", fmt_bytes(report.disk_usage.cache_bytes), 8);
+    storage.kv("models", fmt_bytes(report.disk_usage.models_bytes), 8);
     if let Some(metadata) = &report.metadata {
-        println!(
-            "  embedding: {} (dim {})",
-            metadata.embed_model, metadata.embedding_dim
+        storage.kv(
+            "embed",
+            format!("{} (dim {})", metadata.embed_model, metadata.embedding_dim),
+            8,
         );
-        println!(
-            "  chunking: size {}, overlap {}",
-            metadata.chunk_size, metadata.chunk_overlap
+        storage.kv(
+            "chunking",
+            format!(
+                "size {}, overlap {}",
+                metadata.chunk_size, metadata.chunk_overlap
+            ),
+            8,
         );
     } else {
-        println!("  embedding: metadata missing");
+        storage.kv("embed", ui::warn("metadata missing"), 8);
     }
+    storage.render();
 
-    println!("  disk usage: {}", fmt_bytes(report.disk_usage.total_bytes));
-    println!(
-        "    lancedb: {}",
-        fmt_bytes(report.disk_usage.lancedb_bytes)
-    );
-    println!("    meta: {}", fmt_bytes(report.disk_usage.meta_bytes));
-    println!("    cache: {}", fmt_bytes(report.disk_usage.cache_bytes));
-    println!("    models: {}", fmt_bytes(report.disk_usage.models_bytes));
-    for warning in &report.warnings {
-        eprintln!("  warning: {}", warning);
+    if !report.warnings.is_empty() {
+        println!();
+        let mut warnings = Panel::new("Warnings");
+        for warning in &report.warnings {
+            warnings.prose("warning", warning, 8);
+        }
+        warnings.render();
     }
 
     if !report.stats.top_sources.is_empty() {
-        println!("  top sources by chunk count:");
-        for source in &report.stats.top_sources {
-            println!(
-                "    - {}  [{} chunks, ~{} tokens]",
-                source.source_path,
-                fmt_count(source.chunks),
-                fmt_count(source.estimated_tokens)
-            );
-        }
+        println!();
+        ui::render_table(
+            "Top Sources",
+            &["Source", "Chunks", "Tokens"],
+            report
+                .stats
+                .top_sources
+                .iter()
+                .map(|source| {
+                    vec![
+                        source.source_path.clone(),
+                        fmt_count(source.chunks),
+                        format!("~{}", fmt_count(source.estimated_tokens)),
+                    ]
+                })
+                .collect(),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod store;
 mod telemetry;
 #[cfg(test)]
 mod test_support;
+mod ui;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -11,6 +11,7 @@ use crate::models::Generator;
 use crate::retrieval::{merge_candidates, prune_candidates, RetrievalCandidate};
 use crate::rewrite::{rewrite_query_for_retrieval, QueryRewriteSet};
 use crate::store;
+use crate::ui::Panel;
 use anyhow::Result;
 use std::collections::BTreeSet;
 use tracing::{field, Instrument};
@@ -59,7 +60,9 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
         span_inner.record("iteration_count", result.iterations.len());
 
         if result.hits.is_empty() {
-            println!("No relevant context found in the local store.");
+            let mut panel = Panel::new("Query Result");
+            panel.kv("status", "No relevant context found in the local store.", 8);
+            panel.render();
             return Ok(());
         }
 
@@ -74,7 +77,9 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
             None => generate_answer(&runtime, &command, &result).await?,
         };
         println!();
-        println!("{}", store::strip_thinking(&answer).trim());
+        let mut panel = Panel::new("Answer");
+        panel.prose("", store::strip_thinking(&answer).trim(), 0);
+        panel.render();
         Ok(())
     }
     .instrument(span)

--- a/src/query/render.rs
+++ b/src/query/render.rs
@@ -2,6 +2,7 @@ use crate::agent::{EvidenceVerdict, QueryPlan, RetrievalStrategy};
 use crate::citation::render_citations;
 use crate::commands::query::QueryCommand;
 use crate::retrieval::RetrievalCandidate;
+use crate::ui::{self, Panel};
 
 use super::runtime::mode_label;
 use super::types::QueryResult;
@@ -11,26 +12,28 @@ pub(crate) fn print_query_plan(command: &QueryCommand, result: &QueryResult) {
         return;
     }
 
-    println!("Query plan:");
-    println!("  requested_mode: {}", mode_label(result.requested_mode));
-    println!("  execution_path: {}", result.execution_label);
-    println!("  top_k: {}", command.top_k);
-    println!("  fetch_k: {}", command.fetch_k);
-    println!("  max_iterations: {}", command.max_iterations);
-    println!("  rewrite: {}", command.rewrite);
-    println!("  rerank: {}", command.rerank);
-    println!(
-        "  query_variants: {}",
-        result.rewrite_set.query_variants().join(" | ")
+    let mut panel = Panel::new("Query Plan:");
+    panel.kv("requested", mode_label(result.requested_mode), 14);
+    panel.kv("execution", result.execution_label, 14);
+    panel.kv("top k", command.top_k.to_string(), 14);
+    panel.kv("fetch k", command.fetch_k.to_string(), 14);
+    panel.kv("iterations", command.max_iterations.to_string(), 14);
+    panel.kv("rewrite", enabled(command.rewrite), 14);
+    panel.kv("rerank", enabled(command.rerank), 14);
+    panel.prose(
+        "variants",
+        &result.rewrite_set.query_variants().join(" | "),
+        14,
     );
     if let Some(plan) = &result.plan {
-        println!("  question_type: {}", question_type_label(plan));
-        println!("  strategy: {}", strategy_label(plan));
-        println!("  reasoning: {}", plan.reasoning);
+        panel.kv("question", question_type_label(plan), 14);
+        panel.kv("strategy", strategy_label(plan), 14);
+        panel.prose("reasoning", &plan.reasoning, 14);
         if !plan.subqueries.is_empty() {
-            println!("  subqueries: {}", plan.subqueries.join(" | "));
+            panel.prose("subqueries", &plan.subqueries.join(" | "), 14);
         }
     }
+    panel.render();
 }
 
 pub(crate) fn print_query_trace(command: &QueryCommand, result: &QueryResult) {
@@ -38,30 +41,36 @@ pub(crate) fn print_query_trace(command: &QueryCommand, result: &QueryResult) {
         return;
     }
 
-    println!("Query trace:");
+    let mut panel = Panel::new("Query Trace:");
     for entry in &result.trace {
-        println!("  - {entry}");
+        panel.prose("step", entry, 9);
     }
     for iteration in &result.iterations {
-        println!(
-            "  - iteration {} summary: verdict={}, queries={}, kept={}",
-            iteration.iteration,
-            evidence_verdict_label(&iteration.sufficiency),
-            iteration.query_variants.join(" | "),
-            iteration.kept_count
+        panel.prose(
+            "iteration",
+            &format!(
+                "{} summary: verdict={}, queries={}, kept={}",
+                iteration.iteration,
+                evidence_verdict_label(&iteration.sufficiency),
+                iteration.query_variants.join(" | "),
+                iteration.kept_count
+            ),
+            9,
         );
     }
     if let Some(check) = &result.support_check {
-        println!(
-            "  - support_check: {}",
+        panel.kv(
+            "support",
             if check.supported {
-                "supported"
+                ui::ok("supported")
             } else {
-                "unsupported"
-            }
+                ui::err("unsupported")
+            },
+            9,
         );
     }
-    println!("  - retrieved_hits: {}", result.hits.len());
+    panel.kv("hits", result.hits.len().to_string(), 9);
+    panel.render();
 }
 
 pub(crate) fn print_scores(command: &QueryCommand, result: &QueryResult) {
@@ -69,17 +78,24 @@ pub(crate) fn print_scores(command: &QueryCommand, result: &QueryResult) {
         return;
     }
 
-    println!("Scores:");
-    for (idx, hit) in result.hits.iter().enumerate() {
-        println!(
-            "  [{}] best={:.6} fused={} rerank={} {}",
-            idx + 1,
-            hit.best_score().unwrap_or_default(),
-            format_score(hit.fused_score),
-            format_score(hit.rerank_score),
-            hit.source_path
-        );
-    }
+    ui::render_table(
+        "Scores:",
+        &["#", "Best", "Fused", "Rerank", "Source"],
+        result
+            .hits
+            .iter()
+            .enumerate()
+            .map(|(idx, hit)| {
+                vec![
+                    (idx + 1).to_string(),
+                    format!("{:.6}", hit.best_score().unwrap_or_default()),
+                    format_score(hit.fused_score),
+                    format_score(hit.rerank_score),
+                    hit.source_path.clone(),
+                ]
+            })
+            .collect(),
+    );
 }
 
 pub(crate) fn print_citations(command: &QueryCommand, result: &QueryResult) {
@@ -87,10 +103,11 @@ pub(crate) fn print_citations(command: &QueryCommand, result: &QueryResult) {
         return;
     }
 
-    println!("Citations:");
+    let mut panel = Panel::new("Citations:");
     for citation in render_citations(&result.hits) {
-        println!("  {citation}");
+        panel.prose("", &citation, 0);
     }
+    panel.render();
 }
 
 pub(crate) fn print_contexts(command: &QueryCommand, result: &QueryResult) {
@@ -98,16 +115,25 @@ pub(crate) fn print_contexts(command: &QueryCommand, result: &QueryResult) {
         return;
     }
 
-    println!("Retrieved context:");
+    let mut panel = Panel::new("Retrieved context:");
     for (idx, hit) in result.hits.iter().enumerate() {
         let compact = retrieval_context(hit).replace('\n', " ");
         let preview: String = compact.chars().take(220).collect();
-        println!("  [{}] {}", idx + 1, preview);
+        panel.prose(&format!("[{}]", idx + 1), &preview, 5);
     }
+    panel.render();
 }
 
 fn retrieval_context(hit: &RetrievalCandidate) -> String {
     format!("Source: {}\n{}", hit.source_path, hit.chunk_text)
+}
+
+fn enabled(value: bool) -> String {
+    if value {
+        ui::ok("enabled")
+    } else {
+        "disabled".to_string()
+    }
 }
 
 fn format_score(score: Option<f32>) -> String {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,193 @@
+use comfy_table::{
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, ContentArrangement, Table,
+};
+use console::{measure_text_width, style};
+
+pub const MIN_PANEL_WIDTH: usize = 48;
+pub const DEFAULT_WRAP_WIDTH: usize = 104;
+
+/// Renders a labelled, non-interactive TUI-style panel for human CLI output.
+pub struct Panel {
+    title: String,
+    rows: Vec<String>,
+}
+
+impl Panel {
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            rows: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, row: impl Into<String>) {
+        self.rows.push(row.into());
+    }
+
+    pub fn kv(&mut self, label: &str, value: impl AsRef<str>, width: usize) {
+        self.push(kv_row(label, value.as_ref(), width));
+    }
+
+    pub fn status(
+        &mut self,
+        label: &str,
+        healthy: bool,
+        ok_text: &str,
+        err_text: &str,
+        width: usize,
+    ) {
+        let value = if healthy { ok(ok_text) } else { err(err_text) };
+        self.kv(label, value, width);
+    }
+
+    pub fn prose(&mut self, label: &str, text: &str, label_width: usize) {
+        for row in wrapped_dim_rows(label, text, label_width, DEFAULT_WRAP_WIDTH) {
+            self.push(row);
+        }
+    }
+
+    pub fn hint(&mut self, hint: &str) {
+        for row in wrapped_hint_rows(hint, DEFAULT_WRAP_WIDTH) {
+            self.push(row);
+        }
+    }
+
+    pub fn render(&self) {
+        let title_visual = measure_text_width(&self.title);
+        let max_row_visual = self
+            .rows
+            .iter()
+            .map(|row| measure_text_width(row))
+            .max()
+            .unwrap_or(0);
+        let box_width = (max_row_visual + 4)
+            .max(title_visual + 6)
+            .max(MIN_PANEL_WIDTH);
+        let inner_width = box_width - 4;
+        let top_fill = box_width.saturating_sub(title_visual + 5);
+
+        println!(
+            "╭─ {} {}╮",
+            style(&self.title).bold().cyan(),
+            "─".repeat(top_fill)
+        );
+        for row in &self.rows {
+            let visual = measure_text_width(row);
+            let pad = inner_width.saturating_sub(visual);
+            println!("│ {}{} │", row, " ".repeat(pad));
+        }
+        println!("╰{}╯", "─".repeat(box_width - 2));
+    }
+}
+
+pub fn command_header(name: &str, suffix: impl AsRef<str>) {
+    let suffix = suffix.as_ref();
+    if suffix.is_empty() {
+        println!("{}", style(name).bold().cyan());
+    } else {
+        println!("{}  {}", style(name).bold().cyan(), style(suffix).dim());
+    }
+    println!();
+}
+
+pub fn kv_row(label: &str, value: &str, width: usize) -> String {
+    format!("  {}  {}", style(format!("{label:<width$}")).dim(), value)
+}
+
+pub fn ok(text: &str) -> String {
+    format!("{} {}", style("✓").green().bold(), style(text).green())
+}
+
+pub fn err(text: &str) -> String {
+    format!("{} {}", style("✗").red().bold(), style(text).red())
+}
+
+pub fn warn(text: &str) -> String {
+    format!("{} {}", style("!").yellow().bold(), style(text).yellow())
+}
+
+pub fn wrapped_dim_rows(
+    label: &str,
+    text: &str,
+    label_width: usize,
+    value_width: usize,
+) -> Vec<String> {
+    wrap_words(text, value_width)
+        .into_iter()
+        .enumerate()
+        .map(|(idx, line)| {
+            let label = if idx == 0 { label } else { "" };
+            format!(
+                "  {}  {}",
+                style(format!("{label:<label_width$}")).dim(),
+                style(line).dim()
+            )
+        })
+        .collect()
+}
+
+pub fn wrapped_hint_rows(hint: &str, width: usize) -> Vec<String> {
+    wrap_words(hint, width)
+        .into_iter()
+        .enumerate()
+        .map(|(idx, line)| {
+            if idx == 0 {
+                format!("  {} {}", style("→").yellow().bold(), style(line).yellow())
+            } else {
+                format!("    {}", style(line).yellow())
+            }
+        })
+        .collect()
+}
+
+pub fn wrap_words(text: &str, max_width: usize) -> Vec<String> {
+    let options = textwrap::Options::new(max_width)
+        .break_words(false)
+        .word_separator(textwrap::WordSeparator::AsciiSpace)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
+    let wrapped = textwrap::wrap(text, options);
+    if wrapped.is_empty() {
+        vec![String::new()]
+    } else {
+        wrapped.into_iter().map(|line| line.into_owned()).collect()
+    }
+}
+
+pub fn render_table(title: &str, headers: &[&str], rows: Vec<Vec<String>>) {
+    println!("{}", style(title).bold().cyan());
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(
+            headers
+                .iter()
+                .map(|header| Cell::new(*header).add_attribute(Attribute::Bold))
+                .collect::<Vec<_>>(),
+        );
+
+    for row in rows {
+        table.add_row(row);
+    }
+
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wrap_words_wraps_long_text() {
+        let rows = wrap_words("alpha beta gamma delta", 12);
+        assert_eq!(rows, vec!["alpha beta", "gamma delta"]);
+    }
+
+    #[test]
+    fn test_kv_row_pads_before_styling() {
+        let row = kv_row("key", "value", 6);
+        assert!(row.contains("key"));
+        assert!(row.contains("value"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared TUI-style output layer using comfy-table and textwrap
- apply polished panels/tables across human output for doctor, index, stat, sources, config, maintenance, and query rendering
- keep JSON output unchanged

## Tests
- rustfmt --edition 2021 --check src/ui.rs src/main.rs src/commands/config.rs src/commands/doctor.rs src/commands/index.rs src/commands/maintenance.rs src/commands/sources.rs src/commands/stat.rs src/query/execute.rs src/query/render.rs
- cargo check
- cargo test --all-targets