### PR TITLE
feat(index): add single-page web indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1753,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1832,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1870,12 @@ checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -2117,6 +2182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2335,15 @@ checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
 dependencies = [
  "geo-types",
  "libm",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2429,8 +2512,8 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf7722c2ffdd62628b6e13065b6ab6cf154a236bd476c6e89af1352d745b83e"
 dependencies = [
- "html5ever",
- "markup5ever",
+ "html5ever 0.29.1",
+ "markup5ever 0.14.1",
  "nom 7.1.3",
  "tendril",
  "thiserror 2.0.18",
@@ -2445,8 +2528,19 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
- "match_token",
+ "markup5ever 0.14.1",
+ "match_token 0.1.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+ "match_token 0.35.0",
 ]
 
 [[package]]
@@ -3780,10 +3874,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4365,6 +4481,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.11.3",
 ]
 
@@ -4395,6 +4512,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4696,6 +4826,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-vcr",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -5241,6 +5372,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.35.0",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5261,6 +5407,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -5379,6 +5544,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6665,6 +6839,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ textwrap = "0.16"
 lancedb = "0.26"
 pdf-extract = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"] }
+scraper = "0.24"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,9 +37,9 @@ pub struct Cli {
 /// Supported `ragcli` subcommands.
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Indexes a file or directory into the local store.
+    /// Indexes a file, directory, or HTTP(S) URL into the local store.
     Index {
-        /// Path to a file or directory to index.
+        /// Path to a file, directory, or HTTP(S) URL to index.
         path: PathBuf,
         /// Overrides the chunk size in characters.
         #[arg(long)]

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -3,7 +3,7 @@ use crate::config::{
     ensure_store_layout, load_or_create_config, normalize_chunk_settings, resolve_model_name,
     store_dir,
 };
-use crate::ingest::{ingest_path, PdfParser};
+use crate::ingest::{ingest_path, ingest_url, is_web_url, PdfParser};
 use crate::models::{Embedder, VisionCaptioner};
 use crate::store::{connect_db, ensure_metadata, load_source_fingerprints, replace_source_rows};
 use crate::ui::{self, Panel};
@@ -72,29 +72,50 @@ pub async fn run(
             PdfParserArg::Native => PdfParser::Native,
             PdfParserArg::Liteparse => PdfParser::Liteparse,
         };
-        let ingest_span = tracing::info_span!(
-            "ingest_path",
-            path = %path.display(),
-            chunk_size = size,
-            chunk_overlap = overlap,
-            parser = ?parser,
-            include_hidden,
-            force,
-        );
-        let result = ingest_path(
-            &path,
-            size,
-            overlap,
-            &embedder,
-            Some(&vision),
-            parser,
-            &exclude,
-            include_hidden,
-            &existing_fingerprints,
-            force,
-        )
-        .instrument(ingest_span)
-        .await?;
+        let input = path.to_string_lossy();
+        let result = if is_web_url(&input) {
+            let ingest_span = tracing::info_span!(
+                "ingest_url",
+                url = %input,
+                chunk_size = size,
+                chunk_overlap = overlap,
+                force,
+            );
+            ingest_url(
+                &input,
+                size,
+                overlap,
+                &embedder,
+                &existing_fingerprints,
+                force,
+            )
+            .instrument(ingest_span)
+            .await?
+        } else {
+            let ingest_span = tracing::info_span!(
+                "ingest_path",
+                path = %path.display(),
+                chunk_size = size,
+                chunk_overlap = overlap,
+                parser = ?parser,
+                include_hidden,
+                force,
+            );
+            ingest_path(
+                &path,
+                size,
+                overlap,
+                &embedder,
+                Some(&vision),
+                parser,
+                &exclude,
+                include_hidden,
+                &existing_fingerprints,
+                force,
+            )
+            .instrument(ingest_span)
+            .await?
+        };
 
         if let Some(dim) = result.embedding_dim {
             ensure_metadata(&store, &embed_model_name, dim, size, overlap)?;

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -130,6 +130,10 @@ fn source_prune_path(source: &IndexedSourceSummary) -> Result<PathBuf> {
 }
 
 fn source_is_missing(source: &IndexedSourceSummary) -> Result<bool> {
+    if source.source_path.starts_with("http://") || source.source_path.starts_with("https://") {
+        return Ok(false);
+    }
+
     let path = source_prune_path(source)?;
     Ok(!path
         .try_exists()

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -7,6 +7,8 @@ use anyhow::{Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use indicatif::{ProgressBar, ProgressStyle};
 use pdf_extract::extract_text_by_pages;
+use reqwest::header::{CONTENT_TYPE, USER_AGENT};
+use reqwest::Url;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -14,7 +16,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 use walkdir::{DirEntry, WalkDir};
 
 /// Aggregated indexing counters for a single ingest run.
@@ -42,6 +44,8 @@ pub struct IngestResult {
 }
 
 const MIN_CONTEXT_RETRY_CHARS: usize = 8;
+const WEB_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+const WEB_USER_AGENT: &str = "ragcli/0.1";
 
 #[derive(Debug, Clone)]
 struct ChunkContent {
@@ -65,6 +69,116 @@ pub enum PdfParser {
 struct IngestOptions {
     excludes: GlobSet,
     include_hidden: bool,
+}
+
+pub fn is_web_url(input: &str) -> bool {
+    Url::parse(input).is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+/// Fetches and indexes one web page into chunk rows.
+pub async fn ingest_url(
+    url: &str,
+    chunk_size: usize,
+    overlap: usize,
+    embedder: &Embedder,
+    existing_fingerprints: &BTreeMap<String, SourceFingerprint>,
+    force: bool,
+) -> Result<IngestResult> {
+    let url = parse_web_url(url)?;
+    let progress = build_progress_bar(1);
+    let mut dim = None;
+    let mut stats = IndexStats {
+        indexed_files: 0,
+        skipped_files: 0,
+        total_chunks: 0,
+        errors: Vec::new(),
+    };
+
+    progress.set_message(format!("Fetching {url}"));
+    let page = match fetch_web_page(url).await {
+        Ok(page) => page,
+        Err(err) => {
+            stats.skipped_files += 1;
+            stats.errors.push(err.to_string());
+            progress.finish_with_message("Indexed 0 web page(s), wrote 0 chunk(s)");
+            return Ok(IngestResult {
+                rows: Vec::new(),
+                source_paths: Vec::new(),
+                embedding_dim: None,
+                stats,
+            });
+        }
+    };
+
+    let source_fingerprint = fingerprint_web_page(&page);
+    if !force
+        && existing_fingerprints
+            .get(&page.url)
+            .is_some_and(|existing| existing == &source_fingerprint)
+    {
+        stats.skipped_files += 1;
+        progress.finish_with_message("Skipped unchanged web page");
+        return Ok(IngestResult {
+            rows: Vec::new(),
+            source_paths: Vec::new(),
+            embedding_dim: None,
+            stats,
+        });
+    }
+
+    let chunks = chunk_web_page(&page, chunk_size, overlap);
+    if chunks.is_empty() {
+        stats.skipped_files += 1;
+        stats
+            .errors
+            .push(format!("{}: no readable text found", page.url));
+        progress.finish_with_message("Indexed 0 web page(s), wrote 0 chunk(s)");
+        return Ok(IngestResult {
+            rows: Vec::new(),
+            source_paths: Vec::new(),
+            embedding_dim: None,
+            stats,
+        });
+    }
+
+    progress.set_message(format!("Embedding {}", page.url));
+    let rows = match embed_chunks(
+        Path::new(&page.url),
+        &source_fingerprint,
+        0,
+        chunks,
+        embedder,
+        &mut dim,
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            stats.skipped_files += 1;
+            stats.errors.push(format!("{}: {}", page.url, err));
+            progress.finish_with_message("Indexed 0 web page(s), wrote 0 chunk(s)");
+            return Ok(IngestResult {
+                rows: Vec::new(),
+                source_paths: Vec::new(),
+                embedding_dim: dim,
+                stats,
+            });
+        }
+    };
+
+    stats.indexed_files += 1;
+    stats.total_chunks += rows.len();
+    progress.finish_with_message(format!(
+        "Indexed {} web page(s), wrote {} chunk(s)",
+        stats.indexed_files, stats.total_chunks
+    ));
+
+    Ok(IngestResult {
+        rows,
+        source_paths: vec![page.url],
+        embedding_dim: dim,
+        stats,
+    })
 }
 
 /// Walks a file or directory, extracts supported content, and returns chunk rows.
@@ -572,9 +686,119 @@ fn load_text_file(path: &Path) -> Result<String> {
 
 fn load_html_file(path: &Path) -> Result<String> {
     let html = load_text_file(path)?;
+    render_html_text(&html)
+}
+
+struct WebPage {
+    url: String,
+    title: Option<String>,
+    content_type: Option<String>,
+    raw_len: u64,
+    text: String,
+}
+
+fn parse_web_url(input: &str) -> Result<Url> {
+    let url = Url::parse(input).with_context(|| format!("parse URL: {input}"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!(
+            "unsupported URL scheme `{}`; expected http or https",
+            url.scheme()
+        );
+    }
+    Ok(url)
+}
+
+async fn fetch_web_page(url: Url) -> Result<WebPage> {
+    let client = reqwest::Client::builder()
+        .timeout(WEB_FETCH_TIMEOUT)
+        .build()
+        .context("build web fetch client")?;
+    let response = client
+        .get(url)
+        .header(USER_AGENT, WEB_USER_AGENT)
+        .send()
+        .await
+        .context("fetch web page")?;
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("fetch web page failed with HTTP {status}");
+    }
+
+    let final_url = response.url().to_string();
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = response.text().await.context("read web page body")?;
+    let title = extract_html_title(&body);
+    let text = if content_type
+        .as_deref()
+        .is_some_and(|value| value.to_ascii_lowercase().starts_with("text/plain"))
+    {
+        body.trim().to_string()
+    } else {
+        render_html_text(&body)?
+    };
+    let text = match (title.as_deref(), text.trim()) {
+        (Some(title), "") => title.to_string(),
+        (Some(title), text) if !text.contains(title) => format!("{title}\n\n{text}"),
+        (_, text) => text.to_string(),
+    };
+
+    Ok(WebPage {
+        url: final_url,
+        title,
+        content_type,
+        raw_len: body.len() as u64,
+        text,
+    })
+}
+
+fn render_html_text(html: &str) -> Result<String> {
     let rendered =
         html2text::from_read(html.as_bytes(), usize::MAX).context("render html as text")?;
     Ok(rendered.trim().to_string())
+}
+
+fn extract_html_title(html: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let start = lower.find("<title")?;
+    let after_start = &html[start..];
+    let title_body_start = after_start.find('>')? + start + 1;
+    let end = lower[title_body_start..].find("</title>")? + title_body_start;
+    let title = html[title_body_start..end]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!title.is_empty()).then_some(title)
+}
+
+fn fingerprint_web_page(page: &WebPage) -> SourceFingerprint {
+    let mut hasher = Sha256::new();
+    hasher.update(page.url.as_bytes());
+    hasher.update(page.text.as_bytes());
+    SourceFingerprint {
+        fingerprint: to_hex(&hasher.finalize()),
+        size_bytes: page.raw_len,
+        modified_unix_ms: 0,
+    }
+}
+
+fn chunk_web_page(page: &WebPage, chunk_size: usize, overlap: usize) -> Vec<ChunkContent> {
+    let mut chunks = chunk_document_text(&page.text, "html", None, chunk_size, overlap);
+    for chunk in &mut chunks {
+        if let Some(obj) = chunk.metadata.as_object_mut() {
+            obj.insert("url".to_string(), json!(page.url));
+            if let Some(title) = &page.title {
+                obj.insert("title".to_string(), json!(title));
+            }
+            if let Some(content_type) = &page.content_type {
+                obj.insert("content_type".to_string(), json!(content_type));
+            }
+        }
+    }
+    chunks
 }
 
 fn load_delimited_file(path: &Path, delimiter: u8) -> Result<String> {
@@ -1118,17 +1342,27 @@ mod tests {
     use std::thread;
 
     fn one_shot_json_server(status_line: &str, body: &'static str) -> String {
+        one_shot_http_server(status_line, "application/json", body)
+    }
+
+    fn one_shot_html_server(body: &'static str) -> String {
+        one_shot_http_server("200 OK", "text/html; charset=utf-8", body)
+    }
+
+    fn one_shot_http_server(status_line: &str, content_type: &str, body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
         let addr = listener.local_addr().unwrap();
         let status_line = status_line.to_string();
+        let content_type = content_type.to_string();
 
         thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept request");
             let mut buf = [0_u8; 4096];
             let _ = stream.read(&mut buf);
             let response = format!(
-                "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 status_line,
+                content_type,
                 body.len(),
                 body
             );
@@ -1214,6 +1448,14 @@ mod tests {
         haystack
             .windows(needle.len())
             .position(|window| window == needle)
+    }
+
+    #[test]
+    fn test_is_web_url_detects_http_and_https_only() {
+        assert!(is_web_url("https://example.com/docs"));
+        assert!(is_web_url("http://example.com"));
+        assert!(!is_web_url("file:///tmp/index.html"));
+        assert!(!is_web_url("notes/index.html"));
     }
 
     #[test]
@@ -1528,6 +1770,30 @@ mod tests {
         assert_eq!(result.stats.indexed_files, 0);
         assert_eq!(result.stats.skipped_files, 1);
         assert!(result.stats.errors[0].contains("broken.pdf"));
+    }
+
+    #[tokio::test]
+    async fn test_ingest_url_indexes_single_html_page() {
+        let page_url = one_shot_html_server(
+            "<html><head><title>Guide</title></head><body><h1>Guide</h1><p>Hello web.</p></body></html>",
+        );
+        let base_url = one_shot_json_server("200 OK", r#"{"embeddings":[[0.1,0.2]]}"#);
+        let embedder = Embedder::new(base_url, "embed".to_string());
+
+        let result = ingest_url(&page_url, 100, 0, &embedder, &BTreeMap::new(), false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.stats.indexed_files, 1);
+        assert_eq!(result.stats.skipped_files, 0);
+        assert_eq!(result.rows.len(), 1);
+        assert!(result.source_paths[0].starts_with(&page_url));
+        assert!(result.rows[0].source_path.starts_with(&page_url));
+        assert_eq!(result.rows[0].format, "html");
+        assert!(result.rows[0].chunk_text.contains("Guide"));
+        assert!(result.rows[0].chunk_text.contains("Hello web."));
+        assert!(result.rows[0].metadata.contains("\"title\":\"Guide\""));
+        assert!(result.rows[0].metadata.contains("\"url\":"));
     }
 
     #[tokio::test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,6 +9,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use pdf_extract::extract_text_by_pages;
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use reqwest::Url;
+use scraper::{Html, Selector};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -814,74 +815,18 @@ fn render_html_text(html: &str) -> Result<String> {
 }
 
 fn extract_html_title(html: &str) -> Option<String> {
-    let without_comments = strip_html_comments(html);
-    let lower = without_comments.to_ascii_lowercase();
-    let start = lower.find("<title")?;
-    let after_start = &without_comments[start..];
-    let title_body_start = after_start.find('>')? + start + 1;
-    let end = lower[title_body_start..].find("</title>")? + title_body_start;
-    let title = without_comments[title_body_start..end]
+    let document = Html::parse_document(html);
+    let selector = Selector::parse("title").expect("valid title selector");
+    let title = document
+        .select(&selector)
+        .next()?
+        .text()
+        .collect::<Vec<_>>()
+        .join(" ")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ");
-    let title = decode_html_entities(&title);
     (!title.is_empty()).then_some(title)
-}
-
-fn strip_html_comments(html: &str) -> String {
-    let mut out = String::with_capacity(html.len());
-    let mut remaining = html;
-    while let Some(start) = remaining.find("<!--") {
-        out.push_str(&remaining[..start]);
-        let comment = &remaining[start + 4..];
-        let Some(end) = comment.find("-->") else {
-            return out;
-        };
-        remaining = &comment[end + 3..];
-    }
-    out.push_str(remaining);
-    out
-}
-
-fn decode_html_entities(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut remaining = text;
-    while let Some(start) = remaining.find('&') {
-        out.push_str(&remaining[..start]);
-        let entity_candidate = &remaining[start + 1..];
-        let Some(end) = entity_candidate.find(';') else {
-            out.push_str(&remaining[start..]);
-            return out;
-        };
-        let entity = &entity_candidate[..end];
-        if let Some(decoded) = decode_html_entity(entity) {
-            out.push(decoded);
-        } else {
-            out.push('&');
-            out.push_str(entity);
-            out.push(';');
-        }
-        remaining = &entity_candidate[end + 1..];
-    }
-    out.push_str(remaining);
-    out
-}
-
-fn decode_html_entity(entity: &str) -> Option<char> {
-    match entity {
-        "amp" => Some('&'),
-        "lt" => Some('<'),
-        "gt" => Some('>'),
-        "quot" => Some('"'),
-        "apos" => Some('\''),
-        _ if entity.starts_with("#x") || entity.starts_with("#X") => {
-            u32::from_str_radix(&entity[2..], 16)
-                .ok()
-                .and_then(char::from_u32)
-        }
-        _ if entity.starts_with('#') => entity[1..].parse::<u32>().ok().and_then(char::from_u32),
-        _ => None,
-    }
 }
 
 fn fingerprint_web_page(page: &WebPage) -> SourceFingerprint {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -45,6 +45,7 @@ pub struct IngestResult {
 
 const MIN_CONTEXT_RETRY_CHARS: usize = 8;
 const WEB_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+const WEB_MAX_BODY_BYTES: u64 = 5 * 1024 * 1024;
 const WEB_USER_AGENT: &str = "ragcli/0.1";
 
 #[derive(Debug, Clone)]
@@ -730,7 +731,13 @@ async fn fetch_web_page(url: Url) -> Result<WebPage> {
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
-    let body = response.text().await.context("read web page body")?;
+    validate_web_response_headers(
+        &final_url,
+        content_type.as_deref(),
+        response.content_length(),
+    )?;
+
+    let body = read_limited_response_body(response).await?;
     let title = extract_html_title(&body);
     let text = if content_type
         .as_deref()
@@ -755,6 +762,51 @@ async fn fetch_web_page(url: Url) -> Result<WebPage> {
     })
 }
 
+fn validate_web_response_headers(
+    url: &str,
+    content_type: Option<&str>,
+    content_length: Option<u64>,
+) -> Result<()> {
+    if let Some(content_type) = content_type {
+        let content_type = content_type.to_ascii_lowercase();
+        let media_type = content_type.split(';').next().unwrap_or("").trim();
+        if !matches!(
+            media_type,
+            "text/html" | "text/plain" | "application/xhtml+xml"
+        ) {
+            anyhow::bail!("unsupported web content type for {url}: {media_type}");
+        }
+    }
+
+    if let Some(content_length) = content_length {
+        if content_length > WEB_MAX_BODY_BYTES {
+            anyhow::bail!(
+                "web page too large for {url}: {} bytes exceeds {} byte limit",
+                content_length,
+                WEB_MAX_BODY_BYTES
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn read_limited_response_body(mut response: reqwest::Response) -> Result<String> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.context("read web page body")? {
+        if body.len() as u64 + chunk.len() as u64 > WEB_MAX_BODY_BYTES {
+            anyhow::bail!(
+                "web page body exceeds {} byte limit while reading {}",
+                WEB_MAX_BODY_BYTES,
+                response.url()
+            );
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
 fn render_html_text(html: &str) -> Result<String> {
     let rendered =
         html2text::from_read(html.as_bytes(), usize::MAX).context("render html as text")?;
@@ -762,16 +814,74 @@ fn render_html_text(html: &str) -> Result<String> {
 }
 
 fn extract_html_title(html: &str) -> Option<String> {
-    let lower = html.to_ascii_lowercase();
+    let without_comments = strip_html_comments(html);
+    let lower = without_comments.to_ascii_lowercase();
     let start = lower.find("<title")?;
-    let after_start = &html[start..];
+    let after_start = &without_comments[start..];
     let title_body_start = after_start.find('>')? + start + 1;
     let end = lower[title_body_start..].find("</title>")? + title_body_start;
-    let title = html[title_body_start..end]
+    let title = without_comments[title_body_start..end]
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ");
+    let title = decode_html_entities(&title);
     (!title.is_empty()).then_some(title)
+}
+
+fn strip_html_comments(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut remaining = html;
+    while let Some(start) = remaining.find("<!--") {
+        out.push_str(&remaining[..start]);
+        let comment = &remaining[start + 4..];
+        let Some(end) = comment.find("-->") else {
+            return out;
+        };
+        remaining = &comment[end + 3..];
+    }
+    out.push_str(remaining);
+    out
+}
+
+fn decode_html_entities(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(start) = remaining.find('&') {
+        out.push_str(&remaining[..start]);
+        let entity_candidate = &remaining[start + 1..];
+        let Some(end) = entity_candidate.find(';') else {
+            out.push_str(&remaining[start..]);
+            return out;
+        };
+        let entity = &entity_candidate[..end];
+        if let Some(decoded) = decode_html_entity(entity) {
+            out.push(decoded);
+        } else {
+            out.push('&');
+            out.push_str(entity);
+            out.push(';');
+        }
+        remaining = &entity_candidate[end + 1..];
+    }
+    out.push_str(remaining);
+    out
+}
+
+fn decode_html_entity(entity: &str) -> Option<char> {
+    match entity {
+        "amp" => Some('&'),
+        "lt" => Some('<'),
+        "gt" => Some('>'),
+        "quot" => Some('"'),
+        "apos" => Some('\''),
+        _ if entity.starts_with("#x") || entity.starts_with("#X") => {
+            u32::from_str_radix(&entity[2..], 16)
+                .ok()
+                .and_then(char::from_u32)
+        }
+        _ if entity.starts_with('#') => entity[1..].parse::<u32>().ok().and_then(char::from_u32),
+        _ => None,
+    }
 }
 
 fn fingerprint_web_page(page: &WebPage) -> SourceFingerprint {
@@ -1459,6 +1569,40 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_web_response_headers_rejects_unsupported_or_large_pages() {
+        assert!(validate_web_response_headers(
+            "https://example.com/file.zip",
+            Some("application/octet-stream"),
+            Some(10),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("unsupported web content type"));
+        assert!(validate_web_response_headers(
+            "https://example.com/huge.html",
+            Some("text/html; charset=utf-8"),
+            Some(WEB_MAX_BODY_BYTES + 1),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("too large"));
+        assert!(validate_web_response_headers(
+            "https://example.com/page.html",
+            Some("text/html; charset=utf-8"),
+            Some(WEB_MAX_BODY_BYTES),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_extract_html_title_decodes_entities_and_ignores_comments() {
+        let title = extract_html_title(
+            "<!-- <title>Wrong</title> --><html><head><TITLE>Guide &amp; Docs &#40;v1&#41;</TITLE></head></html>",
+        );
+        assert_eq!(title.as_deref(), Some("Guide & Docs (v1)"));
+    }
+
+    #[test]
     fn test_chunk_text_basic() {
         let chunks = chunk_text("abcdefghij", 5, 2);
         assert_eq!(chunks, vec!["abcde", "defgh", "ghij"]);
@@ -1775,7 +1919,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingest_url_indexes_single_html_page() {
         let page_url = one_shot_html_server(
-            "<html><head><title>Guide</title></head><body><h1>Guide</h1><p>Hello web.</p></body></html>",
+            "<html><head><title>Guide &amp; Docs</title></head><body><h1>Guide &amp; Docs</h1><p>Hello web.</p></body></html>",
         );
         let base_url = one_shot_json_server("200 OK", r#"{"embeddings":[[0.1,0.2]]}"#);
         let embedder = Embedder::new(base_url, "embed".to_string());
@@ -1790,10 +1934,11 @@ mod tests {
         assert!(result.source_paths[0].starts_with(&page_url));
         assert!(result.rows[0].source_path.starts_with(&page_url));
         assert_eq!(result.rows[0].format, "html");
-        assert!(result.rows[0].chunk_text.contains("Guide"));
+        assert!(result.rows[0].chunk_text.contains("Guide & Docs"));
         assert!(result.rows[0].chunk_text.contains("Hello web."));
-        assert!(result.rows[0].metadata.contains("\"title\":\"Guide\""));
-        assert!(result.rows[0].metadata.contains("\"url\":"));
+        let metadata: Value = serde_json::from_str(&result.rows[0].metadata).unwrap();
+        assert_eq!(metadata["title"], "Guide & Docs");
+        assert!(metadata["url"].as_str().is_some());
     }
 
     #[tokio::test]

--- a/src/source_kind.rs
+++ b/src/source_kind.rs
@@ -48,6 +48,11 @@ impl SourceKind {
     ///
     /// Extension matching is case-insensitive. Unknown extensions yield `Unsupported`.
     pub fn from_path(path: &Path) -> Self {
+        let source = path.to_string_lossy();
+        if source.starts_with("http://") || source.starts_with("https://") {
+            return Self::Html;
+        }
+
         let ext = path
             .extension()
             .and_then(|ext| ext.to_str())
@@ -131,6 +136,10 @@ mod tests {
         );
         assert_eq!(
             SourceKind::from_path(Path::new("page.html")),
+            SourceKind::Html
+        );
+        assert_eq!(
+            SourceKind::from_path(Path::new("https://example.com/docs")),
             SourceKind::Html
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- detect HTTP(S) inputs in the index command
- fetch one web page and render HTML to text for chunking and embedding
- store URL metadata/fingerprints so unchanged pages can be skipped
- classify URL sources as HTML and keep prune from treating them as stale files

## Tests
- cargo test --all-targets