### PR TITLE
feat(query): add --json flag for machine-readable query output

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,7 +16,7 @@ use crate::jsonutil::parse_json;
 use crate::models::Generator;
 use crate::retrieval::RetrievalCandidate;
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const SUMMARY_TEXT_MAX_CHARS: usize = 600;
 
@@ -37,7 +37,8 @@ pub struct AgentQueryConfig {
 }
 
 /// Class of a user question, influencing which retrieval strategy is selected.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum QuestionType {
     /// A single factual lookup — "What is X?"
     Lookup,
@@ -52,7 +53,8 @@ pub enum QuestionType {
 }
 
 /// Retrieval strategy selected by the query planner.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum RetrievalStrategy {
     /// Use the original question directly against the store.
     Direct,
@@ -78,7 +80,8 @@ pub struct QueryPlan {
 }
 
 /// Result of an LLM evidence assessment.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum EvidenceVerdict {
     /// Retrieved candidates fully cover what is needed to answer.
     Sufficient,

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 format,
                 gen_model,
                 max_tokens,
+                json,
             } => {
                 let span = tracing::info_span!(
                     "query_command",
@@ -94,6 +95,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                         format,
                         gen_model,
                         max_tokens,
+                        json,
                     },
                 )
                 .instrument(span)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,6 +118,9 @@ pub enum Command {
         /// Maximum number of tokens to generate.
         #[arg(long, default_value_t = 256)]
         max_tokens: usize,
+        /// Prints machine-readable JSON instead of the default text report.
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     /// Shows or updates configuration values.
     Config {
@@ -319,6 +322,12 @@ mod tests {
                 command: ConfigCommand::Show { json },
             } => assert!(json),
             command => panic!("expected config show command, got {command:?}"),
+        }
+
+        let query = Cli::try_parse_from(["ragcli", "query", "test", "--json"]).unwrap();
+        match query.command {
+            Command::Query { json, .. } => assert!(json),
+            command => panic!("expected query command, got {command:?}"),
         }
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -21,6 +21,7 @@ pub struct QueryCommand {
     pub format: Option<String>,
     pub gen_model: Option<String>,
     pub max_tokens: usize,
+    pub json: bool,
 }
 
 pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -65,6 +65,7 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
                     &command.question,
                     mode_label(command.mode),
                     &result,
+                    None,
                 );
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
@@ -76,16 +77,13 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
         }
 
         if command.json {
-            let answer = match &result.answer {
-                Some(answer) => answer.clone(),
-                None => generate_answer(&runtime, &command, &result).await?,
-            };
-            let report =
-                QueryJsonReport::from_result(&command.question, mode_label(command.mode), &result);
-            let report = QueryJsonReport {
-                answer: Some(store::strip_thinking(&answer)),
-                ..report
-            };
+            let answer = stripped_answer(&runtime, &command, &result).await?;
+            let report = QueryJsonReport::from_result(
+                &command.question,
+                mode_label(command.mode),
+                &result,
+                Some(answer),
+            );
             println!("{}", serde_json::to_string_pretty(&report)?);
             return Ok(());
         }
@@ -96,13 +94,10 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
         print_citations(&command, &result);
         print_contexts(&command, &result);
 
-        let answer = match &result.answer {
-            Some(answer) => answer.clone(),
-            None => generate_answer(&runtime, &command, &result).await?,
-        };
+        let answer = stripped_answer(&runtime, &command, &result).await?;
         println!();
         let mut panel = Panel::new("Answer");
-        panel.prose("", store::strip_thinking(&answer).trim(), 0);
+        panel.prose("", answer.trim(), 0);
         panel.render();
         Ok(())
     }
@@ -375,12 +370,16 @@ async fn build_rewrite_set(
     .await
 }
 
-async fn generate_answer(
+async fn stripped_answer(
     runtime: &QueryRuntime,
     command: &QueryCommand,
     result: &QueryResult,
 ) -> Result<String> {
-    generate_answer_from_hits(runtime, command, &result.hits).await
+    let answer = match &result.answer {
+        Some(answer) => answer.clone(),
+        None => generate_answer_from_hits(runtime, command, &result.hits).await?,
+    };
+    Ok(store::strip_thinking(&answer))
 }
 
 async fn generate_answer_from_hits(

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -59,28 +59,34 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
         span_inner.record("hit_count", result.hits.len());
         span_inner.record("iteration_count", result.iterations.len());
 
+        if result.hits.is_empty() {
+            if command.json {
+                let report = QueryJsonReport::from_result(
+                    &command.question,
+                    mode_label(command.mode),
+                    &result,
+                );
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                let mut panel = Panel::new("Query Result");
+                panel.kv("status", "No relevant context found in the local store.", 8);
+                panel.render();
+            }
+            return Ok(());
+        }
+
         if command.json {
             let answer = match &result.answer {
                 Some(answer) => answer.clone(),
                 None => generate_answer(&runtime, &command, &result).await?,
             };
-            let report = QueryJsonReport::from_result(
-                &command.question,
-                mode_label(command.mode),
-                &result,
-            );
+            let report =
+                QueryJsonReport::from_result(&command.question, mode_label(command.mode), &result);
             let report = QueryJsonReport {
                 answer: Some(store::strip_thinking(&answer)),
                 ..report
             };
             println!("{}", serde_json::to_string_pretty(&report)?);
-            return Ok(());
-        }
-
-        if result.hits.is_empty() {
-            let mut panel = Panel::new("Query Result");
-            panel.kv("status", "No relevant context found in the local store.", 8);
-            panel.render();
             return Ok(());
         }
 
@@ -234,6 +240,21 @@ async fn run_agentic_query_command(
         }
 
         let final_hits = prune_candidates(accumulated_hits, command.top_k);
+        if final_hits.is_empty() {
+            trace.push("no evidence retained; skipping answer generation".to_string());
+            return Ok(QueryResult {
+                requested_mode: command.mode,
+                execution_label: "agentic",
+                rewrite_set,
+                plan: Some(plan),
+                iterations,
+                support_check: None,
+                answer: None,
+                hits: final_hits,
+                trace,
+            });
+        }
+
         let answer = generate_answer_from_hits(runtime, command, &final_hits).await?;
         let support_check = match verify_answer_support(
             &generator,

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -22,7 +22,7 @@ use super::render::{
 };
 use super::retrieve::retrieve_candidates;
 use super::runtime::{mode_label, prepare_runtime};
-use super::types::{QueryExecutionPath, QueryResult, QueryRuntime};
+use super::types::{QueryExecutionPath, QueryJsonReport, QueryResult, QueryRuntime};
 
 pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
     let runtime = prepare_runtime(name, &command)?;
@@ -58,6 +58,24 @@ pub async fn run(name: Option<&str>, command: QueryCommand) -> Result<()> {
 
         span_inner.record("hit_count", result.hits.len());
         span_inner.record("iteration_count", result.iterations.len());
+
+        if command.json {
+            let answer = match &result.answer {
+                Some(answer) => answer.clone(),
+                None => generate_answer(&runtime, &command, &result).await?,
+            };
+            let report = QueryJsonReport::from_result(
+                &command.question,
+                mode_label(command.mode),
+                &result,
+            );
+            let report = QueryJsonReport {
+                answer: Some(store::strip_thinking(&answer)),
+                ..report
+            };
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
 
         if result.hits.is_empty() {
             let mut panel = Panel::new("Query Result");
@@ -508,6 +526,7 @@ mod tests {
                     format: None,
                     gen_model: None,
                     max_tokens: 64,
+                    json: false,
                 },
             )
             .await
@@ -573,6 +592,7 @@ mod tests {
                     format: None,
                     gen_model: None,
                     max_tokens: 64,
+                    json: false,
                 },
             )
             .await
@@ -647,6 +667,7 @@ mod tests {
                     format: None,
                     gen_model: None,
                     max_tokens: 64,
+                    json: false,
                 },
             )
             .await
@@ -676,6 +697,7 @@ mod tests {
             format: None,
             gen_model: None,
             max_tokens: 256,
+            json: false,
         };
 
         assert_eq!(retrieval_limit(&command), 20);
@@ -766,6 +788,7 @@ mod tests {
                         format: None,
                         gen_model: None,
                         max_tokens: 64,
+                        json: false,
                     },
                 )
                 .await

--- a/src/query/types.rs
+++ b/src/query/types.rs
@@ -79,11 +79,7 @@ pub(crate) struct SupportCheckJson {
 }
 
 impl QueryJsonReport {
-    pub(crate) fn from_result(
-        question: &str,
-        mode: &str,
-        result: &QueryResult,
-    ) -> Self {
+    pub(crate) fn from_result(question: &str, mode: &str, result: &QueryResult) -> Self {
         Self {
             question: question.to_string(),
             answer: result.answer.clone(),

--- a/src/query/types.rs
+++ b/src/query/types.rs
@@ -1,4 +1,6 @@
-use crate::agent::{AgentIteration, QueryPlan, SupportCheck};
+use crate::agent::{
+    AgentIteration, EvidenceVerdict, QueryPlan, QuestionType, RetrievalStrategy, SupportCheck,
+};
 use crate::cli::QueryModeArg;
 use crate::config::Config;
 use crate::retrieval::RetrievalCandidate;
@@ -58,8 +60,8 @@ pub(crate) struct HitJson {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct PlanJson {
-    pub question_type: String,
-    pub strategy: String,
+    pub question_type: QuestionType,
+    pub strategy: RetrievalStrategy,
     pub reasoning: String,
     pub subqueries: Vec<String>,
 }
@@ -67,7 +69,7 @@ pub(crate) struct PlanJson {
 #[derive(Debug, Serialize)]
 pub(crate) struct IterationJson {
     pub iteration: usize,
-    pub verdict: String,
+    pub verdict: EvidenceVerdict,
     pub retrieved: usize,
     pub kept: usize,
 }
@@ -79,10 +81,15 @@ pub(crate) struct SupportCheckJson {
 }
 
 impl QueryJsonReport {
-    pub(crate) fn from_result(question: &str, mode: &str, result: &QueryResult) -> Self {
+    pub(crate) fn from_result(
+        question: &str,
+        mode: &str,
+        result: &QueryResult,
+        answer: Option<String>,
+    ) -> Self {
         Self {
             question: question.to_string(),
-            answer: result.answer.clone(),
+            answer,
             mode: mode.to_string(),
             hits: result
                 .hits
@@ -96,8 +103,8 @@ impl QueryJsonReport {
                 })
                 .collect(),
             plan: result.plan.as_ref().map(|plan| PlanJson {
-                question_type: question_type_str(&plan.question_type),
-                strategy: strategy_str(&plan.strategy),
+                question_type: plan.question_type.clone(),
+                strategy: plan.strategy.clone(),
                 reasoning: plan.reasoning.clone(),
                 subqueries: plan.subqueries.clone(),
             }),
@@ -106,7 +113,7 @@ impl QueryJsonReport {
                 .iter()
                 .map(|iter| IterationJson {
                     iteration: iter.iteration,
-                    verdict: evidence_verdict_str(&iter.sufficiency),
+                    verdict: iter.sufficiency.clone(),
                     retrieved: iter.retrieved_count,
                     kept: iter.kept_count,
                 })
@@ -119,29 +126,37 @@ impl QueryJsonReport {
     }
 }
 
-fn question_type_str(qt: &crate::agent::QuestionType) -> String {
-    match qt {
-        crate::agent::QuestionType::Lookup => "Lookup".to_string(),
-        crate::agent::QuestionType::Compare => "Compare".to_string(),
-        crate::agent::QuestionType::MultiHop => "MultiHop".to_string(),
-        crate::agent::QuestionType::Summary => "Summary".to_string(),
-        crate::agent::QuestionType::Exploratory => "Exploratory".to_string(),
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
 
-fn strategy_str(s: &crate::agent::RetrievalStrategy) -> String {
-    match s {
-        crate::agent::RetrievalStrategy::Direct => "Direct".to_string(),
-        crate::agent::RetrievalStrategy::Rewrite => "Rewrite".to_string(),
-        crate::agent::RetrievalStrategy::Decompose => "Decompose".to_string(),
-        crate::agent::RetrievalStrategy::BroadThenRerank => "BroadThenRerank".to_string(),
-    }
-}
+    #[test]
+    fn test_query_json_report_serializes_enum_values_consistently() {
+        let report = QueryJsonReport {
+            question: "How do config and metadata interact?".to_string(),
+            answer: Some("They interact during query execution.".to_string()),
+            mode: "agentic".to_string(),
+            hits: Vec::new(),
+            plan: Some(PlanJson {
+                question_type: QuestionType::MultiHop,
+                strategy: RetrievalStrategy::BroadThenRerank,
+                reasoning: "needs multiple facts".to_string(),
+                subqueries: vec!["config".to_string(), "metadata".to_string()],
+            }),
+            iterations: vec![IterationJson {
+                iteration: 1,
+                verdict: EvidenceVerdict::Sufficient,
+                retrieved: 3,
+                kept: 2,
+            }],
+            support_check: None,
+        };
 
-fn evidence_verdict_str(v: &crate::agent::EvidenceVerdict) -> String {
-    match v {
-        crate::agent::EvidenceVerdict::Sufficient => "sufficient".to_string(),
-        crate::agent::EvidenceVerdict::Partial => "partial".to_string(),
-        crate::agent::EvidenceVerdict::Insufficient => "insufficient".to_string(),
+        let value = serde_json::to_value(report).unwrap();
+
+        assert_eq!(value["plan"]["question_type"], json!("MultiHop"));
+        assert_eq!(value["plan"]["strategy"], json!("BroadThenRerank"));
+        assert_eq!(value["iterations"][0]["verdict"], json!("Sufficient"));
     }
 }

--- a/src/query/types.rs
+++ b/src/query/types.rs
@@ -3,6 +3,7 @@ use crate::cli::QueryModeArg;
 use crate::config::Config;
 use crate::retrieval::RetrievalCandidate;
 use crate::rewrite::QueryRewriteSet;
+use serde::Serialize;
 use std::path::PathBuf;
 
 pub(crate) struct QueryRuntime {
@@ -30,4 +31,121 @@ pub(crate) enum QueryExecutionPath {
     Simple,
     Agentic,
     AgenticStub,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct QueryJsonReport {
+    pub question: String,
+    pub answer: Option<String>,
+    pub mode: String,
+    pub hits: Vec<HitJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<PlanJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub iterations: Vec<IterationJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub support_check: Option<SupportCheckJson>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct HitJson {
+    pub source: String,
+    pub page: i32,
+    pub chunk_index: i32,
+    pub score: Option<f32>,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PlanJson {
+    pub question_type: String,
+    pub strategy: String,
+    pub reasoning: String,
+    pub subqueries: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct IterationJson {
+    pub iteration: usize,
+    pub verdict: String,
+    pub retrieved: usize,
+    pub kept: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SupportCheckJson {
+    pub supported: bool,
+    pub unsupported_claims: Vec<String>,
+}
+
+impl QueryJsonReport {
+    pub(crate) fn from_result(
+        question: &str,
+        mode: &str,
+        result: &QueryResult,
+    ) -> Self {
+        Self {
+            question: question.to_string(),
+            answer: result.answer.clone(),
+            mode: mode.to_string(),
+            hits: result
+                .hits
+                .iter()
+                .map(|hit| HitJson {
+                    source: hit.source_path.clone(),
+                    page: hit.page,
+                    chunk_index: hit.chunk_index,
+                    score: hit.best_score(),
+                    text: hit.chunk_text.clone(),
+                })
+                .collect(),
+            plan: result.plan.as_ref().map(|plan| PlanJson {
+                question_type: question_type_str(&plan.question_type),
+                strategy: strategy_str(&plan.strategy),
+                reasoning: plan.reasoning.clone(),
+                subqueries: plan.subqueries.clone(),
+            }),
+            iterations: result
+                .iterations
+                .iter()
+                .map(|iter| IterationJson {
+                    iteration: iter.iteration,
+                    verdict: evidence_verdict_str(&iter.sufficiency),
+                    retrieved: iter.retrieved_count,
+                    kept: iter.kept_count,
+                })
+                .collect(),
+            support_check: result.support_check.as_ref().map(|check| SupportCheckJson {
+                supported: check.supported,
+                unsupported_claims: check.unsupported_claims.clone(),
+            }),
+        }
+    }
+}
+
+fn question_type_str(qt: &crate::agent::QuestionType) -> String {
+    match qt {
+        crate::agent::QuestionType::Lookup => "Lookup".to_string(),
+        crate::agent::QuestionType::Compare => "Compare".to_string(),
+        crate::agent::QuestionType::MultiHop => "MultiHop".to_string(),
+        crate::agent::QuestionType::Summary => "Summary".to_string(),
+        crate::agent::QuestionType::Exploratory => "Exploratory".to_string(),
+    }
+}
+
+fn strategy_str(s: &crate::agent::RetrievalStrategy) -> String {
+    match s {
+        crate::agent::RetrievalStrategy::Direct => "Direct".to_string(),
+        crate::agent::RetrievalStrategy::Rewrite => "Rewrite".to_string(),
+        crate::agent::RetrievalStrategy::Decompose => "Decompose".to_string(),
+        crate::agent::RetrievalStrategy::BroadThenRerank => "BroadThenRerank".to_string(),
+    }
+}
+
+fn evidence_verdict_str(v: &crate::agent::EvidenceVerdict) -> String {
+    match v {
+        crate::agent::EvidenceVerdict::Sufficient => "sufficient".to_string(),
+        crate::agent::EvidenceVerdict::Partial => "partial".to_string(),
+        crate::agent::EvidenceVerdict::Insufficient => "insufficient".to_string(),
+    }
 }

--- a/tests/e2e_query.rs
+++ b/tests/e2e_query.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use serde_json::Value;
 use support::{run_ragcli, MockOllamaConfig, MockOllamaServer};
 
 #[test]
@@ -21,8 +22,7 @@ fn test_query_returns_answer_with_citations_and_context() {
     .unwrap();
 
     let server = MockOllamaServer::start(MockOllamaConfig {
-        chat_response: "Project Nebula maps star catalogs for observatory search [1]."
-            .to_string(),
+        chat_response: "Project Nebula maps star catalogs for observatory search [1].".to_string(),
         ..Default::default()
     });
     let env = [("RAGCLI_OLLAMA_URL", server.url())];
@@ -55,7 +55,11 @@ fn test_query_returns_answer_with_citations_and_context() {
     query.assert_success();
 
     assert!(query.stdout.contains("Citations:"), "{}", query.stdout);
-    assert!(query.stdout.contains("Retrieved context:"), "{}", query.stdout);
+    assert!(
+        query.stdout.contains("Retrieved context:"),
+        "{}",
+        query.stdout
+    );
     assert!(query.stdout.contains("nebula.md"), "{}", query.stdout);
     assert!(
         query
@@ -65,4 +69,55 @@ fn test_query_returns_answer_with_citations_and_context() {
         query.stdout
     );
     assert!(query.stdout.contains("[1]"), "{}", query.stdout);
+}
+
+#[test]
+fn test_query_json_reports_null_answer_when_no_context_is_retained() {
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    let nebula = docs.join("nebula.md");
+    std::fs::write(
+        &nebula,
+        "Project Nebula maps star catalogs for observatory search.",
+    )
+    .unwrap();
+
+    let server = MockOllamaServer::start(MockOllamaConfig {
+        chat_response: "UNSUPPORTED EMPTY CONTEXT ANSWER".to_string(),
+        ..Default::default()
+    });
+    let env = [("RAGCLI_OLLAMA_URL", server.url())];
+
+    let index = run_ragcli(
+        dir.path(),
+        &env,
+        [
+            "--name",
+            "query-json-empty",
+            "index",
+            docs.to_str().unwrap(),
+        ],
+    );
+    index.assert_success();
+
+    let query = run_ragcli(
+        dir.path(),
+        &env,
+        [
+            "--name",
+            "query-json-empty",
+            "query",
+            "What does Project Nebula map?",
+            "--top-k",
+            "0",
+            "--json",
+        ],
+    );
+    query.assert_success();
+
+    let report: Value = query.json();
+    assert_eq!(report["answer"], Value::Null);
+    assert_eq!(report["hits"].as_array().unwrap().len(), 0);
+    assert!(!query.stdout.contains("UNSUPPORTED EMPTY CONTEXT ANSWER"));
 }

--- a/tests/e2e_store_lifecycle.rs
+++ b/tests/e2e_store_lifecycle.rs
@@ -49,11 +49,7 @@ fn test_index_sources_and_stat_cover_store_lifecycle() {
     assert!(source_paths.iter().any(|path| path.ends_with("nebula.md")));
     assert!(source_paths.iter().any(|path| path.ends_with("orchard.md")));
 
-    let stat = run_ragcli(
-        dir.path(),
-        &env,
-        ["--name", "lifecycle", "stat", "--json"],
-    );
+    let stat = run_ragcli(dir.path(), &env, ["--name", "lifecycle", "stat", "--json"]);
     stat.assert_success();
     let stat_json = stat.json();
     assert_eq!(stat_json["stats"]["total_chunks"], 2);

--- a/tests/live_ollama_smoke.rs
+++ b/tests/live_ollama_smoke.rs
@@ -20,8 +20,8 @@ fn test_live_ollama_index_and_query_smoke() {
     )
     .unwrap();
 
-    let ollama_url = std::env::var("RAGCLI_OLLAMA_URL")
-        .unwrap_or_else(|_| "http://localhost:11434".to_string());
+    let ollama_url =
+        std::env::var("RAGCLI_OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".to_string());
     let env = [("RAGCLI_OLLAMA_URL", ollama_url.as_str())];
 
     let index = run_ragcli(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -32,8 +32,7 @@ impl CliOutput {
         assert!(
             self.success,
             "command failed\nstdout:\n{}\nstderr:\n{}",
-            self.stdout,
-            self.stderr
+            self.stdout, self.stderr
         );
     }
 
@@ -213,7 +212,12 @@ fn route_request(config: &MockOllamaConfig, request: &HttpRequest) -> (&'static 
         ("POST", "/api/embed") => {
             let input = serde_json::from_str::<Value>(&request.body)
                 .ok()
-                .and_then(|value| value.get("input").and_then(Value::as_str).map(str::to_owned))
+                .and_then(|value| {
+                    value
+                        .get("input")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
                 .unwrap_or_default();
             let body = serde_json::json!({
                 "embeddings": [compute_embedding(&input)],
@@ -265,5 +269,7 @@ fn write_response(stream: &mut TcpStream, status: &str, body: &str) {
 }
 
 fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|window| window == needle)
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }


### PR DESCRIPTION
## Summary

- Add `--json` flag to the `query` command, consistent with `stat`, `sources`, `doctor`, `prune`, and `config show`
- When `--json` is passed, outputs a structured JSON report with answer, hits (source, page, score, text), plan, iterations, and support check
- Text panel output is unchanged when `--json` is not specified

### JSON output schema

```json
{
  "question": "...",
  "answer": "...",
  "mode": "hybrid",
  "hits": [
    {
      "source": "docs/guide.md",
      "page": 3,
      "chunk_index": 0,
      "score": 0.95,
      "text": "..."
    }
  ],
  "plan": { "question_type": "Lookup", "strategy": "Direct", "reasoning": "...", "subqueries": [] },
  "iterations": [],
  "support_check": { "supported": true, "unsupported_claims": [] }
}
```

## Test plan

- [x] All 153 tests pass (including 6 query execution tests)
- [x] CLI parsing test verifies `--json` flag parses correctly
- [x] `cargo check` passes