### PR TITLE
feat(models): add retry with exponential backoff for Ollama API calls

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1397,7 +1397,11 @@ mod tests {
     use std::thread;
 
     fn one_shot_json_server(status_line: &str, body: &'static str) -> String {
-        one_shot_http_server(status_line, "application/json", body)
+        repeated_json_server(status_line, body, 1)
+    }
+
+    fn repeated_json_server(status_line: &str, body: &'static str, max_requests: usize) -> String {
+        repeated_http_server(status_line, "application/json", body, max_requests)
     }
 
     fn one_shot_html_server(body: &'static str) -> String {
@@ -1405,25 +1409,36 @@ mod tests {
     }
 
     fn one_shot_http_server(status_line: &str, content_type: &str, body: &'static str) -> String {
+        repeated_http_server(status_line, content_type, body, 1)
+    }
+
+    fn repeated_http_server(
+        status_line: &str,
+        content_type: &str,
+        body: &'static str,
+        max_requests: usize,
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
         let addr = listener.local_addr().unwrap();
         let status_line = status_line.to_string();
         let content_type = content_type.to_string();
 
         thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let mut buf = [0_u8; 4096];
-            let _ = stream.read(&mut buf);
-            let response = format!(
-                "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                status_line,
-                content_type,
-                body.len(),
-                body
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("write response");
+            for stream in listener.incoming().take(max_requests) {
+                let mut stream = stream.expect("accept request");
+                let mut buf = [0_u8; 4096];
+                let _ = stream.read(&mut buf);
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status_line,
+                    content_type,
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
         });
 
         format!("http://{}", addr)
@@ -2037,7 +2052,7 @@ mod tests {
         let text = dir.path().join("note.txt");
         fs::write(&text, "hello world").unwrap();
 
-        let base_url = one_shot_json_server("500 Internal Server Error", r#"{"error":"boom"}"#);
+        let base_url = repeated_json_server("500 Internal Server Error", r#"{"error":"boom"}"#, 3);
         let embedder = Embedder::new(base_url, "embed".to_string());
         let result = ingest_path(
             &text,

--- a/src/models.rs
+++ b/src/models.rs
@@ -364,23 +364,18 @@ impl HttpClient {
     }
 
     async fn get_text(&self, url: String) -> Result<(reqwest::StatusCode, String)> {
-        let mut last_err = None;
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..MAX_RETRIES {
             let result = self.get_text_once(&url).await;
-            if should_retry(&result, attempt) {
-                last_err = Some(clone_result_error(&result));
+            if should_retry(&result) {
                 sleep(backoff_duration(attempt)).await;
                 continue;
             }
             return result;
         }
-        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("GET request retries exhausted")))
+        self.get_text_once(&url).await
     }
 
-    async fn get_text_once(
-        &self,
-        url: &str,
-    ) -> Result<(reqwest::StatusCode, String)> {
+    async fn get_text_once(&self, url: &str) -> Result<(reqwest::StatusCode, String)> {
         let response = match self {
             Self::Reqwest(client) => client
                 .get(url)
@@ -398,30 +393,28 @@ impl HttpClient {
         url: String,
         body: serde_json::Value,
     ) -> Result<(reqwest::StatusCode, String)> {
-        let mut last_err = None;
-        for attempt in 0..=MAX_RETRIES {
-            let result = self.post_json_once(&url, &body).await;
-            if should_retry(&result, attempt) {
-                last_err = Some(clone_result_error(&result));
+        let json_body = body.to_string();
+        for attempt in 0..MAX_RETRIES {
+            let result = self.post_json_once(&url, &json_body).await;
+            if should_retry(&result) {
                 sleep(backoff_duration(attempt)).await;
                 continue;
             }
             return result;
         }
-        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("POST request retries exhausted")))
+        self.post_json_once(&url, &json_body).await
     }
 
     async fn post_json_once(
         &self,
         url: &str,
-        body: &serde_json::Value,
+        json_body: &str,
     ) -> Result<(reqwest::StatusCode, String)> {
-        let json_body = body.to_string();
         let response = match self {
             Self::Reqwest(client) => client
                 .post(url)
                 .header(CONTENT_TYPE, "application/json")
-                .body(json_body)
+                .body(json_body.to_string())
                 .send()
                 .await
                 .context("send HTTP POST request")?,
@@ -432,20 +425,10 @@ impl HttpClient {
     }
 }
 
-fn should_retry(result: &Result<(reqwest::StatusCode, String)>, attempt: u32) -> bool {
-    if attempt >= MAX_RETRIES {
-        return false;
-    }
+fn should_retry(result: &Result<(reqwest::StatusCode, String)>) -> bool {
     match result {
         Err(err) => is_connection_error(err),
         Ok((status, _)) => status.is_server_error(),
-    }
-}
-
-fn clone_result_error(result: &Result<(reqwest::StatusCode, String)>) -> anyhow::Error {
-    match result {
-        Err(err) => anyhow::anyhow!("{err:#}"),
-        Ok((status, body)) => anyhow::anyhow!("HTTP {status}: {body}"),
     }
 }
 
@@ -455,13 +438,24 @@ fn backoff_duration(attempt: u32) -> Duration {
 
 fn is_connection_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
+        if let Some(reqwest_err) = cause.downcast_ref::<reqwest::Error>() {
+            return reqwest_err.is_connect() || reqwest_err.is_timeout();
+        }
+        if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
+            return matches!(
+                io_err.kind(),
+                std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::TimedOut
+            );
+        }
+
         let msg = cause.to_string().to_ascii_lowercase();
         msg.contains("connection refused")
             || msg.contains("connection reset")
             || msg.contains("broken pipe")
             || msg.contains("connect error")
-            || msg.contains("error sending request")
-            || msg.contains("send http")
     })
 }
 
@@ -770,24 +764,25 @@ mod tests {
 
     #[test]
     fn test_should_retry_returns_true_for_server_errors() {
-        let result: Result<(reqwest::StatusCode, String)> =
-            Ok((reqwest::StatusCode::INTERNAL_SERVER_ERROR, "error".to_string()));
-        assert!(should_retry(&result, 0));
-        assert!(!should_retry(&result, MAX_RETRIES));
+        let result: Result<(reqwest::StatusCode, String)> = Ok((
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "error".to_string(),
+        ));
+        assert!(should_retry(&result));
     }
 
     #[test]
     fn test_should_retry_returns_false_for_client_errors() {
         let result: Result<(reqwest::StatusCode, String)> =
             Ok((reqwest::StatusCode::NOT_FOUND, "error".to_string()));
-        assert!(!should_retry(&result, 0));
+        assert!(!should_retry(&result));
     }
 
     #[test]
     fn test_should_retry_returns_true_for_connection_errors() {
         let result: Result<(reqwest::StatusCode, String)> =
             Err(anyhow::anyhow!("error sending request: connection refused"));
-        assert!(should_retry(&result, 0));
+        assert!(should_retry(&result));
     }
 
     #[test]
@@ -802,7 +797,10 @@ mod tests {
         assert!(is_connection_error(&anyhow::anyhow!("connection refused")));
         assert!(is_connection_error(&anyhow::anyhow!("connection reset by peer")));
         assert!(is_connection_error(&anyhow::anyhow!("broken pipe")));
-        assert!(is_connection_error(&anyhow::anyhow!("Error sending request")));
+        assert!(is_connection_error(&anyhow::anyhow!(std::io::Error::from(
+            std::io::ErrorKind::ConnectionRefused
+        ))));
+        assert!(!is_connection_error(&anyhow::anyhow!("error sending request")));
         assert!(!is_connection_error(&anyhow::anyhow!("model not found")));
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::path::Path;
 use std::time::{Duration, Instant};
+use tokio::time::sleep;
 use tracing::{field, Instrument};
 
 /// Embedding client backed by Ollama's `/api/embed` endpoint.
@@ -349,6 +350,9 @@ impl VisionCaptioner {
     }
 }
 
+const MAX_RETRIES: u32 = 2;
+const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+
 impl HttpClient {
     fn with_timeout(timeout: Duration) -> Self {
         Self::Reqwest(
@@ -360,6 +364,23 @@ impl HttpClient {
     }
 
     async fn get_text(&self, url: String) -> Result<(reqwest::StatusCode, String)> {
+        let mut last_err = None;
+        for attempt in 0..=MAX_RETRIES {
+            let result = self.get_text_once(&url).await;
+            if should_retry(&result, attempt) {
+                last_err = Some(clone_result_error(&result));
+                sleep(backoff_duration(attempt)).await;
+                continue;
+            }
+            return result;
+        }
+        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("GET request retries exhausted")))
+    }
+
+    async fn get_text_once(
+        &self,
+        url: &str,
+    ) -> Result<(reqwest::StatusCode, String)> {
         let response = match self {
             Self::Reqwest(client) => client
                 .get(url)
@@ -367,7 +388,6 @@ impl HttpClient {
                 .await
                 .context("send HTTP GET request")?,
         };
-
         let status = response.status();
         let body = response.text().await.context("read HTTP response body")?;
         Ok((status, body))
@@ -378,21 +398,71 @@ impl HttpClient {
         url: String,
         body: serde_json::Value,
     ) -> Result<(reqwest::StatusCode, String)> {
-        let body = body.to_string();
+        let mut last_err = None;
+        for attempt in 0..=MAX_RETRIES {
+            let result = self.post_json_once(&url, &body).await;
+            if should_retry(&result, attempt) {
+                last_err = Some(clone_result_error(&result));
+                sleep(backoff_duration(attempt)).await;
+                continue;
+            }
+            return result;
+        }
+        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("POST request retries exhausted")))
+    }
+
+    async fn post_json_once(
+        &self,
+        url: &str,
+        body: &serde_json::Value,
+    ) -> Result<(reqwest::StatusCode, String)> {
+        let json_body = body.to_string();
         let response = match self {
             Self::Reqwest(client) => client
                 .post(url)
                 .header(CONTENT_TYPE, "application/json")
-                .body(body.clone())
+                .body(json_body)
                 .send()
                 .await
                 .context("send HTTP POST request")?,
         };
-
         let status = response.status();
-        let body = response.text().await.context("read HTTP response body")?;
-        Ok((status, body))
+        let response_body = response.text().await.context("read HTTP response body")?;
+        Ok((status, response_body))
     }
+}
+
+fn should_retry(result: &Result<(reqwest::StatusCode, String)>, attempt: u32) -> bool {
+    if attempt >= MAX_RETRIES {
+        return false;
+    }
+    match result {
+        Err(err) => is_connection_error(err),
+        Ok((status, _)) => status.is_server_error(),
+    }
+}
+
+fn clone_result_error(result: &Result<(reqwest::StatusCode, String)>) -> anyhow::Error {
+    match result {
+        Err(err) => anyhow::anyhow!("{err:#}"),
+        Ok((status, body)) => anyhow::anyhow!("HTTP {status}: {body}"),
+    }
+}
+
+fn backoff_duration(attempt: u32) -> Duration {
+    INITIAL_BACKOFF * 2u32.saturating_pow(attempt)
+}
+
+fn is_connection_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let msg = cause.to_string().to_ascii_lowercase();
+        msg.contains("connection refused")
+            || msg.contains("connection reset")
+            || msg.contains("broken pipe")
+            || msg.contains("connect error")
+            || msg.contains("error sending request")
+            || msg.contains("send http")
+    })
 }
 
 /// Converts a raw Ollama HTTP error into a user-friendly `anyhow::Error`.
@@ -696,5 +766,43 @@ mod tests {
             .expect("generate Ollama chat response");
 
         assert_eq!(answer, "A cat sits on a windowsill. [1]");
+    }
+
+    #[test]
+    fn test_should_retry_returns_true_for_server_errors() {
+        let result: Result<(reqwest::StatusCode, String)> =
+            Ok((reqwest::StatusCode::INTERNAL_SERVER_ERROR, "error".to_string()));
+        assert!(should_retry(&result, 0));
+        assert!(!should_retry(&result, MAX_RETRIES));
+    }
+
+    #[test]
+    fn test_should_retry_returns_false_for_client_errors() {
+        let result: Result<(reqwest::StatusCode, String)> =
+            Ok((reqwest::StatusCode::NOT_FOUND, "error".to_string()));
+        assert!(!should_retry(&result, 0));
+    }
+
+    #[test]
+    fn test_should_retry_returns_true_for_connection_errors() {
+        let result: Result<(reqwest::StatusCode, String)> =
+            Err(anyhow::anyhow!("error sending request: connection refused"));
+        assert!(should_retry(&result, 0));
+    }
+
+    #[test]
+    fn test_backoff_duration_doubles_each_attempt() {
+        assert_eq!(backoff_duration(0), Duration::from_millis(500));
+        assert_eq!(backoff_duration(1), Duration::from_millis(1000));
+        assert_eq!(backoff_duration(2), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn test_is_connection_error_detects_known_patterns() {
+        assert!(is_connection_error(&anyhow::anyhow!("connection refused")));
+        assert!(is_connection_error(&anyhow::anyhow!("connection reset by peer")));
+        assert!(is_connection_error(&anyhow::anyhow!("broken pipe")));
+        assert!(is_connection_error(&anyhow::anyhow!("Error sending request")));
+        assert!(!is_connection_error(&anyhow::anyhow!("model not found")));
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -367,7 +367,9 @@ impl HttpClient {
         for attempt in 0..MAX_RETRIES {
             let result = self.get_text_once(&url).await;
             if should_retry(&result) {
-                sleep(backoff_duration(attempt)).await;
+                let delay = backoff_duration(attempt);
+                log_retry("GET", &url, &result, attempt, delay);
+                sleep(delay).await;
                 continue;
             }
             return result;
@@ -397,7 +399,9 @@ impl HttpClient {
         for attempt in 0..MAX_RETRIES {
             let result = self.post_json_once(&url, &json_body).await;
             if should_retry(&result) {
-                sleep(backoff_duration(attempt)).await;
+                let delay = backoff_duration(attempt);
+                log_retry("POST", &url, &result, attempt, delay);
+                sleep(delay).await;
                 continue;
             }
             return result;
@@ -434,6 +438,40 @@ fn should_retry(result: &Result<(reqwest::StatusCode, String)>) -> bool {
 
 fn backoff_duration(attempt: u32) -> Duration {
     INITIAL_BACKOFF * 2u32.saturating_pow(attempt)
+}
+
+fn log_retry(
+    method: &str,
+    url: &str,
+    result: &Result<(reqwest::StatusCode, String)>,
+    attempt: u32,
+    delay: Duration,
+) {
+    let retry = attempt + 1;
+    let total_attempts = MAX_RETRIES + 1;
+    let delay_ms = delay.as_millis() as u64;
+    match result {
+        Err(err) => tracing::warn!(
+            method = %method,
+            url = %url,
+            retry,
+            max_retries = MAX_RETRIES,
+            total_attempts,
+            delay_ms,
+            error = %err,
+            "Ollama request failed; retrying"
+        ),
+        Ok((status, _)) => tracing::warn!(
+            method = %method,
+            url = %url,
+            retry,
+            max_retries = MAX_RETRIES,
+            total_attempts,
+            delay_ms,
+            status = %status,
+            "Ollama request returned retryable status; retrying"
+        ),
+    }
 }
 
 fn is_connection_error(err: &anyhow::Error) -> bool {


### PR DESCRIPTION
## Summary

- Add automatic retry (up to 2 retries / 3 total attempts) with exponential backoff for transient Ollama API failures
- Retries on connection errors (connection refused, broken pipe, etc.) and 5xx server errors
- Client errors (4xx) are not retried — they bubble up immediately with the existing error handling
- Backoff starts at 500ms and doubles per retry (500ms → 1s before the final attempt)

## Test plan

- [x] 5 new unit tests covering `should_retry`, `is_connection_error`, and `backoff_duration`
- [x] All 18 existing models tests pass (embed, chat, vision, tags)
- [x] `cargo check` passes

